### PR TITLE
Refactor: replace os.environ with Pydantic settings

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -11,6 +11,9 @@ class Settings(BaseSettings):
     BOT_ID: str = ""
     KAKAO_BOT_API_URL: str = "https://bot-api.kakao.com/v1/bots/message/send"
 
+    # --- TMAP API Configuration ---
+    TMAP_APP_KEY: str = ""
+
     # Gemini API 설정 (버스 통제 알림용)
     GEMINI_API_KEY: str = ""
 

--- a/app/services/bus_logic/restricted_bus.py
+++ b/app/services/bus_logic/restricted_bus.py
@@ -50,15 +50,8 @@ class TOPISCrawler:
     def __init__(self, gemini_api_key=None, cache_file="topis_cache.json"):
         """TOPIS 크롤러 초기화"""
         self.base_url = "https://topis.seoul.go.kr"
-        try:
-            from app.config.settings import settings as _settings
-        except ImportError:
-            _settings = None
-
-        if _settings:
-            self.service_key = _settings.SEOUL_BUS_API_KEY or os.environ.get("SEOUL_BUS_API_KEY")
-        else:
-            self.service_key = os.environ.get("SEOUL_BUS_API_KEY")
+        from app.config.settings import settings as _settings
+        self.service_key = _settings.SEOUL_BUS_API_KEY
         
         # 캐시 및 다운로드 폴더 경로 조정 (프로젝트 루트 기준)
         self.cache_file = cache_file
@@ -85,11 +78,7 @@ class TOPISCrawler:
         
         # Gemini 설정
         if not gemini_api_key:
-            if _settings:
-                gemini_api_key = _settings.GEMINI_API_KEY
-        
-        if not gemini_api_key:
-            gemini_api_key = os.environ.get("GEMINI_API_KEY")
+            gemini_api_key = _settings.GEMINI_API_KEY
             
         if not gemini_api_key:
             raise RuntimeError("Gemini API Key가 필요합니다. 환경변수 설정을 확인하세요.")

--- a/app/services/bus_logic/restricted_bus.py
+++ b/app/services/bus_logic/restricted_bus.py
@@ -16,6 +16,7 @@ import shutil
 from datetime import datetime, timedelta
 from bs4 import BeautifulSoup
 import google.generativeai as genai
+from app.config.settings import settings
 
 try:
     import fitz  # PyMuPDF for PDF processing
@@ -50,8 +51,7 @@ class TOPISCrawler:
     def __init__(self, gemini_api_key=None, cache_file="topis_cache.json"):
         """TOPIS 크롤러 초기화"""
         self.base_url = "https://topis.seoul.go.kr"
-        from app.config.settings import settings as _settings
-        self.service_key = _settings.SEOUL_BUS_API_KEY
+        self.service_key = settings.SEOUL_BUS_API_KEY
         
         # 캐시 및 다운로드 폴더 경로 조정 (프로젝트 루트 기준)
         self.cache_file = cache_file
@@ -78,7 +78,7 @@ class TOPISCrawler:
         
         # Gemini 설정
         if not gemini_api_key:
-            gemini_api_key = _settings.GEMINI_API_KEY
+            gemini_api_key = settings.GEMINI_API_KEY
             
         if not gemini_api_key:
             raise RuntimeError("Gemini API Key가 필요합니다. 환경변수 설정을 확인하세요.")

--- a/app/utils/geo_utils.py
+++ b/app/utils/geo_utils.py
@@ -6,9 +6,9 @@ from typing import Optional
 
 import httpx
 
+from app.config.settings import settings
+
 logger = logging.getLogger(__name__)
-KAKAO_REST_API_KEY = os.getenv("KAKAO_REST_API_KEY")
-TMAP_APP_KEY = os.getenv("TMAP_APP_KEY")
 
 def haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """
@@ -141,12 +141,12 @@ async def get_location_info(query: str, client: Optional[httpx.AsyncClient] = No
     Returns:
         dict: 장소 정보 (name, address, x, y) 또는 None
     """
-    if not KAKAO_REST_API_KEY:
+    if not settings.KAKAO_REST_API_KEY:
         logger.error("KAKAO_REST_API_KEY가 설정되지 않았습니다.")
         return None
         
     url = "https://dapi.kakao.com/v2/local/search/keyword.json"
-    headers = {"Authorization": f"KakaoAK {KAKAO_REST_API_KEY}"}
+    headers = {"Authorization": f"KakaoAK {settings.KAKAO_REST_API_KEY}"}
     params = {"query": query}
 
     try:
@@ -201,14 +201,14 @@ async def get_route_coordinates_tmap_transit(
         list[tuple[float, float]]: 경로상의 (위도, 경도) 좌표 리스트
     """
 
-    if not TMAP_APP_KEY:
+    if not settings.TMAP_APP_KEY:
         logger.error("TMAP_APP_KEY가 설정되지 않았습니다.")
         return []
 
     url = "https://apis.openapi.sk.com/transit/routes"
     headers = {
         "accept": "application/json",
-        "appKey": TMAP_APP_KEY,
+        "appKey": settings.TMAP_APP_KEY,
         "content-type": "application/json",
     }
     payload = {
@@ -293,12 +293,12 @@ async def get_route_coordinates_kakao(start_x: float, start_y: float,
     Returns:
         list[tuple[float, float]]: 경로상의 (위도, 경도) 좌표 리스트
     """
-    if not KAKAO_REST_API_KEY:
+    if not settings.KAKAO_REST_API_KEY:
         logger.error("KAKAO_REST_API_KEY가 설정되지 않았습니다.")
         return []
         
     url = "https://apis-navi.kakaomobility.com/v1/directions"
-    headers = {"Authorization": f"KakaoAK {KAKAO_REST_API_KEY}"}
+    headers = {"Authorization": f"KakaoAK {settings.KAKAO_REST_API_KEY}"}
     params = {
         "origin": f"{start_x},{start_y}",
         "destination": f"{end_x},{end_y}",

--- a/tests/test_geo_utils.py
+++ b/tests/test_geo_utils.py
@@ -8,6 +8,7 @@ from app.utils.geo_utils import (
     get_route_coordinates
 )
 import httpx
+from app.config.settings import settings
 
 @pytest.mark.asyncio
 async def test_haversine_distance():
@@ -58,7 +59,7 @@ async def test_get_location_info_mocked():
     }
     
     # Mock the API Key
-    with patch("app.utils.geo_utils.KAKAO_REST_API_KEY", "test_key"):
+    with patch.object(settings, "KAKAO_REST_API_KEY", "test_key"):
         # Test with injected client
         client = AsyncMock(spec=httpx.AsyncClient)
         client.get.return_value = MagicMock(
@@ -97,7 +98,7 @@ async def test_get_route_coordinates_mocked():
     }
     
     # Mock the API Key
-    with patch("app.utils.geo_utils.KAKAO_REST_API_KEY", "test_key"):
+    with patch.object(settings, "KAKAO_REST_API_KEY", "test_key"):
         client = AsyncMock(spec=httpx.AsyncClient)
         client.get.return_value = MagicMock(
             status_code=200,


### PR DESCRIPTION
Resolves #50

This PR removes residual usages of `os.environ` and `os.getenv` in `geo_utils.py` and `restricted_bus.py` that were missed during the initial Pydantic settings refactoring (PR #49). Now all configuration values are consistently read through the `app.config.settings` object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated authentication credentials into a centralized configuration system, standardizing how API keys are managed and accessed across the application for improved consistency and maintainability.
  * Replaced scattered credential lookups with unified settings-based sourcing to reduce duplication and simplify configuration management.

* **Tests**
  * Updated tests to mock and verify API keys via the centralized settings object, aligning test behavior with the new configuration approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->