### PR TITLE
feat: 관심장소 알림 설정 기능 추가

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -23,7 +23,8 @@ USERS_TABLE_SCHEMA = '''
         route_updated_at DATETIME,
         -- 개인화 설정
         marked_bus TEXT,
-        language TEXT
+        language TEXT,
+        favorite_zone INTEGER
     )
 '''
 
@@ -79,5 +80,6 @@ ROUTE_COLUMNS = [
     ('language', 'TEXT'),
     ('is_alarm_on', 'BOOLEAN'),
     ('open_id', 'TEXT'),  # 웹훅에서만 제공
-    ('plusfriend_user_key', 'TEXT')  # Skill Block에서 제공 (실질적 primary key)
+    ('plusfriend_user_key', 'TEXT'),  # Skill Block에서 제공 (실질적 primary key)
+    ('favorite_zone', 'INTEGER')  # 관심장소 구역 (1, 2, 3 또는 NULL)
 ]

--- a/app/routers/kakao_skills.py
+++ b/app/routers/kakao_skills.py
@@ -5,6 +5,7 @@ import logging
 
 from app.database.connection import get_db
 from app.services.event_service import EventService
+from app.services.user_service import UserService
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["kakao-skills"])
@@ -279,3 +280,159 @@ async def save_user_info(request: dict, background_tasks: BackgroundTasks):
             ]
         }
     }
+
+
+# ─── 관심장소 알림 설정 ─────────────────────────────────────
+
+# 구역 정보 상수
+ZONE_INFO = {
+    1: {
+        "title": "1구역",
+        "description": "광화문광장 중심 반경 2KM\n(삼청동, 청운효자동, 가회동, 사직동, 종로1·4가동)",
+    },
+    2: {
+        "title": "2구역",
+        "description": "세검정 중심 반경 1.3KM\n(평창동, 부암동)",
+    },
+    3: {
+        "title": "3구역",
+        "description": "한국방송통신대학교 중심 반경 1.3KM\n(혜화동, 이화동, 종로5·6가동, 창신제1~3동, 숭인제1~2동)",
+    },
+}
+
+# zone 파라미터 값 → zone 번호 매핑
+ZONE_PARAM_MAP = {
+    "1구역": 1,
+    "2구역": 2,
+    "3구역": 3,
+    "미설정": None,
+}
+
+
+@router.post("/favorite-zone")
+async def get_favorite_zone_selection(request: dict):
+    """
+    관심장소 구역 선택 UI 반환 (카카오톡 Skill Block)
+    - ListCard 형식으로 4개 구역 옵션 표시
+    """
+    logger.info(f"🔍 /favorite-zone 요청: {request}")
+
+    items = []
+    for zone_num, info in ZONE_INFO.items():
+        items.append({
+            "title": info["title"],
+            "description": info["description"],
+            "action": "message",
+            "messageText": info["title"],
+        })
+
+    # 미설정 옵션 추가
+    items.append({
+        "title": "미설정",
+        "description": "기존 관심장소 정보를 삭제합니다",
+        "action": "message",
+        "messageText": "미설정",
+    })
+
+    return {
+        "version": "2.0",
+        "template": {
+            "outputs": [
+                {
+                    "listCard": {
+                        "header": {
+                            "title": "📍 관심장소를 선택해 주세요"
+                        },
+                        "items": items
+                    }
+                }
+            ]
+        }
+    }
+
+
+@router.post("/favorite-zone/save")
+async def save_favorite_zone(
+    request: dict,
+    db: sqlite3.Connection = Depends(get_db)
+):
+    """
+    관심장소 구역 선택 저장 (카카오톡 Skill Block)
+    - 사용자가 선택한 구역을 DB에 저장
+    - params.zone: "1구역", "2구역", "3구역", "미설정"
+    """
+    try:
+        logger.info(f"🔍 /favorite-zone/save 요청: {request}")
+
+        # Skill Block에서 사용자 ID 추출
+        user_request = request.get('userRequest', {})
+        user_info = user_request.get('user', {})
+        bot_user_key = user_info.get('id')
+        properties = user_info.get('properties', {})
+        plusfriend_key = properties.get('plusfriendUserKey')
+
+        user_id = plusfriend_key if plusfriend_key else bot_user_key
+
+        if not user_id:
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [{"simpleText": {"text": "사용자 식별 정보가 누락되었습니다. 카카오톡 채널을 통해 다시 시도해주세요."}}]
+                }
+            }
+
+        # 파라미터 추출
+        params = request.get('action', {}).get('params', {})
+        zone_param = params.get('zone', '').strip()
+
+        if zone_param not in ZONE_PARAM_MAP:
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [{"simpleText": {"text": f"올바르지 않은 구역 값입니다 ('{zone_param}'). 1구역, 2구역, 3구역, 미설정 중 선택해주세요."}}]
+                }
+            }
+
+        zone_value = ZONE_PARAM_MAP[zone_param]
+
+        logger.info(f"📝 관심장소 설정 변경: user_id={user_id}, zone={zone_param}")
+
+        # 사용자 동기화
+        UserService.sync_kakao_user(bot_user_key, plusfriend_key, db)
+
+        # 구역 설정 업데이트
+        result = UserService.update_favorite_zone(user_id, zone_value, db)
+
+        if result["success"]:
+            if zone_value is not None:
+                zone_info = ZONE_INFO[zone_value]
+                msg = (
+                    f"✅ 관심장소가 [{zone_info['title']}]으로 설정되었습니다.\n\n"
+                    f"📍 {zone_info['description']}\n\n"
+                    "해당 구역 내 집회 정보가 있을 때 알림을 보내드립니다."
+                )
+            else:
+                msg = "🔕 관심장소 설정이 해제되었습니다.\n기존 관심장소 정보가 삭제되었습니다."
+
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [{"simpleText": {"text": msg}}]
+                }
+            }
+        else:
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [{"simpleText": {"text": result.get("error", "관심장소 설정에 실패했습니다.")}}]
+                }
+            }
+
+    except Exception as e:
+        logger.exception("관심장소 설정 중 시스템 오류 발생")
+        return {
+            "version": "2.0",
+            "template": {
+                "outputs": [{"simpleText": {"text": "시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요."}}]
+            }
+        }

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -181,6 +181,49 @@ class UserService:
             return {"success": False, "error": "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."}
 
     @staticmethod
+    def update_favorite_zone(user_id: str, zone: Optional[int], db: sqlite3.Connection) -> Dict[str, Any]:
+        """
+        사용자 관심장소 구역 설정 업데이트
+
+        Args:
+            user_id: 사용자 ID (plusfriend_user_key 또는 bot_user_key)
+            zone: 구역 번호 (1, 2, 3) 또는 None (미설정/삭제)
+            db: 데이터베이스 연결
+
+        Returns:
+            Dict: 처리 결과
+        """
+        try:
+            cursor = db.cursor()
+
+            # 1. plusfriend_user_key로 우선 업데이트 시도
+            cursor.execute('''
+                UPDATE users SET favorite_zone = ?
+                WHERE plusfriend_user_key = ?
+            ''', (zone, user_id))
+
+            # 2. 업데이트된 레코드가 없으면 bot_user_key로 폴백 시도
+            if cursor.rowcount == 0:
+                cursor.execute('''
+                    UPDATE users SET favorite_zone = ?
+                    WHERE bot_user_key = ?
+                ''', (zone, user_id))
+
+            if cursor.rowcount == 0:
+                logger.warning(f"관심장소 설정 업데이트 대상 사용자를 찾을 수 없음: {user_id}")
+                return {"success": False, "error": "사용자를 찾을 수 없습니다"}
+
+            db.commit()
+            zone_label = f"{zone}구역" if zone else "미설정"
+            logger.info(f"사용자 관심장소 설정 업데이트 완료: {user_id} -> {zone_label}")
+
+            return {"success": True}
+
+        except Exception as e:
+            logger.error(f"사용자 관심장소 설정 업데이트 실패: {str(e)}")
+            return {"success": False, "error": "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."}
+
+    @staticmethod
     async def update_user_route(user_id: str, departure: str, arrival: str, db: sqlite3.Connection) -> Dict[str, Any]:
         """
         사용자 경로 정보만 업데이트 (출발지/도착지)

--- a/tests/test_favorite_zone.py
+++ b/tests/test_favorite_zone.py
@@ -1,0 +1,172 @@
+"""관심장소 알림 설정 기능 테스트"""
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def zone_save_payload():
+    """관심장소 저장 요청 기본 payload"""
+    return {
+        "userRequest": {
+            "user": {
+                "id": "bot_user_key_123",
+                "properties": {
+                    "plusfriendUserKey": "plusfriend_key_123"
+                }
+            }
+        },
+        "action": {
+            "params": {
+                "zone": "1구역"
+            }
+        }
+    }
+
+
+@pytest.fixture
+def zone_select_payload():
+    """관심장소 선택 UI 요청 기본 payload"""
+    return {
+        "userRequest": {
+            "user": {
+                "id": "bot_user_key_123",
+                "properties": {
+                    "plusfriendUserKey": "plusfriend_key_123"
+                }
+            }
+        },
+        "action": {
+            "params": {}
+        }
+    }
+
+
+class TestFavoriteZoneSelectionUI:
+    """관심장소 선택 UI (ListCard) 반환 테스트"""
+
+    def test_favorite_zone_selection_ui(self, zone_select_payload):
+        """ListCard 형식으로 4개 구역 옵션이 반환되는지 확인"""
+        response = client.post("/favorite-zone", json=zone_select_payload)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # ListCard 존재 확인
+        output = data["template"]["outputs"][0]
+        assert "listCard" in output
+
+        list_card = output["listCard"]
+
+        # 헤더 확인
+        assert "관심장소" in list_card["header"]["title"]
+
+        # 아이템 4개 확인 (3 구역 + 미설정)
+        items = list_card["items"]
+        assert len(items) == 4
+
+        # 각 아이템에 action: message 확인
+        for item in items:
+            assert item["action"] == "message"
+            assert "messageText" in item
+
+        # 구역 이름 확인
+        titles = [item["title"] for item in items]
+        assert "1구역" in titles
+        assert "2구역" in titles
+        assert "3구역" in titles
+        assert "미설정" in titles
+
+
+class TestFavoriteZoneSave:
+    """관심장소 구역 저장 테스트"""
+
+    def test_save_zone1_success(self, clean_test_db, zone_save_payload):
+        """1구역 선택 시 성공 메시지 반환"""
+        zone_save_payload["action"]["params"]["zone"] = "1구역"
+
+        with patch("app.services.user_service.UserService.sync_kakao_user"):
+            with patch("app.services.user_service.UserService.update_favorite_zone") as mock_update:
+                mock_update.return_value = {"success": True}
+
+                response = client.post("/favorite-zone/save", json=zone_save_payload)
+
+                assert response.status_code == 200
+                data = response.json()
+                text = data["template"]["outputs"][0]["simpleText"]["text"]
+                assert "1구역" in text
+                assert "설정되었습니다" in text
+
+                # update_favorite_zone이 zone=1로 호출됐는지 확인
+                mock_update.assert_called_once()
+                call_args = mock_update.call_args
+                assert call_args[0][1] == 1  # zone value
+
+    def test_save_zone_unset(self, clean_test_db, zone_save_payload):
+        """미설정 선택 시 삭제 확인 메시지 반환"""
+        zone_save_payload["action"]["params"]["zone"] = "미설정"
+
+        with patch("app.services.user_service.UserService.sync_kakao_user"):
+            with patch("app.services.user_service.UserService.update_favorite_zone") as mock_update:
+                mock_update.return_value = {"success": True}
+
+                response = client.post("/favorite-zone/save", json=zone_save_payload)
+
+                assert response.status_code == 200
+                data = response.json()
+                text = data["template"]["outputs"][0]["simpleText"]["text"]
+                assert "해제" in text
+
+                # update_favorite_zone이 zone=None으로 호출됐는지 확인
+                mock_update.assert_called_once()
+                call_args = mock_update.call_args
+                assert call_args[0][1] is None  # zone value
+
+    def test_save_invalid_zone(self, clean_test_db, zone_save_payload):
+        """잘못된 구역 값 입력 시 에러 메시지 반환"""
+        zone_save_payload["action"]["params"]["zone"] = "5구역"
+
+        response = client.post("/favorite-zone/save", json=zone_save_payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        text = data["template"]["outputs"][0]["simpleText"]["text"]
+        assert "올바르지 않은" in text
+
+    def test_save_no_user_id(self, clean_test_db):
+        """사용자 식별 정보 누락 시 에러 반환"""
+        payload = {
+            "userRequest": {
+                "user": {
+                    "id": None,
+                    "properties": {}
+                }
+            },
+            "action": {
+                "params": {
+                    "zone": "1구역"
+                }
+            }
+        }
+
+        response = client.post("/favorite-zone/save", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        text = data["template"]["outputs"][0]["simpleText"]["text"]
+        assert "사용자 식별 정보" in text
+
+    def test_save_system_error(self, clean_test_db, zone_save_payload):
+        """시스템 오류 시 에러 메시지 반환"""
+        with patch("app.services.user_service.UserService.sync_kakao_user") as mock_sync:
+            mock_sync.side_effect = Exception("DB Connection Fail")
+
+            response = client.post("/favorite-zone/save", json=zone_save_payload)
+
+            assert response.status_code == 200
+            data = response.json()
+            text = data["template"]["outputs"][0]["simpleText"]["text"]
+            assert "시스템 오류" in text


### PR DESCRIPTION
## 개요
사용자가 카카오 챗봇에서 **관심장소 구역(1~3구역)**을 선택/해제할 수 있는 기능을 추가합니다.

## 구역 정보
| 구역 | 중심지 | 반경 | 포함 동네 |
|------|--------|------|----------|
| 1구역 | 광화문광장 | 2KM | 삼청동, 청운효자동, 가회동, 사직동, 종로1·4가동 |
| 2구역 | 세검정 | 1.3KM | 평창동, 부암동 |
| 3구역 | 한국방송통신대학교 | 1.3KM | 혜화동, 이화동, 종로5·6가동, 창신제1~3동, 숭인제1~2동 |
| 미설정 | - | - | 기존 정보 삭제 |

## 변경 사항

### DB Schema (app/database/models.py)
- users 테이블에 favorite_zone INTEGER 컬럼 추가
- ROUTE_COLUMNS에 동적 마이그레이션 항목 추가

### Service (app/services/user_service.py)
- UserService.update_favorite_zone() 메서드 추가
- plusfriend_user_key 우선 → bot_user_key 폴백 패턴

### Router (app/routers/kakao_skills.py)
- POST /favorite-zone — ListCard 형식 구역 선택 UI 반환
- POST /favorite-zone/save — 선택한 구역 DB 저장

### Tests (tests/test_favorite_zone.py)
- 6개 테스트 케이스 (UI 반환, 저장 성공, 미설정, 잘못된 값, 사용자 미식별, 시스템 오류)

## 카카오 챗봇 빌더 설정 필요
1. **블록 1**: 관심장소 알림 설정 발화 → /favorite-zone Skill 호출
2. **블록 2**: 1구역, 2구역, 3구역, 미설정 발화 매핑 → /favorite-zone/save Skill 호출 (파라미터 zone)

## 테스트 결과
59 passed, 6 warnings in 1.09s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now select and save their favorite zone preference through a dedicated interface
  * Four zone options available with the ability to unset the preference at any time
  * Zone selections are saved to user accounts for personalized future interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->