### PR TITLE
feat: 알림 설정 ListCard 내 개인화된 상태 표시 (#57)

### DIFF
--- a/app/routers/kakao_skills.py
+++ b/app/routers/kakao_skills.py
@@ -545,30 +545,50 @@ from app.config.settings import settings
 
 
 @router.post("/alarm-setting")
-async def get_alarm_setting_selection(request: dict):
+async def get_alarm_setting_selection(
+    request: dict,
+    db: sqlite3.Connection = Depends(get_db)
+):
     """
     알람 On/Off 선택 UI 반환 (카카오톡 Skill Block)
     - ListCard 형식으로 알림 켜기/끄기 옵션 표시
-    - action:block + extra 방식으로 alarm_status 값을 직접 다음 블록에 전달
+    - 사용자의 현재 설정 상태를 헤더에 표시
     """
     logger.info(f"🔍 /alarm-setting 요청: {request}")
 
+    # 사용자 ID 추출
+    user_request = request.get('userRequest', {})
+    user_info_req = user_request.get('user', {})
+    properties = user_info_req.get('properties', {})
+    plusfriend_key = properties.get('plusfriendUserKey')
+    bot_user_key = user_info_req.get('id')
+    user_id = plusfriend_key if plusfriend_key else bot_user_key
+
+    # 사용자 정보 조회
+    user_info = None
+    if user_id:
+        user_info = UserService.get_user_info(user_id, db)
+
+    # 헤더 정보 구성
+    title = "🔔 알림 설정"
+    if user_info:
+        status_text = "수신 중" if user_info.get("is_alarm_on") else "수신거부 중"
+        title = f"🔔 알림 설정 ({status_text})"
+
     # 카카오 챗봇 관리자센터의 '알람 저장' 스킬 블록 ID
-    # settings 또는 환경변수에서 읽어오거나, 없으면 message 방식으로 fallback
     save_block_id = getattr(settings, "ALARM_SAVE_BLOCK_ID", None)
 
     if save_block_id:
-        # ✅ 권장: blockId + extra 방식 (NLU 우회, 파라미터 직접 전달)
         items = [
             {
-                "title": "🔔 알림 켜기",
+                "title": "🔔 알람 켜기",
                 "description": "매일 아침 출퇴근 경로 집회 알림을 받습니다",
                 "action": "block",
                 "blockId": save_block_id,
                 "extra": {"alarm_status": "on"},
             },
             {
-                "title": "🔕 알림 끄기",
+                "title": "🔕 알람 끄기",
                 "description": "출퇴근 경로 집회 알림을 받지 않습니다",
                 "action": "block",
                 "blockId": save_block_id,
@@ -576,16 +596,15 @@ async def get_alarm_setting_selection(request: dict):
             },
         ]
     else:
-        # fallback: message 방식 (blockId 미설정 시)
         items = [
             {
-                "title": "🔔 알림 켜기",
+                "title": "🔔 알람 켜기",
                 "description": "매일 아침 출퇴근 경로 집회 알림을 받습니다",
                 "action": "message",
                 "messageText": "알림 켜기",
             },
             {
-                "title": "🔕 알림 끄기",
+                "title": "🔕 알람 끄기",
                 "description": "출퇴근 경로 집회 알림을 받지 않습니다",
                 "action": "message",
                 "messageText": "알림 끄기",
@@ -599,7 +618,7 @@ async def get_alarm_setting_selection(request: dict):
                 {
                     "listCard": {
                         "header": {
-                            "title": "🔔 알림 설정"
+                            "title": title
                         },
                         "items": items
                     }

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -518,19 +518,22 @@ class UserService:
         try:
             cursor = db.cursor()
             
-            # plusfriend_user_key 우선 조회, 없으면 bot_user_key로 조회
-            cursor.execute('''
+            SELECT_FIELDS = '''
                 SELECT 
                     is_alarm_on, favorite_zone, marked_bus, 
                     departure_name, arrival_name,
                     plusfriend_user_key, bot_user_key
                 FROM users 
-                WHERE plusfriend_user_key = ? OR bot_user_key = ?
-                ORDER BY (CASE WHEN plusfriend_user_key = ? THEN 0 ELSE 1 END) ASC
-                LIMIT 1
-            ''', (user_id, user_id, user_id))
-            
+            '''
+
+            # 1단계: plusfriend_user_key로 조회 (우선)
+            cursor.execute(SELECT_FIELDS + 'WHERE plusfriend_user_key = ? LIMIT 1', (user_id,))
             row = cursor.fetchone()
+
+            # 2단계: 없으면 bot_user_key로 조회 (fallback)
+            if not row:
+                cursor.execute(SELECT_FIELDS + 'WHERE bot_user_key = ? LIMIT 1', (user_id,))
+                row = cursor.fetchone()
             if not row:
                 return None
                 

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -502,3 +502,48 @@ class UserService:
         except Exception as e:
             logger.error(f"사용자 경로 정보 조회 실패: {str(e)}")
             return None
+
+    @staticmethod
+    def get_user_info(user_id: str, db: sqlite3.Connection) -> Optional[Dict[str, Any]]:
+        """
+        사용자의 전체 정보 조회 (알람 설정, 관심구역, 경로, 버스 등)
+        
+        Args:
+            user_id: 사용자 ID (plusfriend_user_key 또는 bot_user_key)
+            db: 데이터베이스 연결
+            
+        Returns:
+            Optional[Dict]: 사용자 정보 또는 None
+        """
+        try:
+            cursor = db.cursor()
+            
+            # plusfriend_user_key 우선 조회, 없으면 bot_user_key로 조회
+            cursor.execute('''
+                SELECT 
+                    is_alarm_on, favorite_zone, marked_bus, 
+                    departure_name, arrival_name,
+                    plusfriend_user_key, bot_user_key
+                FROM users 
+                WHERE plusfriend_user_key = ? OR bot_user_key = ?
+                ORDER BY (CASE WHEN plusfriend_user_key = ? THEN 0 ELSE 1 END) ASC
+                LIMIT 1
+            ''', (user_id, user_id, user_id))
+            
+            row = cursor.fetchone()
+            if not row:
+                return None
+                
+            return {
+                "is_alarm_on": bool(row[0]),
+                "favorite_zone": row[1],
+                "marked_bus": row[2],
+                "departure_name": row[3],
+                "arrival_name": row[4],
+                "plusfriend_user_key": row[5],
+                "bot_user_key": row[6]
+            }
+            
+        except Exception as e:
+            logger.error(f"사용자 정보 조회 실패: {str(e)}")
+            return None


### PR DESCRIPTION
알림 설정(listCard) 요청 시, 사용자의 현재 알림 수신 상태(수신 중/수신거부 중)를 헤더 제목에 표시하여 사용자 편의성을 높였습니다.

### 작업 내용
- UserService.get_user_info 구현: 사용자 정보(알림 설정 등) 통합 조회 로직 추가
- kakao_skills.py 수정: /alarm-setting 엔드포인트에서 사용자 정보를 조회하여 헤더 제목에 수신 상태 표시

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alarm settings screen now shows your current notification status in the header (e.g., “수신 중” or “수신거부 중”); if status cannot be determined, the default header remains.

* **Improvements**
  * More reliable user info retrieval with improved error handling and fallback identity resolution using alternative account identifiers.
  * Option items and their selection behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->