### PR TITLE
feat: Add alarm setting functionality with corresponding unit tests

### DIFF
--- a/app/routers/kakao_skills.py
+++ b/app/routers/kakao_skills.py
@@ -509,3 +509,133 @@ async def save_marked_bus(request: dict, background_tasks: BackgroundTasks):
             }]
         }
     }
+
+
+# ─── 알람 On/Off 설정 ─────────────────────────────────────
+
+ALARM_STATUS_MAP = {
+    "알림 켜기": "on",
+    "알림 끄기": "off",
+}
+
+
+@router.post("/alarm-setting")
+async def get_alarm_setting_selection(request: dict):
+    """
+    알람 On/Off 선택 UI 반환 (카카오톡 Skill Block)
+    - ListCard 형식으로 알림 켜기/끄기 옵션 표시
+    """
+    logger.info(f"🔍 /alarm-setting 요청: {request}")
+
+    items = [
+        {
+            "title": "🔔 알림 켜기",
+            "description": "매일 아침 출퇴근 경로 집회 알림을 받습니다",
+            "action": "message",
+            "messageText": "알림 켜기",
+        },
+        {
+            "title": "🔕 알림 끄기",
+            "description": "출퇴근 경로 집회 알림을 받지 않습니다",
+            "action": "message",
+            "messageText": "알림 끄기",
+        },
+    ]
+
+    return {
+        "version": "2.0",
+        "template": {
+            "outputs": [
+                {
+                    "listCard": {
+                        "header": {
+                            "title": "🔔 알림 설정"
+                        },
+                        "items": items
+                    }
+                }
+            ]
+        }
+    }
+
+
+@router.post("/alarm-setting/save")
+async def save_alarm_setting(
+    request: dict,
+    db: sqlite3.Connection = Depends(get_db)
+):
+    """
+    알람 On/Off 선택 저장 (카카오톡 Skill Block)
+    - 사용자가 선택한 알림 상태를 DB에 저장
+    - params.alarm_status: "on" / "off"
+    """
+    try:
+        logger.info(f"🔍 /alarm-setting/save 요청: {request}")
+
+        # Skill Block에서 사용자 ID 추출
+        user_request = request.get('userRequest', {})
+        user_info = user_request.get('user', {})
+        bot_user_key = user_info.get('id')
+        properties = user_info.get('properties', {})
+        plusfriend_key = properties.get('plusfriendUserKey')
+
+        user_id = plusfriend_key if plusfriend_key else bot_user_key
+
+        if not user_id:
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [{"simpleText": {"text": "사용자 식별 정보가 누락되었습니다. 카카오톡 채널을 통해 다시 시도해주세요."}}]
+                }
+            }
+
+        # 파라미터 추출
+        params = request.get('action', {}).get('params', {})
+        alarm_status_str = params.get('alarm_status', '').strip().lower()
+
+        if alarm_status_str not in ("on", "off"):
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [{"simpleText": {"text": f"올바르지 않은 알림 설정 값입니다 ('{alarm_status_str}'). 'on' 또는 'off'여야 합니다."}}]
+                }
+            }
+
+        is_alarm_on = alarm_status_str == "on"
+
+        logger.info(f"📝 알림 설정 변경: user_id={user_id}, status={alarm_status_str}")
+
+        # 사용자 동기화
+        UserService.sync_kakao_user(bot_user_key, plusfriend_key, db)
+
+        # 설정 업데이트
+        result = UserService.update_alarm_setting(user_id, is_alarm_on, db)
+
+        if result["success"]:
+            if is_alarm_on:
+                msg = "✅ 매일 아침 알림이 켜졌습니다.\n등록하신 출퇴근 경로에 영향을 주는 집회 정보를 안내해 드립니다."
+            else:
+                msg = "🔕 매일 아침 알림이 꺼졌습니다.\n출퇴근 경로 집회 알림이 더 이상 발송되지 않습니다."
+
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [{"simpleText": {"text": msg}}]
+                }
+            }
+        else:
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [{"simpleText": {"text": result.get("error", "알람 설정 업데이트에 실패했습니다.")}}]
+                }
+            }
+
+    except Exception as e:
+        logger.exception("알람 설정 중 시스템 오류 발생")
+        return {
+            "version": "2.0",
+            "template": {
+                "outputs": [{"simpleText": {"text": "시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요."}}]
+            }
+        }

--- a/tests/test_alarm_setting.py
+++ b/tests/test_alarm_setting.py
@@ -1,0 +1,169 @@
+"""알람 On/Off 설정 기능 테스트"""
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def alarm_save_payload():
+    """알람 설정 저장 요청 기본 payload"""
+    return {
+        "userRequest": {
+            "user": {
+                "id": "bot_user_key_123",
+                "properties": {
+                    "plusfriendUserKey": "plusfriend_key_123"
+                }
+            }
+        },
+        "action": {
+            "params": {
+                "alarm_status": "on"
+            }
+        }
+    }
+
+
+@pytest.fixture
+def alarm_select_payload():
+    """알람 설정 선택 UI 요청 기본 payload"""
+    return {
+        "userRequest": {
+            "user": {
+                "id": "bot_user_key_123",
+                "properties": {
+                    "plusfriendUserKey": "plusfriend_key_123"
+                }
+            }
+        },
+        "action": {
+            "params": {}
+        }
+    }
+
+
+class TestAlarmSettingSelectionUI:
+    """알람 설정 선택 UI (ListCard) 반환 테스트"""
+
+    def test_alarm_setting_selection_ui(self, alarm_select_payload):
+        """ListCard 형식으로 2개 옵션이 반환되는지 확인"""
+        response = client.post("/alarm-setting", json=alarm_select_payload)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # ListCard 존재 확인
+        output = data["template"]["outputs"][0]
+        assert "listCard" in output
+
+        list_card = output["listCard"]
+
+        # 헤더 확인
+        assert "알림 설정" in list_card["header"]["title"]
+
+        # 아이템 2개 확인 (켜기 + 끄기)
+        items = list_card["items"]
+        assert len(items) == 2
+
+        # 각 아이템에 action: message 확인
+        for item in items:
+            assert item["action"] == "message"
+            assert "messageText" in item
+
+        # 옵션 이름 확인
+        titles = [item["title"] for item in items]
+        assert any("켜기" in t for t in titles)
+        assert any("끄기" in t for t in titles)
+
+
+class TestAlarmSettingSave:
+    """알람 설정 저장 테스트"""
+
+    def test_save_alarm_on_success(self, clean_test_db, alarm_save_payload):
+        """알림 켜기 선택 시 성공 메시지 반환"""
+        alarm_save_payload["action"]["params"]["alarm_status"] = "on"
+
+        with patch("app.services.user_service.UserService.sync_kakao_user"):
+            with patch("app.services.user_service.UserService.update_alarm_setting") as mock_update:
+                mock_update.return_value = {"success": True}
+
+                response = client.post("/alarm-setting/save", json=alarm_save_payload)
+
+                assert response.status_code == 200
+                data = response.json()
+                text = data["template"]["outputs"][0]["simpleText"]["text"]
+                assert "켜졌습니다" in text
+
+                # update_alarm_setting이 is_alarm_on=True로 호출됐는지 확인
+                mock_update.assert_called_once()
+                call_args = mock_update.call_args
+                assert call_args[0][1] is True  # is_alarm_on value
+
+    def test_save_alarm_off_success(self, clean_test_db, alarm_save_payload):
+        """알림 끄기 선택 시 성공 메시지 반환"""
+        alarm_save_payload["action"]["params"]["alarm_status"] = "off"
+
+        with patch("app.services.user_service.UserService.sync_kakao_user"):
+            with patch("app.services.user_service.UserService.update_alarm_setting") as mock_update:
+                mock_update.return_value = {"success": True}
+
+                response = client.post("/alarm-setting/save", json=alarm_save_payload)
+
+                assert response.status_code == 200
+                data = response.json()
+                text = data["template"]["outputs"][0]["simpleText"]["text"]
+                assert "꺼졌습니다" in text
+
+                # update_alarm_setting이 is_alarm_on=False로 호출됐는지 확인
+                mock_update.assert_called_once()
+                call_args = mock_update.call_args
+                assert call_args[0][1] is False  # is_alarm_on value
+
+    def test_save_invalid_alarm_status(self, clean_test_db, alarm_save_payload):
+        """잘못된 알림 설정 값 입력 시 에러 메시지 반환"""
+        alarm_save_payload["action"]["params"]["alarm_status"] = "maybe"
+
+        response = client.post("/alarm-setting/save", json=alarm_save_payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        text = data["template"]["outputs"][0]["simpleText"]["text"]
+        assert "올바르지 않은" in text
+
+    def test_save_no_user_id(self, clean_test_db):
+        """사용자 식별 정보 누락 시 에러 반환"""
+        payload = {
+            "userRequest": {
+                "user": {
+                    "id": None,
+                    "properties": {}
+                }
+            },
+            "action": {
+                "params": {
+                    "alarm_status": "on"
+                }
+            }
+        }
+
+        response = client.post("/alarm-setting/save", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        text = data["template"]["outputs"][0]["simpleText"]["text"]
+        assert "사용자 식별 정보" in text
+
+    def test_save_system_error(self, clean_test_db, alarm_save_payload):
+        """시스템 오류 시 에러 메시지 반환"""
+        with patch("app.services.user_service.UserService.sync_kakao_user") as mock_sync:
+            mock_sync.side_effect = Exception("DB Connection Fail")
+
+            response = client.post("/alarm-setting/save", json=alarm_save_payload)
+
+            assert response.status_code == 200
+            data = response.json()
+            text = data["template"]["outputs"][0]["simpleText"]["text"]
+            assert "시스템 오류" in text


### PR DESCRIPTION
This pull request adds a new feature for users to enable or disable daily commute route notifications (alarms) via KakaoTalk, and introduces comprehensive tests for this functionality. The most important changes are grouped below.

**Alarm On/Off Feature Implementation:**

* Added two new API endpoints in `kakao_skills.py`: `/alarm-setting` to display a ListCard UI for alarm On/Off options, and `/alarm-setting/save` to save the user's alarm preference in the database. The endpoints handle user identification, input validation, and provide user feedback messages.

**Testing:**

* Introduced a new test module `test_alarm_setting.py` with fixtures and test classes to cover the alarm setting UI and alarm save logic, including cases for successful saves, invalid inputs, missing user IDs, and system errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added notification alarm toggle functionality enabling users to control alarm preferences
* Users can now manage notification settings through a dedicated interface with clear on/off options
* Implemented robust notification management with comprehensive error handling and validation

## Tests
* Added integration test suite covering alarm setting endpoints with multiple scenarios including success cases, error handling, and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->