### PR TITLE
Fix SMPA and SPATIC crawling errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,15 +28,14 @@ RUN uv sync --frozen --no-dev
 # Install Playwright browsers and dependencies to shared location
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN mkdir -p /ms-playwright && \
-    uv run playwright install chromium --with-deps && \
-    chmod -R 755 /ms-playwright
+    uv run playwright install chromium --with-deps
 
 # Copy application code
 COPY . .
 
 # Create non-root user
 RUN adduser --disabled-password --gecos '' appuser && \
-    chown -R appuser:appuser /app
+    chown -R appuser:appuser /app /ms-playwright
 USER appuser
 
 # Expose port

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,11 @@ COPY pyproject.toml uv.lock ./
 # Install Python dependencies (no dev, use frozen lock file)
 RUN uv sync --frozen --no-dev
 
-# Install Playwright browsers and dependencies
-RUN uv run playwright install chromium --with-deps
+# Install Playwright browsers and dependencies to shared location
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN mkdir -p /ms-playwright && \
+    uv run playwright install chromium --with-deps && \
+    chmod -R 755 /ms-playwright
 
 # Copy application code
 COPY . .

--- a/app/services/crawling_service.py
+++ b/app/services/crawling_service.py
@@ -363,6 +363,8 @@ class CrawlingService:
         import requests
         import warnings
         from urllib3.exceptions import InsecureRequestWarning
+        from requests.adapters import HTTPAdapter
+        from urllib3.util.retry import Retry
         warnings.simplefilter('ignore', InsecureRequestWarning)
 
         headers = {
@@ -375,6 +377,16 @@ class CrawlingService:
         os.makedirs(out_dir, exist_ok=True)
 
         with requests.Session() as s:
+            retry_strategy = Retry(
+                total=4,
+                backoff_factor=1,
+                status_forcelist=[429, 500, 502, 503, 504],
+                allowed_methods=["HEAD", "GET", "OPTIONS"]
+            )
+            adapter = HTTPAdapter(max_retries=retry_strategy)
+            s.mount("http://", adapter)
+            s.mount("https://", adapter)
+            
             s.verify = False
             s.headers.update(headers)
             


### PR DESCRIPTION
Resolves #52.
- Fixes SMPA PDF download ConnectionResetError with urllib3 Retry
- Fixes SPATIC Playwright executable missing in Docker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * PDF downloads now include automatic retry logic (up to 4 attempts with exponential backoff) to improve reliability against transient network or server errors.
  * Browser automation environment setup and container ownership have been improved to ensure browsers are installed to a dedicated location with correct permissions for non-root execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->