### PR TITLE
refactor: #59 코드 리뷰 후속 개선 (import 위치, getattr 제거, clientExtra 테스트 추가)

### DIFF
--- a/app/routers/kakao_skills.py
+++ b/app/routers/kakao_skills.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends, BackgroundTasks
 import sqlite3
 import logging
 
+from app.config.settings import settings
 from app.database.connection import get_db
 from app.services.event_service import EventService
 from app.services.user_service import UserService
@@ -319,7 +320,7 @@ async def get_favorite_zone_selection(request: dict):
     logger.info(f"🔍 /favorite-zone 요청: {request}")
 
     # 카카오 챗봇 관리자센터의 '관심장소 저장' 스킬 블록 ID
-    save_block_id = getattr(settings, "FAVORITE_ZONE_SAVE_BLOCK_ID", None)
+    save_block_id = settings.FAVORITE_ZONE_SAVE_BLOCK_ID
 
     items = []
     for zone_num, info in ZONE_INFO.items():
@@ -541,8 +542,6 @@ async def save_marked_bus(request: dict, background_tasks: BackgroundTasks):
 
 # ─── 알람 On/Off 설정 ─────────────────────────────────────
 
-from app.config.settings import settings
-
 
 @router.post("/alarm-setting")
 async def get_alarm_setting_selection(
@@ -576,7 +575,8 @@ async def get_alarm_setting_selection(
         title = f"🔔 알림 설정 ({status_text})"
 
     # 카카오 챗봇 관리자센터의 '알람 저장' 스킬 블록 ID
-    save_block_id = getattr(settings, "ALARM_SAVE_BLOCK_ID", None)
+    # settings 또는 환경변수에서 읽어오거나, 없으면 message 방식으로 fallback
+    save_block_id = settings.ALARM_SAVE_BLOCK_ID
 
     if save_block_id:
         items = [

--- a/tests/test_alarm_setting.py
+++ b/tests/test_alarm_setting.py
@@ -172,3 +172,156 @@ class TestAlarmSettingSave:
             data = response.json()
             text = data["template"]["outputs"][0]["simpleText"]["text"]
             assert "시스템 오류" in text
+
+
+class TestAlarmSettingSaveViaClientExtra:
+    """block+extra 방식(clientExtra) 알람 설정 저장 테스트"""
+
+    def _make_client_extra_payload(self, alarm_status: str) -> dict:
+        """clientExtra 기반 payload 생성 (실제 카카오 block+extra 요청 형식)"""
+        return {
+            "userRequest": {
+                "user": {
+                    "id": "bot_user_key_123",
+                    "properties": {
+                        "plusfriendUserKey": "plusfriend_key_123"
+                    }
+                }
+            },
+            "action": {
+                "clientExtra": {"alarm_status": alarm_status},
+                "params": {}
+            }
+        }
+
+    def test_save_alarm_on_via_client_extra(self, clean_test_db):
+        """block+extra 방식: clientExtra.alarm_status='on' 으로 알림 켜기"""
+        payload = self._make_client_extra_payload("on")
+
+        with patch("app.services.user_service.UserService.sync_kakao_user"):
+            with patch("app.services.user_service.UserService.update_alarm_setting") as mock_update:
+                mock_update.return_value = {"success": True}
+
+                response = client.post("/alarm-setting/save", json=payload)
+
+                assert response.status_code == 200
+                text = response.json()["template"]["outputs"][0]["simpleText"]["text"]
+                assert "켜졌습니다" in text
+
+                mock_update.assert_called_once()
+                assert mock_update.call_args[0][1] is True  # is_alarm_on=True
+
+    def test_save_alarm_off_via_client_extra(self, clean_test_db):
+        """block+extra 방식: clientExtra.alarm_status='off' 으로 알림 끄기"""
+        payload = self._make_client_extra_payload("off")
+
+        with patch("app.services.user_service.UserService.sync_kakao_user"):
+            with patch("app.services.user_service.UserService.update_alarm_setting") as mock_update:
+                mock_update.return_value = {"success": True}
+
+                response = client.post("/alarm-setting/save", json=payload)
+
+                assert response.status_code == 200
+                text = response.json()["template"]["outputs"][0]["simpleText"]["text"]
+                assert "꺼졌습니다" in text
+
+                mock_update.assert_called_once()
+                assert mock_update.call_args[0][1] is False  # is_alarm_on=False
+
+    def test_client_extra_takes_priority_over_params(self, clean_test_db):
+        """clientExtra가 params보다 우선 적용되는지 확인"""
+        payload = {
+            "userRequest": {
+                "user": {
+                    "id": "bot_user_key_123",
+                    "properties": {"plusfriendUserKey": "plusfriend_key_123"}
+                }
+            },
+            "action": {
+                "clientExtra": {"alarm_status": "on"},   # ← 우선
+                "params": {"alarm_status": "off"}         # ← 무시되어야 함
+            }
+        }
+
+        with patch("app.services.user_service.UserService.sync_kakao_user"):
+            with patch("app.services.user_service.UserService.update_alarm_setting") as mock_update:
+                mock_update.return_value = {"success": True}
+
+                response = client.post("/alarm-setting/save", json=payload)
+
+                text = response.json()["template"]["outputs"][0]["simpleText"]["text"]
+                assert "켜졌습니다" in text  # clientExtra의 "on"이 적용되어야 함
+                assert mock_update.call_args[0][1] is True
+
+
+class TestFavoriteZoneSaveViaClientExtra:
+    """/favorite-zone/save: block+extra 방식(clientExtra) 관심장소 저장 테스트"""
+
+    def _make_payload(self, zone: str, use_client_extra: bool = True) -> dict:
+        action = (
+            {"clientExtra": {"zone": zone}, "params": {}}
+            if use_client_extra
+            else {"params": {"zone": zone}}
+        )
+        return {
+            "userRequest": {
+                "user": {
+                    "id": "bot_user_key_123",
+                    "properties": {"plusfriendUserKey": "plusfriend_key_123"}
+                }
+            },
+            "action": action
+        }
+
+    def test_save_zone_via_client_extra(self, clean_test_db):
+        """block+extra 방식: clientExtra.zone='1구역' 저장 성공"""
+        payload = self._make_payload("1구역")
+
+        with patch("app.services.user_service.UserService.sync_kakao_user"):
+            with patch("app.services.user_service.UserService.update_favorite_zone") as mock_update:
+                mock_update.return_value = {"success": True}
+
+                response = client.post("/favorite-zone/save", json=payload)
+
+                assert response.status_code == 200
+                text = response.json()["template"]["outputs"][0]["simpleText"]["text"]
+                assert "1구역" in text
+
+    def test_save_unset_zone_via_client_extra(self, clean_test_db):
+        """block+extra 방식: clientExtra.zone='미설정' 으로 관심장소 해제"""
+        payload = self._make_payload("미설정")
+
+        with patch("app.services.user_service.UserService.sync_kakao_user"):
+            with patch("app.services.user_service.UserService.update_favorite_zone") as mock_update:
+                mock_update.return_value = {"success": True}
+
+                response = client.post("/favorite-zone/save", json=payload)
+
+                assert response.status_code == 200
+                text = response.json()["template"]["outputs"][0]["simpleText"]["text"]
+                assert "해제" in text
+
+    def test_client_extra_takes_priority_over_params_zone(self, clean_test_db):
+        """clientExtra.zone이 params.zone보다 우선 적용"""
+        payload = {
+            "userRequest": {
+                "user": {
+                    "id": "bot_user_key_123",
+                    "properties": {"plusfriendUserKey": "plusfriend_key_123"}
+                }
+            },
+            "action": {
+                "clientExtra": {"zone": "1구역"},   # ← 우선
+                "params": {"zone": "3구역"}          # ← 무시되어야 함
+            }
+        }
+
+        with patch("app.services.user_service.UserService.sync_kakao_user"):
+            with patch("app.services.user_service.UserService.update_favorite_zone") as mock_update:
+                mock_update.return_value = {"success": True}
+
+                response = client.post("/favorite-zone/save", json=payload)
+
+                text = response.json()["template"]["outputs"][0]["simpleText"]["text"]
+                assert "1구역" in text
+


### PR DESCRIPTION
- kakao_skills.py: settings import를 파일 최상단으로 이동 (PEP8, #55/#56 리뷰 반영)
- kakao_skills.py: getattr 대신 settings.ALARM_SAVE_BLOCK_ID 직접 접근
- kakao_skills.py: getattr 대신 settings.FAVORITE_ZONE_SAVE_BLOCK_ID 직접 접근
- test_alarm_setting.py: block+extra 방식(clientExtra) 테스트 케이스 6개 추가
  - TestAlarmSettingSaveViaClientExtra (on/off/우선순위 검증)
  - TestFavoriteZoneSaveViaClientExtra (zone/미설정/우선순위 검증)

refs: #55, #56
closes: #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved configuration management for alarm and favorite zone settings handlers.

* **Tests**
  * Added comprehensive test coverage for alarm settings and favorite zone functionality, including validation of configuration precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->