### PR TITLE
fix: init_db에 favorite_zone 컬럼 마이그레이션 추가

### DIFF
--- a/app/database/connection.py
+++ b/app/database/connection.py
@@ -60,6 +60,13 @@ def init_db():
         if "duplicate column name" not in str(e).lower():
             logger.warning(f"is_alarm_on 컬럼 갱신 실패 (무시됨): {str(e)}")
 
+    try:
+        cursor.execute("ALTER TABLE users ADD COLUMN favorite_zone INTEGER")
+        logger.info("✅ favorite_zone 컬럼 추가 완료")
+    except sqlite3.OperationalError as e:
+        if "duplicate column name" not in str(e).lower():
+            logger.warning(f"favorite_zone 컬럼 갱신 실패 (무시됨): {str(e)}")
+
     conn.commit()
     conn.close()
     print("✅ 데이터베이스 초기화 완료")


### PR DESCRIPTION
## 문제
기존 DB에 `favorite_zone` 컬럼이 없어서 `no such column: favorite_zone` 에러 발생.

## 수정
`init_db()`에 `ALTER TABLE users ADD COLUMN favorite_zone INTEGER` 마이그레이션 구문 추가.
서버 재시작 시 자동으로 컬럼이 생성됩니다.

## 테스트
59 passed, 6 warnings