### PR TITLE
feat: favorite_zone 기반 알람 독립 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,10 @@ CRAWLING_MINUTE=30
 ROUTE_CHECK_HOUR=7
 ROUTE_CHECK_MINUTE=0
 
+# 관심장소 구역 집회 확인 시간 (24시간제)
+ZONE_CHECK_HOUR=8
+ZONE_CHECK_MINUTE=0
+
 # --- Notification Configuration ---
 # 알림 대량 발송 시 배치 크기
 BATCH_SIZE=100

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -50,6 +50,8 @@ class Settings(BaseSettings):
     CRAWLING_MINUTE: int = 30
     ROUTE_CHECK_HOUR: int = 7
     ROUTE_CHECK_MINUTE: int = 0
+    ZONE_CHECK_HOUR: int = 8
+    ZONE_CHECK_MINUTE: int = 0
     
     # --- Notification Configuration ---
     BATCH_SIZE: int = 100

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -40,6 +40,33 @@ class NotificationService:
         return f"⚠️ 경로상에 {len(events)}개의 집회가 감지되었습니다:\n\n" + "\n\n".join(event_messages)
 
     @staticmethod
+    def _format_zone_message(zone_name: str, events: List[Dict[str, Any]]) -> str:
+        """
+        구역 기반 집회 알림 메시지 포맷팅
+
+        Args:
+            zone_name: 구역 이름 (예: "광화문광장(1구역)")
+            events: 집회 정보 목록
+
+        Returns:
+            str: 포맷팅된 메시지 텍스트
+        """
+        event_messages = []
+        for event in events:
+            severity_level = event.get("severity_level", 1)
+            severity_emoji = "🔴" if severity_level >= 3 else "🟡" if severity_level >= 2 else "🟢"
+            event_messages.append(
+                f"{severity_emoji} {event['title']}\n"
+                f"📍 {event['location']}\n"
+                f"⏰ {event['start_date']}\n"
+                f"🏷️ {event.get('category', '일반')}"
+            )
+        return (
+            f"설정하신 {zone_name}에 집회가 감지되었습니다.\n\n"
+            + "\n\n".join(event_messages)
+        )
+
+    @staticmethod
     async def send_individual_alarm(
         alarm_request: AlarmRequest, 
         id_type: str = "plusfriendUserKey",

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -15,29 +15,30 @@ class NotificationService:
     """알림 전송 비즈니스 로직"""
 
     @staticmethod
+    def _format_event_block(event: Dict[str, Any]) -> str:
+        """단일 집회 정보를 이모지 블록으로 포맷팅"""
+        severity_level = event.get("severity_level", 1)
+        severity_emoji = "🔴" if severity_level >= 3 else "🟡" if severity_level >= 2 else "🟢"
+        return (
+            f"{severity_emoji} {event['title']}\n"
+            f"📍 {event['location']}\n"
+            f"⏰ {event['start_date']}\n"
+            f"🏷️ {event.get('category', '일반')}"
+        )
+
+    @staticmethod
     def _format_event_message(events: List[Dict[str, Any]]) -> str:
         """
         집회 정보를 텍스트 메시지로 포맷팅
-        
+
         Args:
             events: 집회 정보 목록
-            
+
         Returns:
             str: 포맷팅된 메시지 텍스트
         """
-        event_messages = []
-        for event in events:
-            severity_level = event.get("severity_level", 1)
-            severity_emoji = "🔴" if severity_level >= 3 else "🟡" if severity_level >= 2 else "🟢"
-
-            event_messages.append(
-                f"{severity_emoji} {event['title']}\n"
-                f"📍 {event['location']}\n"
-                f"⏰ {event['start_date']}\n"
-                f"🏷️ {event.get('category', '일반')}"
-            )
-
-        return f"⚠️ 경로상에 {len(events)}개의 집회가 감지되었습니다:\n\n" + "\n\n".join(event_messages)
+        blocks = [NotificationService._format_event_block(e) for e in events]
+        return f"⚠️ 경로상에 {len(events)}개의 집회가 감지되었습니다:\n\n" + "\n\n".join(blocks)
 
     @staticmethod
     def _format_zone_message(zone_name: str, events: List[Dict[str, Any]]) -> str:
@@ -51,20 +52,8 @@ class NotificationService:
         Returns:
             str: 포맷팅된 메시지 텍스트
         """
-        event_messages = []
-        for event in events:
-            severity_level = event.get("severity_level", 1)
-            severity_emoji = "🔴" if severity_level >= 3 else "🟡" if severity_level >= 2 else "🟢"
-            event_messages.append(
-                f"{severity_emoji} {event['title']}\n"
-                f"📍 {event['location']}\n"
-                f"⏰ {event['start_date']}\n"
-                f"🏷️ {event.get('category', '일반')}"
-            )
-        return (
-            f"설정하신 {zone_name}에 집회가 감지되었습니다.\n\n"
-            + "\n\n".join(event_messages)
-        )
+        blocks = [NotificationService._format_event_block(e) for e in events]
+        return f"설정하신 {zone_name}에 집회가 감지되었습니다.\n\n" + "\n\n".join(blocks)
 
     @staticmethod
     async def send_individual_alarm(

--- a/app/services/zone_alarm_service.py
+++ b/app/services/zone_alarm_service.py
@@ -113,7 +113,7 @@ class ZoneAlarmService:
             total_success = 0
             total_fail = 0
 
-            for group_key, group_data in grouped.items():
+            for group_data in grouped.values():
                 zone_name = group_data["zone_name"]
                 user_ids = group_data["user_ids"]
                 events_data = group_data["events_data"]

--- a/app/services/zone_alarm_service.py
+++ b/app/services/zone_alarm_service.py
@@ -1,0 +1,158 @@
+"""구역 기반 알람 서비스"""
+import logging
+from typing import Dict, Any
+
+from app.database.connection import get_db_connection
+from app.utils.geo_utils import haversine_distance, FAVORITE_ZONES
+from app.services.notification_service import NotificationService
+from app.services.alarm_status_service import AlarmStatusService
+
+logger = logging.getLogger(__name__)
+
+
+class ZoneAlarmService:
+
+    @staticmethod
+    async def scheduled_zone_check() -> Dict[str, Any]:
+        """
+        구역 기반 정기 집회 확인 및 알람 발송.
+        경로 알람(EventService.scheduled_route_check)과 완전 독립적으로 동작.
+        favorite_zone이 설정된 사용자에게 해당 구역 내 집회 알람을 발송한다.
+        """
+        logger.info("=== 구역 기반 집회 확인 시작 ===")
+
+        task_id = None
+        try:
+            task_id = AlarmStatusService.create_alarm_task(
+                alarm_type="zone_scheduled", total_recipients=0
+            )
+            AlarmStatusService.update_alarm_task_status(task_id, "processing")
+
+            with get_db_connection() as db:
+                cursor = db.cursor()
+
+                # 1. favorite_zone이 설정된 활성 사용자 조회
+                cursor.execute('''
+                    SELECT plusfriend_user_key, favorite_zone
+                    FROM users
+                    WHERE active = 1
+                      AND is_alarm_on = 1
+                      AND favorite_zone IS NOT NULL
+                      AND plusfriend_user_key IS NOT NULL
+                ''')
+                users = cursor.fetchall()
+                logger.info(f"구역 설정된 사용자 {len(users)}명 확인 중...")
+
+                # 2. 활성 집회 전체 조회
+                cursor.execute('''
+                    SELECT id, title, location_name, location_address,
+                           latitude, longitude, start_date, category, severity_level
+                    FROM events
+                    WHERE status = 'active'
+                      AND start_date > datetime('now', '+9 hours')
+                    ORDER BY start_date
+                ''')
+                events = cursor.fetchall()
+
+                if not events:
+                    logger.info("활성 집회 없음 — 구역 알람 발송 생략")
+                    AlarmStatusService.update_alarm_task_status(task_id, "completed", total_recipients=0)
+                    return {"success": True, "task_id": task_id, "total_users": len(users), "notifications_sent": 0}
+
+                # 3. 각 사용자의 구역과 집회 좌표를 haversine_distance로 비교
+                #    (zone_id, frozenset(event_ids)) 기준으로 그룹화
+                grouped: Dict[tuple, Dict] = {}
+
+                for user_row in users:
+                    plusfriend_key = user_row["plusfriend_user_key"]
+                    zone_id = user_row["favorite_zone"]
+
+                    if zone_id not in FAVORITE_ZONES:
+                        continue
+
+                    zone = FAVORITE_ZONES[zone_id]
+                    matched_events = []
+
+                    for event_row in events:
+                        dist = haversine_distance(
+                            zone["lat"], zone["lon"],
+                            event_row["latitude"], event_row["longitude"]
+                        )
+                        if dist <= zone["radius_m"]:
+                            matched_events.append(event_row)
+
+                    if not matched_events:
+                        continue
+
+                    group_key = (zone_id, tuple(sorted(e["id"] for e in matched_events)))
+
+                    if group_key not in grouped:
+                        grouped[group_key] = {
+                            "zone_name": zone["name"],
+                            "user_ids": [],
+                            "events_data": [
+                                {
+                                    "id": e["id"],
+                                    "title": e["title"],
+                                    "location": e["location_name"],
+                                    "latitude": e["latitude"],
+                                    "longitude": e["longitude"],
+                                    "start_date": e["start_date"],
+                                    "category": e["category"],
+                                    "severity_level": e["severity_level"],
+                                }
+                                for e in matched_events
+                            ],
+                        }
+                    grouped[group_key]["user_ids"].append(plusfriend_key)
+
+            # 4. 그룹별 일괄 발송
+            actual_recipients = sum(len(g["user_ids"]) for g in grouped.values())
+            AlarmStatusService.update_alarm_task_status(task_id, "processing", total_recipients=actual_recipients)
+
+            total_success = 0
+            total_fail = 0
+
+            for group_key, group_data in grouped.items():
+                zone_name = group_data["zone_name"]
+                user_ids = group_data["user_ids"]
+                events_data = group_data["events_data"]
+                message_text = NotificationService._format_zone_message(zone_name, events_data)
+
+                logger.info(f"📢 [{zone_name}] {len(user_ids)}명에게 집회 {len(events_data)}건 알림 전송")
+
+                send_result = await NotificationService.send_bulk_alarm(
+                    user_ids=user_ids,
+                    event_name="morning_demo_alarm",
+                    data={"message": message_text},
+                    id_type="plusfriendUserKey",
+                )
+
+                if not send_result.get("success", True):
+                    total_fail += len(user_ids)
+                else:
+                    total_success += send_result.get("total_sent", 0)
+                    total_fail += send_result.get("total_failed", 0)
+
+            final_status = "completed" if total_fail == 0 else "partial"
+            AlarmStatusService.update_alarm_task_status(
+                task_id, final_status,
+                successful_sends=total_success,
+                failed_sends=total_fail,
+            )
+
+            logger.info(
+                f"=== 구역 집회 확인 완료: 대상 {actual_recipients}명, 성공 {total_success}명, 실패 {total_fail}명 ==="
+            )
+            return {
+                "success": True,
+                "task_id": task_id,
+                "total_users": len(users),
+                "notifications_sent": total_success,
+            }
+
+        except Exception as e:
+            logger.error(f"구역 집회 확인 중 오류 발생: {str(e)}")
+            if task_id:
+                AlarmStatusService.update_alarm_task_status(task_id, "failed", error_messages=[str(e)])
+            return {"success": False, "task_id": task_id, "error": str(e)}

--- a/app/services/zone_alarm_service.py
+++ b/app/services/zone_alarm_service.py
@@ -49,6 +49,8 @@ class ZoneAlarmService:
                            latitude, longitude, start_date, category, severity_level
                     FROM events
                     WHERE status = 'active'
+                      AND latitude IS NOT NULL
+                      AND longitude IS NOT NULL
                       AND start_date > datetime('now', '+9 hours')
                     ORDER BY start_date
                 ''')

--- a/app/utils/geo_utils.py
+++ b/app/utils/geo_utils.py
@@ -10,6 +10,13 @@ from app.config.settings import settings
 
 logger = logging.getLogger(__name__)
 
+# 관심장소 구역 정의 (중심 좌표 + 반경)
+FAVORITE_ZONES = {
+    1: {"name": "광화문광장(1구역)", "lat": 37.5720, "lon": 126.9769, "radius_m": 2000},
+    2: {"name": "세검정(2구역)",     "lat": 37.6050, "lon": 126.9680, "radius_m": 1300},
+    3: {"name": "한국방송통신대학교(3구역)", "lat": 37.5790, "lon": 127.0030, "radius_m": 1300},
+}
+
 def haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """
     Haversine 공식을 사용하여 두 지점 간의 거리를 계산 (단위: 미터)

--- a/app/utils/scheduler_utils.py
+++ b/app/utils/scheduler_utils.py
@@ -10,14 +10,15 @@ logger = logging.getLogger(__name__)
 scheduler = AsyncIOScheduler()
 
 
-def setup_scheduler(crawling_func, route_check_func, bus_crawling_func=None):
+def setup_scheduler(crawling_func, route_check_func, bus_crawling_func=None, zone_check_func=None):
     """
     스케줄러 설정 및 작업 등록
-    
+
     Args:
         crawling_func: 크롤링 함수 (SMPA 집회 데이터)
         route_check_func: 경로 확인 함수
         bus_crawling_func: 버스 통제 공지 재크롤링 함수 (선택)
+        zone_check_func: 구역 알람 확인 함수 (선택)
     """
     # 설정된 시간에 SMPA 집회 데이터 크롤링 및 동기화
     scheduler.add_job(
@@ -47,8 +48,19 @@ def setup_scheduler(crawling_func, route_check_func, bus_crawling_func=None):
             replace_existing=True
         )
 
+    # 구역 알람 확인
+    if zone_check_func:
+        scheduler.add_job(
+            zone_check_func,
+            CronTrigger(hour=settings.ZONE_CHECK_HOUR, minute=settings.ZONE_CHECK_MINUTE, timezone='Asia/Seoul'),
+            id="zone_alarm_check",
+            name="Zone Alarm Check",
+            replace_existing=True
+        )
+
     bus_job_info = f", {settings.CRAWLING_HOUR:02d}:{settings.CRAWLING_MINUTE:02d} 버스 통제 공지 갱신" if bus_crawling_func else ""
-    logger.info(f"🚀 스케줄러 작업 등록 완료: 매일 {settings.CRAWLING_HOUR:02d}:{settings.CRAWLING_MINUTE:02d} 크롤링, {settings.ROUTE_CHECK_HOUR:02d}:{settings.ROUTE_CHECK_MINUTE:02d} 경로 확인{bus_job_info}")
+    zone_job_info = f", {settings.ZONE_CHECK_HOUR:02d}:{settings.ZONE_CHECK_MINUTE:02d} 구역 확인" if zone_check_func else ""
+    logger.info(f"🚀 스케줄러 작업 등록 완료: 매일 {settings.CRAWLING_HOUR:02d}:{settings.CRAWLING_MINUTE:02d} 크롤링, {settings.ROUTE_CHECK_HOUR:02d}:{settings.ROUTE_CHECK_MINUTE:02d} 경로 확인{bus_job_info}{zone_job_info}")
 
 
 def start_scheduler():

--- a/main.py
+++ b/main.py
@@ -41,14 +41,21 @@ async def lifespan(app: FastAPI):
     
     # 스케줄러 설정 및 시작
     from app.services.event_service import EventService
+    from app.services.zone_alarm_service import ZoneAlarmService
     setup_scheduler(
         crawling_func=CrawlingService.crawl_and_sync_events,  # 실제 크롤링 서비스 연동
         route_check_func=EventService.scheduled_route_check,
         bus_crawling_func=BusNoticeService.refresh,           # 버스 통제 공지 재크롤링
+        zone_check_func=ZoneAlarmService.scheduled_zone_check,
     )
     start_scheduler()
-    
-    logger.info(f"스케줄러가 시작되었습니다: {settings.CRAWLING_HOUR:02d}:{settings.CRAWLING_MINUTE:02d} 크롤링, {settings.ROUTE_CHECK_HOUR:02d}:{settings.ROUTE_CHECK_MINUTE:02d} 경로체크")
+
+    logger.info(
+        f"스케줄러가 시작되었습니다: "
+        f"{settings.CRAWLING_HOUR:02d}:{settings.CRAWLING_MINUTE:02d} 크롤링, "
+        f"{settings.ROUTE_CHECK_HOUR:02d}:{settings.ROUTE_CHECK_MINUTE:02d} 경로체크, "
+        f"{settings.ZONE_CHECK_HOUR:02d}:{settings.ZONE_CHECK_MINUTE:02d} 구역체크"
+    )
     
     # 버스 알림 서비스: startup에서 초기화하지 않음
     # 집회 크롤링과 동일하게 스케줄러(BusNoticeService.refresh)에 의해서만 동작


### PR DESCRIPTION
Closes #79

## Summary

- `favorite_zone`이 설정된 사용자에게 구역 내 집회 알람을 발송하는 기능을 추가합니다.
- 기존 경로(출발지→도착지) 알람과 완전히 독립적으로 동작하며, 두 조건이 모두 충족되면 각각 발송됩니다.

## Changes

| 파일 | 내용 |
|------|------|
| `app/utils/geo_utils.py` | `FAVORITE_ZONES` 상수 추가 (구역 중심 좌표 + 반경) |
| `app/services/notification_service.py` | `_format_zone_message()` 추가 |
| `app/services/zone_alarm_service.py` | **신규** `ZoneAlarmService.scheduled_zone_check()` |
| `app/config/settings.py` | `ZONE_CHECK_HOUR`, `ZONE_CHECK_MINUTE` 설정 추가 |
| `app/utils/scheduler_utils.py` | `zone_check_func` 파라미터 + zone job 등록 |
| `main.py` | `ZoneAlarmService` 스케줄러 등록 |

## 구역 정의

| 구역 | 이름 | 반경 |
|------|------|------|
| 1 | 광화문광장 | 2000m |
| 2 | 세검정 | 1300m |
| 3 | 한국방송통신대학교 | 1300m |

## 알람 메시지 예시

```
설정하신 광화문광장(1구역)에 집회가 감지되었습니다.

🔴 촛불집회
📍 광화문광장
⏰ 2026-04-15 14:00
🏷️ 정치
```

## 스케줄 설정

`.env`에 아래 값을 추가해 발송 시간을 조정할 수 있습니다 (기본: 매일 08:00):

```
ZONE_CHECK_HOUR=8
ZONE_CHECK_MINUTE=0
```

## Test plan

- [ ] `favorite_zone=1` 사용자가 1구역 내 활성 집회에 알람 수신 확인
- [ ] `favorite_zone IS NULL` 사용자에게 구역 알람 미발송 확인
- [ ] 경로+구역 모두 있는 사용자에게 알람 2개 독립 발송 확인
- [ ] `ZONE_CHECK_HOUR/MINUTE` 변경 후 재시작 시 새 시간 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Zone-based event notifications: Users can now receive alerts when events occur within their designated favorite geographic zones.
  * Automatic daily monitoring: The system checks for events in user zones at a scheduled time with configurable check timing.
  * Zone alert formatting: Zone-specific notifications include detailed event information grouped by location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->