### PR TITLE
Fix Kakao Event API Alarm Logic Bugs

### DIFF
--- a/app/routers/alarms.py
+++ b/app/routers/alarms.py
@@ -102,11 +102,11 @@ async def send_alarm_to_all(
         cursor = db.cursor()
         # plusfriend_user_key 우선 조회
         cursor.execute("SELECT plusfriend_user_key FROM users WHERE active = 1 AND is_alarm_on = 1 AND plusfriend_user_key IS NOT NULL")
-        plusfriend_users = [row[0] for row in cursor.fetchall()]
+        plusfriend_users = list(dict.fromkeys([row[0] for row in cursor.fetchall()]))
         
         # bot_user_key만 있는 사용자
         cursor.execute("SELECT bot_user_key FROM users WHERE active = 1 AND is_alarm_on = 1 AND plusfriend_user_key IS NULL AND bot_user_key IS NOT NULL")
-        bot_users = [row[0] for row in cursor.fetchall()]
+        bot_users = list(dict.fromkeys([row[0] for row in cursor.fetchall()]))
         
         if not plusfriend_users and not bot_users:
             raise HTTPException(status_code=404, detail="활성 사용자가 없습니다")
@@ -152,6 +152,8 @@ async def send_alarm_to_all(
             "failed": result["total_failed"]
         }
         
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"전체 알림 전송 실패: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -194,8 +196,10 @@ async def send_filtered_alarm(
         cursor.execute(query, params)
         rows = cursor.fetchall()
         
-        plusfriend_users = [r[0] for r in rows if r[0] is not None]
-        bot_users = [r[1] for r in rows if r[0] is None and r[1] is not None]
+        plusfriend_users_raw = [r[0] for r in rows if r[0] is not None]
+        bot_users_raw = [r[1] for r in rows if r[0] is None and r[1] is not None]
+        plusfriend_users = list(dict.fromkeys(plusfriend_users_raw))
+        bot_users = list(dict.fromkeys(bot_users_raw))
         
         if not plusfriend_users and not bot_users:
             raise HTTPException(status_code=404, detail="조건에 맞는 사용자가 없습니다")
@@ -246,6 +250,8 @@ async def send_filtered_alarm(
             "failed": result["total_failed"]
         }
         
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"필터링된 알림 전송 실패: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/app/routers/alarms.py
+++ b/app/routers/alarms.py
@@ -120,9 +120,14 @@ async def send_alarm_to_all(
                 data=data,
                 id_type="plusfriendUserKey"
             )
-            result["total_users"] += pf_result["total_users"]
-            result["total_sent"] += pf_result["total_sent"]
-            result["total_failed"] += pf_result["total_failed"]
+            if pf_result.get("success", True):  # Assume True if missing, or maybe success is explicitly returned
+                result["total_users"] += pf_result.get("total_users", 0)
+                result["total_sent"] += pf_result.get("total_sent", 0)
+                result["total_failed"] += pf_result.get("total_failed", 0)
+            else:
+                logger.error(f"plusfriend_user_key 알림 전송 실패: {pf_result.get('error')}")
+                result["total_users"] += len(plusfriend_users)
+                result["total_failed"] += len(plusfriend_users)
             
         if bot_users:
             bot_result = await NotificationService.send_bulk_alarm(
@@ -131,9 +136,14 @@ async def send_alarm_to_all(
                 data=data,
                 id_type="botUserKey"
             )
-            result["total_users"] += bot_result["total_users"]
-            result["total_sent"] += bot_result["total_sent"]
-            result["total_failed"] += bot_result["total_failed"]
+            if bot_result.get("success", True):
+                result["total_users"] += bot_result.get("total_users", 0)
+                result["total_sent"] += bot_result.get("total_sent", 0)
+                result["total_failed"] += bot_result.get("total_failed", 0)
+            else:
+                logger.error(f"bot_user_key 알림 전송 실패: {bot_result.get('error')}")
+                result["total_users"] += len(bot_users)
+                result["total_failed"] += len(bot_users)
         
         return {
             "message": f"전체 알림 전송 완료",
@@ -188,7 +198,7 @@ async def send_filtered_alarm(
         bot_users = [r[1] for r in rows if r[0] is None and r[1] is not None]
         
         if not plusfriend_users and not bot_users:
-            return {"message": "조건에 맞는 사용자가 없습니다", "sent": 0}
+            raise HTTPException(status_code=404, detail="조건에 맞는 사용자가 없습니다")
         
         result = {"total_users": 0, "total_sent": 0, "total_failed": 0}
         
@@ -199,9 +209,14 @@ async def send_filtered_alarm(
                 data=request.data,
                 id_type="plusfriendUserKey"
             )
-            result["total_users"] += pf_result["total_users"]
-            result["total_sent"] += pf_result["total_sent"]
-            result["total_failed"] += pf_result["total_failed"]
+            if pf_result.get("success", True):
+                result["total_users"] += pf_result.get("total_users", 0)
+                result["total_sent"] += pf_result.get("total_sent", 0)
+                result["total_failed"] += pf_result.get("total_failed", 0)
+            else:
+                logger.error(f"plusfriend_user_key 알림 전송 실패: {pf_result.get('error')}")
+                result["total_users"] += len(plusfriend_users)
+                result["total_failed"] += len(plusfriend_users)
             
         if bot_users:
             bot_result = await NotificationService.send_bulk_alarm(
@@ -210,9 +225,14 @@ async def send_filtered_alarm(
                 data=request.data,
                 id_type="botUserKey"
             )
-            result["total_users"] += bot_result["total_users"]
-            result["total_sent"] += bot_result["total_sent"]
-            result["total_failed"] += bot_result["total_failed"]
+            if bot_result.get("success", True):
+                result["total_users"] += bot_result.get("total_users", 0)
+                result["total_sent"] += bot_result.get("total_sent", 0)
+                result["total_failed"] += bot_result.get("total_failed", 0)
+            else:
+                logger.error(f"bot_user_key 알림 전송 실패: {bot_result.get('error')}")
+                result["total_users"] += len(bot_users)
+                result["total_failed"] += len(bot_users)
         
         return {
             "message": f"필터링된 알림 전송 완료",

--- a/app/routers/alarms.py
+++ b/app/routers/alarms.py
@@ -100,18 +100,40 @@ async def send_alarm_to_all(
     """전체 활성 사용자에게 알림 전송"""
     try:
         cursor = db.cursor()
-        cursor.execute("SELECT bot_user_key FROM users WHERE active = 1 AND is_alarm_on = 1")
+        # plusfriend_user_key 우선 조회
+        cursor.execute("SELECT plusfriend_user_key FROM users WHERE active = 1 AND is_alarm_on = 1 AND plusfriend_user_key IS NOT NULL")
+        plusfriend_users = [row[0] for row in cursor.fetchall()]
         
-        user_ids = [row[0] for row in cursor.fetchall()]
+        # bot_user_key만 있는 사용자
+        cursor.execute("SELECT bot_user_key FROM users WHERE active = 1 AND is_alarm_on = 1 AND plusfriend_user_key IS NULL AND bot_user_key IS NOT NULL")
+        bot_users = [row[0] for row in cursor.fetchall()]
         
-        if not user_ids:
+        if not plusfriend_users and not bot_users:
             raise HTTPException(status_code=404, detail="활성 사용자가 없습니다")
         
-        result = await NotificationService.send_bulk_alarm(
-            user_ids=user_ids,
-            event_name=event_name,
-            data=data
-        )
+        result = {"total_users": 0, "total_sent": 0, "total_failed": 0}
+        
+        if plusfriend_users:
+            pf_result = await NotificationService.send_bulk_alarm(
+                user_ids=plusfriend_users,
+                event_name=event_name,
+                data=data,
+                id_type="plusfriendUserKey"
+            )
+            result["total_users"] += pf_result["total_users"]
+            result["total_sent"] += pf_result["total_sent"]
+            result["total_failed"] += pf_result["total_failed"]
+            
+        if bot_users:
+            bot_result = await NotificationService.send_bulk_alarm(
+                user_ids=bot_users,
+                event_name=event_name,
+                data=data,
+                id_type="botUserKey"
+            )
+            result["total_users"] += bot_result["total_users"]
+            result["total_sent"] += bot_result["total_sent"]
+            result["total_failed"] += bot_result["total_failed"]
         
         return {
             "message": f"전체 알림 전송 완료",
@@ -136,7 +158,12 @@ async def send_filtered_alarm(
         cursor = db.cursor()
         
         # 기본 쿼리
-        query = "SELECT bot_user_key FROM users WHERE active = 1 AND is_alarm_on = 1"
+        query = """
+            SELECT plusfriend_user_key, bot_user_key 
+            FROM users 
+            WHERE active = 1 AND is_alarm_on = 1
+            AND (plusfriend_user_key IS NOT NULL OR bot_user_key IS NOT NULL)
+        """
         params = []
         
         # 필터 조건 추가
@@ -148,23 +175,44 @@ async def send_filtered_alarm(
             query += " AND marked_bus = ?"
             params.append(request.filter_marked_bus)
         
-        if request.filter_has_route:
+        if request.filter_has_route is not None:
             if request.filter_has_route:
                 query += " AND departure_x IS NOT NULL AND arrival_x IS NOT NULL"
             else:
                 query += " AND (departure_x IS NULL OR arrival_x IS NULL)"
         
         cursor.execute(query, params)
-        user_ids = [row[0] for row in cursor.fetchall()]
+        rows = cursor.fetchall()
         
-        if not user_ids:
-            raise HTTPException(status_code=404, detail="필터 조건에 맞는 사용자가 없습니다")
+        plusfriend_users = [r[0] for r in rows if r[0] is not None]
+        bot_users = [r[1] for r in rows if r[0] is None and r[1] is not None]
         
-        result = await NotificationService.send_bulk_alarm(
-            user_ids=user_ids,
-            event_name=request.event_name,
-            data=request.data
-        )
+        if not plusfriend_users and not bot_users:
+            return {"message": "조건에 맞는 사용자가 없습니다", "sent": 0}
+        
+        result = {"total_users": 0, "total_sent": 0, "total_failed": 0}
+        
+        if plusfriend_users:
+            pf_result = await NotificationService.send_bulk_alarm(
+                user_ids=plusfriend_users,
+                event_name=request.event_name,
+                data=request.data,
+                id_type="plusfriendUserKey"
+            )
+            result["total_users"] += pf_result["total_users"]
+            result["total_sent"] += pf_result["total_sent"]
+            result["total_failed"] += pf_result["total_failed"]
+            
+        if bot_users:
+            bot_result = await NotificationService.send_bulk_alarm(
+                user_ids=bot_users,
+                event_name=request.event_name,
+                data=request.data,
+                id_type="botUserKey"
+            )
+            result["total_users"] += bot_result["total_users"]
+            result["total_sent"] += bot_result["total_sent"]
+            result["total_failed"] += bot_result["total_failed"]
         
         return {
             "message": f"필터링된 알림 전송 완료",

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -172,7 +172,7 @@ class EventService:
             # 활성 집회 목록 조회
             cursor.execute('''
                 SELECT * FROM events 
-                WHERE status = 'active' AND start_date > datetime('now')
+                WHERE status = 'active' AND start_date > datetime('now', '+9 hours')
                 ORDER BY start_date
             ''')
             
@@ -241,9 +241,10 @@ class EventService:
             )
             
         except Exception as e:
-            logger.error(f"경로 집회 확인 실패 - {user_id}: {str(e)}")
+            safe_user_id = user_id or "unknown"
+            logger.error(f"경로 집회 확인 실패 - {safe_user_id}: {str(e)}")
             return RouteEventCheck(
-                user_id=user_id,
+                user_id=safe_user_id,
                 events_found=[],
                 route_info={},
                 total_events=0
@@ -284,7 +285,7 @@ class EventService:
 
             logger.info(f"경로 등록된 사용자 {len(users)}명 확인 중...")
 
-            # 조건별로 그룹화 (예: 출발지가 같은 사용자끼리)
+            # 조건별로 그룹화 (출발지와 도착지가 같은 사용자끼리)
             grouped_users = {}
             for user_row in users:
                 plusfriend_key, departure, arrival = user_row
@@ -293,10 +294,10 @@ class EventService:
                 result = await EventService.check_route_events(plusfriend_key, auto_notify=False, db=db)
 
                 if result.events_found:
-                    # 조건별로 그룹화 (출발지 기준)
-                    if departure not in grouped_users:
-                        grouped_users[departure] = []
-                    grouped_users[departure].append({
+                    route_key = (departure or "알수없음", arrival or "알수없음")
+                    if route_key not in grouped_users:
+                        grouped_users[route_key] = []
+                    grouped_users[route_key].append({
                         "plusfriend_key": plusfriend_key,
                         "events": [
                             {
@@ -314,11 +315,11 @@ class EventService:
                     })
 
             # Event API로 일괄 전송
-            for departure, user_group in grouped_users.items():
+            for (dep, arr), user_group in grouped_users.items():
                 user_ids = [u["plusfriend_key"] for u in user_group]
                 events_data = user_group[0]["events"]  # 공통 이벤트
 
-                logger.info(f"📢 출발지 '{departure}' 사용자 {len(user_ids)}명에게 알림 전송")
+                logger.info(f"📢 경로 '{dep}->{arr}' 사용자 {len(user_ids)}명에게 알림 전송")
 
                 # Event API 호출 (type=plusfriendUserKey)
                 await NotificationService.send_bulk_alert(

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -285,7 +285,7 @@ class EventService:
 
             logger.info(f"경로 등록된 사용자 {len(users)}명 확인 중...")
 
-            # 조건별로 그룹화 (출발지와 도착지가 같은 사용자끼리)
+            # 이벤트 결과가 정확히 일치하는 사용자끼리 그룹화
             grouped_users = {}
             for user_row in users:
                 plusfriend_key, departure, arrival = user_row
@@ -294,32 +294,35 @@ class EventService:
                 result = await EventService.check_route_events(plusfriend_key, auto_notify=False, db=db)
 
                 if result.events_found:
-                    route_key = (departure or "알수없음", arrival or "알수없음")
-                    if route_key not in grouped_users:
-                        grouped_users[route_key] = []
-                    grouped_users[route_key].append({
-                        "plusfriend_key": plusfriend_key,
-                        "events": [
-                            {
-                                "id": event.id,
-                                "title": event.title,
-                                "location": event.location_name,
-                                "latitude": event.latitude,
-                                "longitude": event.longitude,
-                                "start_date": event.start_date.isoformat() if hasattr(event.start_date, 'isoformat') else str(event.start_date),
-                                "category": event.category,
-                                "severity_level": event.severity_level
-                            }
-                            for event in result.events_found
-                        ]
-                    })
+                    # 해당 사용자에게 전달될 정확한 이벤트 집합을 키로 사용
+                    event_key = tuple(sorted(event.id for event in result.events_found))
+                    
+                    if event_key not in grouped_users:
+                        grouped_users[event_key] = {
+                            "user_ids": [],
+                            "events_data": [
+                                {
+                                    "id": event.id,
+                                    "title": event.title,
+                                    "location": event.location_name,
+                                    "latitude": event.latitude,
+                                    "longitude": event.longitude,
+                                    "start_date": event.start_date.isoformat() if hasattr(event.start_date, 'isoformat') else str(event.start_date),
+                                    "category": event.category,
+                                    "severity_level": event.severity_level
+                                }
+                                for event in result.events_found
+                            ]
+                        }
+                    
+                    grouped_users[event_key]["user_ids"].append(plusfriend_key)
 
             # Event API로 일괄 전송
-            for (dep, arr), user_group in grouped_users.items():
-                user_ids = [u["plusfriend_key"] for u in user_group]
-                events_data = user_group[0]["events"]  # 공통 이벤트
+            for event_key, group_data in grouped_users.items():
+                user_ids = group_data["user_ids"]
+                events_data = group_data["events_data"]
 
-                logger.info(f"📢 경로 '{dep}->{arr}' 사용자 {len(user_ids)}명에게 알림 전송")
+                logger.info(f"📢 수신 대상 {len(user_ids)}명에게 공통 이벤트({len(events_data)}건) 알림 전송")
 
                 # Event API 호출 (type=plusfriendUserKey)
                 await NotificationService.send_bulk_alert(

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -137,27 +137,26 @@ class NotificationService:
 
             # 하나의 세션을 생성하여 모든 요청에 재사용
             async with httpx.AsyncClient() as client:
+                # 내부 헬퍼 함수 - 세션과 파라미터 캡처
+                async def send_to_user(user_id: str) -> Dict[str, Any]:
+                    try:
+                        alarm_request = AlarmRequest(
+                            user_id=user_id,
+                            event_name=event_name,
+                            data=data
+                        )
+                        return await NotificationService.send_individual_alarm(
+                            alarm_request, 
+                            id_type=id_type,
+                            client=client
+                        )
+                    except Exception as e:
+                        logger.error(f"사용자 {user_id} 알림 전송 실패: {str(e)}")
+                        return {"success": False, "error": str(e)}
+
                 # 배치 단위로 처리
                 for i in range(0, len(user_ids), actual_batch_size):
                     batch_users = user_ids[i:i + actual_batch_size]
-
-                    # 배치 내 모든 사용자에게 병렬로 알림 전송
-                    async def send_to_user(user_id: str) -> Dict[str, Any]:
-                        try:
-                            alarm_request = AlarmRequest(
-                                user_id=user_id,
-                                event_name=event_name,
-                                data=data
-                            )
-                            # 생성한 클라이언트를 주입
-                            return await NotificationService.send_individual_alarm(
-                                alarm_request, 
-                                id_type=id_type,
-                                client=client
-                            )
-                        except Exception as e:
-                            logger.error(f"사용자 {user_id} 알림 전송 실패: {str(e)}")
-                            return {"success": False, "error": str(e)}
                     
                     # 배치 내 모든 작업을 동시에 실행
                     batch_tasks = [send_to_user(user_id) for user_id in batch_users]

--- a/tests/test_api_alarms.py
+++ b/tests/test_api_alarms.py
@@ -1,0 +1,81 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+import sqlite3
+
+def test_send_alarms_separates_id_types(test_client, clean_test_db):
+    """plusfriendUserKey와 botUserKey 보유자에 따라 알림 발송이 2번 분리되어 호출되는지 확인하는 테스트"""
+    conn = sqlite3.connect(clean_test_db)
+    cursor = conn.cursor()
+    try:
+        # User 1: plusfriend와 bot 둘 다 있음 (plusfriend로 분류되어야 함)
+        cursor.execute("INSERT INTO users (bot_user_key, plusfriend_user_key, active, is_alarm_on) VALUES ('bot1', 'pf1', 1, 1)")
+        # User 2: bot_user_key만 있음 (botUserKey로 분류되어야 함)
+        cursor.execute("INSERT INTO users (bot_user_key, active, is_alarm_on) VALUES ('bot2', 1, 1)")
+        # User 3: 또 다른 plusfriend (plusfriend로 분류되어야 함)
+        cursor.execute("INSERT INTO users (bot_user_key, plusfriend_user_key, active, is_alarm_on) VALUES ('bot3', 'pf3', 1, 1)")
+        # User 4: 알림 꺼둠 (제외되어야 함)
+        cursor.execute("INSERT INTO users (bot_user_key, plusfriend_user_key, active, is_alarm_on) VALUES ('bot4', 'pf4', 1, 0)")
+        # User 5: 비활성화 (제외되어야 함)
+        cursor.execute("INSERT INTO users (bot_user_key, plusfriend_user_key, active, is_alarm_on) VALUES ('bot5', 'pf5', 0, 1)")
+        
+        conn.commit()
+    finally:
+        conn.close()
+
+    with patch('app.routers.alarms.NotificationService.send_bulk_alarm', new_callable=AsyncMock) as mock_send_bulk:
+        mock_send_bulk.return_value = {"success": True, "total_users": 1, "total_sent": 1, "total_failed": 0}
+        
+        response = test_client.post(
+            "/alarms/send-to-all?event_name=test_event",
+            headers={"X-API-Key": "test-api-key"},
+            json={}
+        )
+        
+        assert response.status_code == 200
+        
+        # ID 타입별로 2번 호출되어야 합니다 (plusfriend 대상자 그룹 1번, bot_user 대상자 그룹 1번)
+        assert mock_send_bulk.call_count == 2
+        
+        # 첫 번째 호출은 plusfriendUserKey 대상자 (pf1, pf3)
+        call1_kwargs = mock_send_bulk.call_args_list[0].kwargs
+        assert set(call1_kwargs['user_ids']) == {'pf1', 'pf3'}
+        assert call1_kwargs['id_type'] == "plusfriendUserKey"
+        
+        # 두 번째 호출은 botUserKey 대상자 (bot2)
+        call2_kwargs = mock_send_bulk.call_args_list[1].kwargs
+        assert set(call2_kwargs['user_ids']) == {'bot2'}
+        assert call2_kwargs['id_type'] == "botUserKey"
+
+
+def test_send_alarms_to_all_404_when_empty(test_client, clean_test_db):
+    """발송 대상자가 한 명도 없을 때 500 에러를 뿜지 않고 404를 잘 반환하는지 확인하는 테스트"""
+    # DB가 비어있는 상태에서 바로 호출
+    response = test_client.post(
+        "/alarms/send-to-all?event_name=test_event",
+        headers={"X-API-Key": "test-api-key"},
+        json={}
+    )
+    
+    assert response.status_code == 404
+    assert response.json()["detail"] == "활성 사용자가 없습니다"
+
+
+def test_send_filtered_alarms_404_when_empty(test_client, clean_test_db):
+    """필터링 된 발송 대상자가 한 명도 없을 때 404를 잘 반환하는지 확인하는 테스트"""
+    conn = sqlite3.connect(clean_test_db)
+    cursor = conn.cursor()
+    try:
+        # 사용자는 있지만 필터 조건(location)에 맞는 사용자가 없는 상황 구성
+        cursor.execute("INSERT INTO users (bot_user_key, plusfriend_user_key, location, active, is_alarm_on) VALUES ('bot1', 'pf1', '부산광역시', 1, 1)")
+        conn.commit()
+    finally:
+        conn.close()
+    
+    response = test_client.post(
+        "/alarms/send-filtered",
+        headers={"X-API-Key": "test-api-key"},
+        json={"filter_location": "서울특별시", "event_name": "test", "data": {}}
+    )
+    
+    assert response.status_code == 404
+    assert response.json()["detail"] == "조건에 맞는 사용자가 없습니다"


### PR DESCRIPTION
Fixes #63.
Implemented changes:
1. Alarms router: Distinguish ID types (plusfriend vs bot_user) and fix dead logic.
2. Event Service: Add +9 hours mapping to SQLite datetime('now') queries to fix logic issue blocking alarms. Group correctly by departure+arrival pair.
3. Notification Service: move closure out of loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable alarm delivery by splitting recipients into two recipient flows, sending each batch separately, improving failure counting and error logging; empty-recipient responses now occur only when no recipients exist across both flows.
  * Specific HTTP errors are preserved while other failures return internal errors.
  * Event detection window shifted by +9 hours, reducing missed/early notifications.

* **Refactor**
  * Notification send flow reorganized to reuse a shared client for per-recipient sends.

* **Tests**
  * Added end-to-end tests verifying recipient separation, empty-recipient 404s, and filtered-send behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->