### PR TITLE
ci: optimize CI/CD pipeline with caching and prune fix (#61)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,7 +156,7 @@ jobs:
             # Stop old stack (ignore if not running)
             docker compose down || true
 
-            # Remove only dangling/unused images; keep layer cache
+            # Remove dangling images; keep layer cache
             docker image prune -f || true
 
             echo "=== Disk usage (after prune) ==="

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,14 +51,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build Docker image
-        run: |
-          docker build -t kt-demo-alarm:${{ github.sha }} .
-          docker tag kt-demo-alarm:${{ github.sha }} kt-demo-alarm:latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Save Docker image (gzipped tar)
-        run: |
-          docker save kt-demo-alarm:latest | gzip -c > kt-demo-alarm-image.tar.gz
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          tags: kt-demo-alarm:latest,kt-demo-alarm:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=kt-demo-alarm-image.tar
+
+      - name: Compress Docker image
+        run: gzip kt-demo-alarm-image.tar
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,10 +150,8 @@ jobs:
             # Stop old stack (ignore if not running)
             docker compose down || true
 
-            # IMPORTANT: free disk BEFORE docker load / up
-            docker system prune -af || true
-            # Only if you are OK with deleting unused volumes (may delete caches)
-            # docker volume prune -f || true
+            # Remove only dangling/unused images; keep layer cache
+            docker image prune -f || true
 
             echo "=== Disk usage (after prune) ==="
             df -h

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --dev
 
+      - name: Cache Playwright Browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+
       - name: Install Playwright Browsers
         run: |
           uv run playwright install-deps


### PR DESCRIPTION
## 개요
Closes #61

CI/CD 파이프라인의 세 가지 병목을 개선합니다.

## 변경 사항

### Commit 1 — Playwright 브라우저 캐싱
- `actions/cache@v4`로 `~/.cache/ms-playwright` 캐싱
- `uv.lock` 해시 기반 캐시 키 → 의존성 변경 시에만 재설치
- 예상 절약: **~1.5분**

### Commit 2 — `docker system prune -af` → `docker image prune -f`
- `system prune -af`는 EC2의 모든 Docker 레이어 캐시를 삭제하여 매 배포마다 이미지 전체를 재로드하게 만들었음
- `image prune -f`로 교체해 미사용 이미지만 정리하고 레이어 캐시 보존

### Commit 3 — Docker GHA 레이어 캐시
- `docker build` → `docker/setup-buildx-action@v3` + `docker/build-push-action@v5`
- `cache-from/cache-to: type=gha` 활성화
- 소스 코드만 변경된 경우 의존성 설치 레이어 재사용
- 예상 절약: **2~3분**

## 예상 결과
| 항목 | 변경 전 | 변경 후 |
|------|--------|--------|
| Playwright 설치 | ~1.5분 | ~10초 (캐시 히트 시) |
| Docker 빌드 | ~3분 | ~1분 (소스 변경 시) |
| EC2 이미지 로드 | 매번 전체 로드 | 레이어 캐시 활용 |
| **총 배포 시간** | **~8분** | **~4-5분** |