### PR TITLE
refactor: improve initial-setup error handling to return 200 OK

### DIFF
--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -174,6 +174,20 @@ async def initial_setup(request: dict, db: sqlite3.Connection = Depends(get_db))
         properties = user_info.get('properties', {})
         plusfriend_key = properties.get('plusfriendUserKey')  # ← 핵심!
 
+        if not plusfriend_key:
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [
+                        {
+                            "simpleText": {
+                                "text": "사용자 식별 정보가 누락되었습니다. 카카오톡 채널을 통해 다시 시도해주세요."
+                            }
+                        }
+                    ]
+                }
+            }
+
         # 파라미터 추출
         departure = params.get('departure')
         arrival = params.get('arrival')
@@ -233,7 +247,7 @@ async def initial_setup(request: dict, db: sqlite3.Connection = Depends(get_db))
             }
 
     except Exception as e:
-        logger.error(f"초기 설정 중 시스템 오류 발생: {str(e)}")
+        logger.exception("초기 설정 중 시스템 오류 발생")
         # 시스템 오류 시에도 200 OK 리턴
         return {
             "version": "2.0",

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -182,10 +182,6 @@ class UserService:
                 logger.warning(f"경로 업데이트 대상 사용자를 찾을 수 없음: {user_id}")
                 return {"success": False, "error": "사용자를 찾을 수 없습니다"}
 
-            if cursor.rowcount == 0:
-                logger.warning(f"경로 업데이트 대상 사용자를 찾을 수 없음: {user_id}")
-                return {"success": False, "error": "사용자를 찾을 수 없습니다"}
-
             db.commit()
             
             logger.info(f"경로(Route Only) 업데이트 완료 - 사용자: {user_id}")


### PR DESCRIPTION
This pull request updates the error handling behavior in the `initial_setup` endpoint in `app/routers/users.py`. Instead of returning an HTTP 400 error on failure, the API now always returns a 200 OK status and delivers the error message to the user in the response body.

Error handling changes:

* Modified `initial_setup` to return a 200 OK response with an error message in the response body instead of raising an HTTPException with status 400.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified initial-setup behavior so users always receive clear, user-facing messages for success, expected failures, and system/temporary errors (includes a standardized temporary-error message in Korean).
* **Tests**
  * Added tests for the initial setup endpoint covering normal success, expected logic failures, and system-error scenarios to verify consistent user-facing responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->