### PR TITLE
fix: 스케줄러 타임존 UTC→KST 수정 (#74)

### DIFF
--- a/app/utils/scheduler_utils.py
+++ b/app/utils/scheduler_utils.py
@@ -22,26 +22,26 @@ def setup_scheduler(crawling_func, route_check_func, bus_crawling_func=None):
     # 설정된 시간에 SMPA 집회 데이터 크롤링 및 동기화
     scheduler.add_job(
         crawling_func,
-        CronTrigger(hour=settings.CRAWLING_HOUR, minute=settings.CRAWLING_MINUTE),
+        CronTrigger(hour=settings.CRAWLING_HOUR, minute=settings.CRAWLING_MINUTE, timezone='Asia/Seoul'),
         id="daily_crawling_sync",
         name="Daily SMPA Crawling & Sync",
         replace_existing=True
     )
-    
+
     # 설정된 시간에 정기 집회 확인 스케줄 추가
     scheduler.add_job(
         route_check_func,
-        CronTrigger(hour=settings.ROUTE_CHECK_HOUR, minute=settings.ROUTE_CHECK_MINUTE),
+        CronTrigger(hour=settings.ROUTE_CHECK_HOUR, minute=settings.ROUTE_CHECK_MINUTE, timezone='Asia/Seoul'),
         id="daily_route_check",
         name="Daily Route Rally Check",
         replace_existing=True
     )
-    
+
     # 버스 통제 공지 재크롤링 (매일 CRAWLING_HOUR:CRAWLING_MINUTE)
     if bus_crawling_func:
         scheduler.add_job(
             bus_crawling_func,
-            CronTrigger(hour=settings.CRAWLING_HOUR, minute=settings.CRAWLING_MINUTE),
+            CronTrigger(hour=settings.CRAWLING_HOUR, minute=settings.CRAWLING_MINUTE, timezone='Asia/Seoul'),
             id="daily_bus_crawling",
             name="Daily Bus Control Crawling",
             replace_existing=True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     env_file:
       - .env
     environment:
+      - TZ=Asia/Seoul
       - DEBUG=false
       - LOG_LEVEL=INFO
       - DATABASE_PATH=/app/data/kt_demo_alarm.db


### PR DESCRIPTION
## Summary

- `docker-compose.yml`에 `TZ=Asia/Seoul` 환경변수 추가
- `scheduler_utils.py`의 모든 `CronTrigger`에 `timezone='Asia/Seoul'` 명시

Closes #74

## 변경 배경

Docker 컨테이너 기본 타임존이 UTC여서 `CRAWLING_HOUR=8`로 설정해도 실제 실행은 **08:30 UTC = 17:30 KST** (오후 5시 반)에 이뤄졌음.
아침에 크롤링이 돌지 않아 수동으로 트리거해야 하는 문제가 발생.

## Test plan

- [ ] 컨테이너 재시작 후 `docker exec <container> date` 로 KST 확인
- [ ] `GET /scheduler/status` 응답의 `next_run` 이 KST 기준 시각인지 확인
- [ ] 로그 타임스탬프가 KST로 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduled job execution timing by ensuring operations run in the correct timezone (Asia/Seoul) consistently across the application and container environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->