### PR TITLE
fix: scheduled_route_check()에 alarm_tasks 등록 누락 수정

### DIFF
--- a/app/services/alarm_status_service.py
+++ b/app/services/alarm_status_service.py
@@ -64,7 +64,8 @@ class AlarmStatusService:
         status: str,
         successful_sends: Optional[int] = None,
         failed_sends: Optional[int] = None,
-        error_messages: Optional[List[str]] = None
+        error_messages: Optional[List[str]] = None,
+        total_recipients: Optional[int] = None
     ) -> bool:
         """
         알림 작업 상태 업데이트
@@ -99,6 +100,10 @@ class AlarmStatusService:
                 if error_messages is not None:
                     update_fields.append("error_messages = ?")
                     update_values.append(json.dumps(error_messages))
+
+                if total_recipients is not None:
+                    update_fields.append("total_recipients = ?")
+                    update_values.append(total_recipients)
                 
                 # 완료 상태인 경우 완료 시간 추가
                 if status in ["completed", "failed", "partial"]:

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -264,10 +264,12 @@ class EventService:
 
         logger.info("=== 정기 집회 확인 시작 ===")
 
-        task_id = AlarmStatusService.create_alarm_task(alarm_type="scheduled", total_recipients=0)
-        AlarmStatusService.update_alarm_task_status(task_id, "processing")
-
+        task_id = None
+        db = None
         try:
+            task_id = AlarmStatusService.create_alarm_task(alarm_type="scheduled", total_recipients=0)
+            AlarmStatusService.update_alarm_task_status(task_id, "processing")
+
             # 데이터베이스 연결
             db = sqlite3.connect(DATABASE_PATH, check_same_thread=False)
 
@@ -289,6 +291,9 @@ class EventService:
             total_notifications = 0
 
             logger.info(f"경로 등록된 사용자 {len(users)}명 확인 중...")
+
+            # 실제 수신 대상 수 기록
+            AlarmStatusService.update_alarm_task_status(task_id, "processing", total_recipients=len(users))
 
             # 이벤트 결과가 정확히 일치하는 사용자끼리 그룹화
             grouped_users = {}
@@ -342,8 +347,6 @@ class EventService:
                 total_success += send_result.get("total_sent", 0)
                 total_fail += send_result.get("total_failed", 0)
 
-            db.close()
-
             final_status = "completed" if total_fail == 0 else "partial"
             AlarmStatusService.update_alarm_task_status(
                 task_id, final_status,
@@ -362,12 +365,17 @@ class EventService:
 
         except Exception as e:
             logger.error(f"정기 집회 확인 중 오류 발생: {str(e)}")
-            AlarmStatusService.update_alarm_task_status(task_id, "failed", error_messages=[str(e)])
+            if task_id:
+                AlarmStatusService.update_alarm_task_status(task_id, "failed", error_messages=[str(e)])
             return {
                 "success": False,
                 "task_id": task_id,
                 "error": str(e)
             }
+
+        finally:
+            if db is not None:
+                db.close()
 
     @staticmethod
     def get_upcoming_events(

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -260,7 +260,12 @@ class EventService:
         Returns:
             Dict: 처리 결과
         """
+        from app.services.alarm_status_service import AlarmStatusService
+
         logger.info("=== 정기 집회 확인 시작 ===")
+
+        task_id = AlarmStatusService.create_alarm_task(alarm_type="scheduled", total_recipients=0)
+        AlarmStatusService.update_alarm_task_status(task_id, "processing")
 
         try:
             # 데이터베이스 연결
@@ -296,7 +301,7 @@ class EventService:
                 if result.events_found:
                     # 해당 사용자에게 전달될 정확한 이벤트 집합을 키로 사용
                     event_key = tuple(sorted(event.id for event in result.events_found))
-                    
+
                     if event_key not in grouped_users:
                         grouped_users[event_key] = {
                             "user_ids": [],
@@ -314,10 +319,12 @@ class EventService:
                                 for event in result.events_found
                             ]
                         }
-                    
+
                     grouped_users[event_key]["user_ids"].append(plusfriend_key)
 
             # Event API로 일괄 전송
+            total_success = 0
+            total_fail = 0
             for event_key, group_data in grouped_users.items():
                 user_ids = group_data["user_ids"]
                 events_data = group_data["events_data"]
@@ -325,28 +332,40 @@ class EventService:
                 logger.info(f"📢 수신 대상 {len(user_ids)}명에게 공통 이벤트({len(events_data)}건) 알림 전송")
 
                 # Event API 호출 (type=plusfriendUserKey)
-                await NotificationService.send_bulk_alert(
+                send_result = await NotificationService.send_bulk_alert(
                     user_ids=user_ids,
                     events_data=events_data,
                     id_type="plusfriendUserKey"  # ← 타입 명시!
                 )
 
                 total_notifications += len(user_ids)
+                total_success += send_result.get("total_sent", 0)
+                total_fail += send_result.get("total_failed", 0)
 
             db.close()
+
+            final_status = "completed" if total_fail == 0 else "partial"
+            AlarmStatusService.update_alarm_task_status(
+                task_id, final_status,
+                successful_sends=total_success,
+                failed_sends=total_fail,
+            )
 
             logger.info(f"=== 정기 집회 확인 완료: {total_notifications}명에게 알림 전송 ===")
 
             return {
                 "success": True,
+                "task_id": task_id,
                 "total_users": len(users),
                 "notifications_sent": total_notifications
             }
 
         except Exception as e:
             logger.error(f"정기 집회 확인 중 오류 발생: {str(e)}")
+            AlarmStatusService.update_alarm_task_status(task_id, "failed", error_messages=[str(e)])
             return {
                 "success": False,
+                "task_id": task_id,
                 "error": str(e)
             }
 

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -292,9 +292,6 @@ class EventService:
 
             logger.info(f"경로 등록된 사용자 {len(users)}명 확인 중...")
 
-            # 실제 수신 대상 수 기록
-            AlarmStatusService.update_alarm_task_status(task_id, "processing", total_recipients=len(users))
-
             # 이벤트 결과가 정확히 일치하는 사용자끼리 그룹화
             grouped_users = {}
             for user_row in users:
@@ -327,6 +324,10 @@ class EventService:
 
                     grouped_users[event_key]["user_ids"].append(plusfriend_key)
 
+            # 실제 발송 대상 수(집회가 경로에 걸린 사용자) 기록
+            actual_recipients = sum(len(g["user_ids"]) for g in grouped_users.values())
+            AlarmStatusService.update_alarm_task_status(task_id, "processing", total_recipients=actual_recipients)
+
             # Event API로 일괄 전송
             total_success = 0
             total_fail = 0
@@ -343,9 +344,11 @@ class EventService:
                     id_type="plusfriendUserKey"  # ← 타입 명시!
                 )
 
-                total_notifications += len(user_ids)
-                total_success += send_result.get("total_sent", 0)
-                total_fail += send_result.get("total_failed", 0)
+                if not send_result.get("success", True):
+                    total_fail += len(user_ids)
+                else:
+                    total_success += send_result.get("total_sent", 0)
+                    total_fail += send_result.get("total_failed", 0)
 
             final_status = "completed" if total_fail == 0 else "partial"
             AlarmStatusService.update_alarm_task_status(
@@ -354,13 +357,15 @@ class EventService:
                 failed_sends=total_fail,
             )
 
-            logger.info(f"=== 정기 집회 확인 완료: {total_notifications}명에게 알림 전송 ===")
+            logger.info(
+                f"=== 정기 집회 확인 완료: 대상 {actual_recipients}명, 성공 {total_success}명, 실패 {total_fail}명 ==="
+            )
 
             return {
                 "success": True,
                 "task_id": task_id,
                 "total_users": len(users),
-                "notifications_sent": total_notifications
+                "notifications_sent": total_success
             }
 
         except Exception as e:


### PR DESCRIPTION
## Summary

- `EventService.scheduled_route_check()`이 `AlarmStatusService`를 전혀 호출하지 않아 매일 아침 스케줄 알림이 `alarm_tasks` 테이블에 기록되지 않던 버그 수정
- 함수 시작 시 `create_alarm_task(alarm_type="scheduled")` 호출로 작업 등록
- 전송 완료 후 성공/실패 수 집계하여 `update_alarm_task_status()` 호출 (`completed` / `partial`)
- 예외 발생 시에도 `"failed"` 상태로 업데이트하여 추적 가능하도록 개선
- 반환 dict에 `task_id` 포함 (수동 API와 동일한 응답 구조)

Closes #69

## Test plan

- [ ] 84개 기존 테스트 모두 통과 확인 (`uv run pytest tests/ -q`)
- [ ] `/scheduler/manual-test` 엔드포인트로 수동 실행 후 `GET /alarms/status`에 `scheduled` 타입 task 생성 확인
- [ ] 실패 케이스: BOT_ID 미설정 등 오류 상황에서 `failed` 상태로 기록되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled route checks now create and track alarm tasks with recipient counts, aggregated success/failure metrics, and include a task ID in success/failure responses.
  * Final task statuses reflect completed/partial/failed outcomes and report successful/failed sends.

* **Bug Fixes**
  * Improved exception handling to record errors on task failure and ensure database resources are closed reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->