### PR TITLE
feat: 이동경로 등록 2단계 UI (설정/삭제 ListCard) #72

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,8 +73,7 @@ ALARM_SAVE_BLOCK_ID=your_alarm_save_block_id_here
 # 관심장소 ListCard 저장 스킬 블록 ID
 FAVORITE_ZONE_SAVE_BLOCK_ID=your_favorite_zone_save_block_id_here
 
-# 이동경로 2단계 UI 블록 ID
-# "설정" 버튼 → 기존 출발지 입력 블록
+# 이동경로 "설정" 버튼에서 호출할 기존 출발지 입력 블록 ID
 ROUTE_SETUP_BLOCK_ID=your_route_setup_block_id_here
-# "삭제" 버튼 → /route-setting/delete 블록
+# 이동경로 "삭제" 버튼에서 호출할 /route-setting/delete 스킬 블록 ID
 ROUTE_DELETE_BLOCK_ID=your_route_delete_block_id_here

--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,7 @@ ALARM_SAVE_BLOCK_ID=your_alarm_save_block_id_here
 
 # 관심장소 ListCard 저장 스킬 블록 ID
 FAVORITE_ZONE_SAVE_BLOCK_ID=your_favorite_zone_save_block_id_here
+
+# 이동경로 2단계 UI 블록 ID
+ROUTE_SETUP_BLOCK_ID=your_route_setup_block_id_here    # "설정" 버튼 → 기존 출발지 입력 블록
+ROUTE_DELETE_BLOCK_ID=your_route_delete_block_id_here  # "삭제" 버튼 → /route-setting/delete 블록

--- a/.env.example
+++ b/.env.example
@@ -74,5 +74,7 @@ ALARM_SAVE_BLOCK_ID=your_alarm_save_block_id_here
 FAVORITE_ZONE_SAVE_BLOCK_ID=your_favorite_zone_save_block_id_here
 
 # 이동경로 2단계 UI 블록 ID
-ROUTE_SETUP_BLOCK_ID=your_route_setup_block_id_here    # "설정" 버튼 → 기존 출발지 입력 블록
-ROUTE_DELETE_BLOCK_ID=your_route_delete_block_id_here  # "삭제" 버튼 → /route-setting/delete 블록
+# "설정" 버튼 → 기존 출발지 입력 블록
+ROUTE_SETUP_BLOCK_ID=your_route_setup_block_id_here
+# "삭제" 버튼 → /route-setting/delete 블록
+ROUTE_DELETE_BLOCK_ID=your_route_delete_block_id_here

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -14,6 +14,9 @@ class Settings(BaseSettings):
     ALARM_SAVE_BLOCK_ID: Optional[str] = None
     # 관심장소 ListCard에서 사용할 저장 스킬 블록 ID (카카오 챗봇 관리자센터에서 확인)
     FAVORITE_ZONE_SAVE_BLOCK_ID: Optional[str] = None
+    # 이동경로 2단계 UI 블록 ID (카카오 챗봇 관리자센터에서 확인)
+    ROUTE_SETUP_BLOCK_ID: Optional[str] = None   # "설정" 버튼 → 기존 출발지 입력 블록
+    ROUTE_DELETE_BLOCK_ID: Optional[str] = None  # "삭제" 버튼 → /route-setting/delete 블록
 
     # --- TMAP API Configuration ---
     TMAP_APP_KEY: str = ""

--- a/app/routers/kakao_skills.py
+++ b/app/routers/kakao_skills.py
@@ -198,6 +198,120 @@ async def check_user_route_events(
     }
 
 
+@router.post("/route-setting")
+async def get_route_setting_selection(request: dict):
+    """
+    이동경로 관리 선택 UI 반환 (카카오톡 Skill Block)
+    - ListCard 형식으로 "설정" / "삭제" 2개 항목 표시
+    - action:block + extra 방식으로 각 블록에 직접 전달
+    """
+    logger.info(f"🔍 /route-setting 요청: {request}")
+
+    setup_block_id = settings.ROUTE_SETUP_BLOCK_ID
+    delete_block_id = settings.ROUTE_DELETE_BLOCK_ID
+
+    if setup_block_id:
+        setup_item = {
+            "title": "✏️ 설정",
+            "description": "출발지/도착지를 새로 등록합니다",
+            "action": "block",
+            "blockId": setup_block_id,
+        }
+    else:
+        setup_item = {
+            "title": "✏️ 설정",
+            "description": "출발지/도착지를 새로 등록합니다",
+            "action": "message",
+            "messageText": "경로 설정",
+        }
+
+    if delete_block_id:
+        delete_item = {
+            "title": "🗑️ 삭제",
+            "description": "등록된 출퇴근 경로를 삭제합니다",
+            "action": "block",
+            "blockId": delete_block_id,
+        }
+    else:
+        delete_item = {
+            "title": "🗑️ 삭제",
+            "description": "등록된 출퇴근 경로를 삭제합니다",
+            "action": "message",
+            "messageText": "경로 삭제",
+        }
+
+    return {
+        "version": "2.0",
+        "template": {
+            "outputs": [
+                {
+                    "listCard": {
+                        "header": {"title": "🚍 출퇴근 경로 관리"},
+                        "items": [setup_item, delete_item],
+                    }
+                }
+            ]
+        },
+    }
+
+
+@router.post("/route-setting/delete")
+async def delete_route_setting(
+    request: dict,
+    db: sqlite3.Connection = Depends(get_db),
+):
+    """
+    이동경로 삭제 처리 (카카오톡 Skill Block)
+    - 사용자의 departure_*, arrival_* 필드를 NULL로 초기화
+    """
+    try:
+        logger.info(f"🔍 /route-setting/delete 요청: {request}")
+
+        user_request = request.get('userRequest', {})
+        user_info = user_request.get('user', {})
+        bot_user_key = user_info.get('id')
+        properties = user_info.get('properties', {})
+        plusfriend_key = properties.get('plusfriendUserKey')
+
+        user_id = plusfriend_key if plusfriend_key else bot_user_key
+
+        if not user_id:
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [{"simpleText": {"text": "사용자 식별 정보가 누락되었습니다. 카카오톡 채널을 통해 다시 시도해주세요."}}]
+                },
+            }
+
+        UserService.sync_kakao_user(bot_user_key, plusfriend_key, db)
+
+        result = UserService.delete_user_route(user_id, db)
+
+        if result["success"]:
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [{"simpleText": {"text": "🗑️ 출퇴근 경로가 삭제되었습니다.\n다시 등록하려면 [🚗 출퇴근 경로 등록하기]를 눌러주세요."}}]
+                },
+            }
+        else:
+            return {
+                "version": "2.0",
+                "template": {
+                    "outputs": [{"simpleText": {"text": result.get("error", "경로 삭제에 실패했습니다.")}}]
+                },
+            }
+
+    except Exception:
+        logger.exception("이동경로 삭제 중 시스템 오류 발생")
+        return {
+            "version": "2.0",
+            "template": {
+                "outputs": [{"simpleText": {"text": "시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요."}}]
+            },
+        }
+
+
 @router.post("/save_user_info")
 async def save_user_info(request: dict, background_tasks: BackgroundTasks):
     """

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -293,6 +293,7 @@ class UserService:
         """
         try:
             cursor = db.cursor()
+            # 1. plusfriend_user_key로 우선 업데이트 시도
             cursor.execute('''
                 UPDATE users SET
                     departure_name = NULL, departure_address = NULL,
@@ -302,6 +303,18 @@ class UserService:
                     route_updated_at = ?
                 WHERE plusfriend_user_key = ?
             ''', (datetime.now(), user_id))
+
+            # 2. 업데이트된 레코드가 없으면 bot_user_key로 폴백 시도
+            if cursor.rowcount == 0:
+                cursor.execute('''
+                    UPDATE users SET
+                        departure_name = NULL, departure_address = NULL,
+                        departure_x = NULL, departure_y = NULL,
+                        arrival_name = NULL, arrival_address = NULL,
+                        arrival_x = NULL, arrival_y = NULL,
+                        route_updated_at = ?
+                    WHERE bot_user_key = ?
+                ''', (datetime.now(), user_id))
 
             if cursor.rowcount == 0:
                 logger.warning(f"경로 삭제 대상 사용자를 찾을 수 없음: {user_id}")

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -293,28 +293,21 @@ class UserService:
         """
         try:
             cursor = db.cursor()
-            # 1. plusfriend_user_key로 우선 업데이트 시도
-            cursor.execute('''
+            clear_sql = '''
                 UPDATE users SET
                     departure_name = NULL, departure_address = NULL,
                     departure_x = NULL, departure_y = NULL,
                     arrival_name = NULL, arrival_address = NULL,
                     arrival_x = NULL, arrival_y = NULL,
                     route_updated_at = ?
-                WHERE plusfriend_user_key = ?
-            ''', (datetime.now(), user_id))
+                WHERE {} = ?
+            '''
+            # 1. plusfriend_user_key로 우선 업데이트 시도
+            cursor.execute(clear_sql.format("plusfriend_user_key"), (datetime.now(), user_id))
 
             # 2. 업데이트된 레코드가 없으면 bot_user_key로 폴백 시도
             if cursor.rowcount == 0:
-                cursor.execute('''
-                    UPDATE users SET
-                        departure_name = NULL, departure_address = NULL,
-                        departure_x = NULL, departure_y = NULL,
-                        arrival_name = NULL, arrival_address = NULL,
-                        arrival_x = NULL, arrival_y = NULL,
-                        route_updated_at = ?
-                    WHERE bot_user_key = ?
-                ''', (datetime.now(), user_id))
+                cursor.execute(clear_sql.format("bot_user_key"), (datetime.now(), user_id))
 
             if cursor.rowcount == 0:
                 logger.warning(f"경로 삭제 대상 사용자를 찾을 수 없음: {user_id}")
@@ -325,8 +318,8 @@ class UserService:
             return {"success": True}
 
         except Exception as e:
-            logger.error(f"경로 삭제 실패: {str(e)}")
-            return {"success": False, "error": str(e)}
+            logger.exception("경로 삭제 DB 처리 실패")
+            return {"success": False, "error": "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."}
 
     @staticmethod
     async def update_marked_bus(user_id: str, marked_bus: str, db: sqlite3.Connection) -> Dict[str, Any]:

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -283,6 +283,39 @@ class UserService:
             return {"success": False, "error": str(e)}
 
     @staticmethod
+    def delete_user_route(user_id: str, db: sqlite3.Connection) -> Dict[str, Any]:
+        """
+        사용자 경로 정보 삭제 (route 관련 필드를 NULL로 초기화)
+
+        Args:
+            user_id: 사용자 ID (plusfriend_user_key)
+            db: 데이터베이스 연결
+        """
+        try:
+            cursor = db.cursor()
+            cursor.execute('''
+                UPDATE users SET
+                    departure_name = NULL, departure_address = NULL,
+                    departure_x = NULL, departure_y = NULL,
+                    arrival_name = NULL, arrival_address = NULL,
+                    arrival_x = NULL, arrival_y = NULL,
+                    route_updated_at = ?
+                WHERE plusfriend_user_key = ?
+            ''', (datetime.now(), user_id))
+
+            if cursor.rowcount == 0:
+                logger.warning(f"경로 삭제 대상 사용자를 찾을 수 없음: {user_id}")
+                return {"success": False, "error": "사용자를 찾을 수 없습니다"}
+
+            db.commit()
+            logger.info(f"경로 삭제 완료 - 사용자: {user_id}")
+            return {"success": True}
+
+        except Exception as e:
+            logger.error(f"경로 삭제 실패: {str(e)}")
+            return {"success": False, "error": str(e)}
+
+    @staticmethod
     async def update_marked_bus(user_id: str, marked_bus: str, db: sqlite3.Connection) -> Dict[str, Any]:
         """
         사용자의 marked_bus(자주 타는 버스)만 업데이트

--- a/tests/test_route_setting.py
+++ b/tests/test_route_setting.py
@@ -1,0 +1,125 @@
+"""이동경로 2단계 UI 기능 테스트"""
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def route_select_payload():
+    """이동경로 관리 선택 UI 요청 기본 payload"""
+    return {
+        "userRequest": {
+            "user": {
+                "id": "bot_user_key_123",
+                "properties": {
+                    "plusfriendUserKey": "plusfriend_key_123"
+                }
+            }
+        },
+        "action": {
+            "params": {}
+        }
+    }
+
+
+@pytest.fixture
+def route_delete_payload():
+    """이동경로 삭제 요청 기본 payload"""
+    return {
+        "userRequest": {
+            "user": {
+                "id": "bot_user_key_123",
+                "properties": {
+                    "plusfriendUserKey": "plusfriend_key_123"
+                }
+            }
+        },
+        "action": {
+            "params": {}
+        }
+    }
+
+
+class TestRouteSettingSelectionUI:
+    """이동경로 선택 UI (ListCard) 반환 테스트"""
+
+    def test_route_setting_selection_ui(self, route_select_payload):
+        """ListCard 형식으로 설정/삭제 2개 항목이 반환되는지 확인"""
+        response = client.post("/route-setting", json=route_select_payload)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        output = data["template"]["outputs"][0]
+        assert "listCard" in output
+
+        list_card = output["listCard"]
+        assert "출퇴근 경로" in list_card["header"]["title"]
+
+        items = list_card["items"]
+        assert len(items) == 2
+
+        # 각 아이템에 action: block+blockId 또는 message+messageText 확인
+        for item in items:
+            assert item["action"] in ("message", "block")
+            if item["action"] == "block":
+                assert "blockId" in item
+            else:
+                assert "messageText" in item
+
+        titles = [item["title"] for item in items]
+        assert any("설정" in t for t in titles)
+        assert any("삭제" in t for t in titles)
+
+
+class TestRouteSettingDelete:
+    """이동경로 삭제 처리 테스트"""
+
+    def test_delete_route_success(self, clean_test_db, route_delete_payload):
+        """삭제 성공 시 완료 메시지 반환"""
+        with patch("app.services.user_service.UserService.sync_kakao_user"):
+            with patch("app.services.user_service.UserService.delete_user_route") as mock_delete:
+                mock_delete.return_value = {"success": True}
+
+                response = client.post("/route-setting/delete", json=route_delete_payload)
+
+                assert response.status_code == 200
+                data = response.json()
+                text = data["template"]["outputs"][0]["simpleText"]["text"]
+                assert "삭제" in text
+
+                mock_delete.assert_called_once()
+
+    def test_delete_no_user_id(self, clean_test_db):
+        """사용자 식별 정보 누락 시 에러 반환"""
+        payload = {
+            "userRequest": {
+                "user": {
+                    "id": None,
+                    "properties": {}
+                }
+            },
+            "action": {"params": {}}
+        }
+
+        response = client.post("/route-setting/delete", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        text = data["template"]["outputs"][0]["simpleText"]["text"]
+        assert "사용자 식별 정보" in text
+
+    def test_delete_system_error(self, clean_test_db, route_delete_payload):
+        """시스템 오류 시 에러 메시지 반환"""
+        with patch("app.services.user_service.UserService.sync_kakao_user") as mock_sync:
+            mock_sync.side_effect = Exception("DB Connection Fail")
+
+            response = client.post("/route-setting/delete", json=route_delete_payload)
+
+            assert response.status_code == 200
+            data = response.json()
+            text = data["template"]["outputs"][0]["simpleText"]["text"]
+            assert "시스템 오류" in text


### PR DESCRIPTION
## Summary

- `POST /route-setting`: "설정" / "삭제" ListCard 반환 (block+extra fallback 지원)
- `POST /route-setting/delete`: 경로 필드 NULL 초기화 후 삭제 완료 메시지 반환
- `UserService.delete_user_route()`: route 관련 DB 컬럼 NULL 처리 (favorite-zone의 zone=None 패턴과 동일)
- `settings.py`, `.env.example`: `ROUTE_SETUP_BLOCK_ID`, `ROUTE_DELETE_BLOCK_ID` 추가

## User Flow

```
[🚗 출퇴근 경로 등록하기] 버튼
  │
  ▼
POST /route-setting → ListCard
  ├── "✏️ 설정" → ROUTE_SETUP_BLOCK_ID (기존 출발지/도착지 텍스트 입력 블록)
  │     → POST /save_user_info (기존, 변경 없음) → "✅ 등록 완료"
  │
  └── "🗑️ 삭제" → ROUTE_DELETE_BLOCK_ID
        → POST /route-setting/delete
        → departure_*, arrival_* → NULL
        → "🗑️ 출퇴근 경로가 삭제되었습니다."
```

## Test plan

- [x] `uv run pytest tests/test_route_setting.py -v` → 4 passed
- [x] `uv run pytest --tb=short -q` → 88 passed (전체 회귀 통과)
- [ ] 카카오 관리자센터에서 블록 2개 생성 후 `ROUTE_SETUP_BLOCK_ID`, `ROUTE_DELETE_BLOCK_ID` env 등록

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a route settings UI with “설정” and “삭제” options and endpoints to present it and handle route deletion.
  * Users can delete saved departure/arrival route data; responses indicate success, missing identification, or system errors.

* **Configuration**
  * Added new environment placeholders and settings for route setup and route-delete block IDs.

* **Tests**
  * Added tests covering the route settings UI and deletion flows (success, missing user ID, and system-error cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->