### PR TITLE
feat: today-protests 종로 이벤트만 필터링

### DIFF
--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -465,7 +465,9 @@ class EventService:
                        latitude, longitude, start_date, end_date, category,
                        severity_level, status, created_at, updated_at
                 FROM events
-                WHERE status = 'active' AND date(start_date) = ?
+                WHERE status = 'active'
+                  AND date(start_date) = ?
+                  AND (location_name LIKE '%종로%' OR location_address LIKE '%종로%')
                 ORDER BY start_date ASC
             ''', (today_kst_str,))
             

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -460,6 +460,7 @@ class EventService:
             # KST 오늘 날짜 문자열 (YYYY-MM-DD)
             today_kst_str = datetime.now(ZoneInfo("Asia/Seoul")).date().isoformat()
             
+            jongno_pattern = '%종로%'
             cursor.execute('''
                 SELECT id, title, description, location_name, location_address,
                        latitude, longitude, start_date, end_date, category,
@@ -467,9 +468,9 @@ class EventService:
                 FROM events
                 WHERE status = 'active'
                   AND date(start_date) = ?
-                  AND (location_name LIKE '%종로%' OR location_address LIKE '%종로%')
+                  AND (location_name LIKE ? OR location_address LIKE ?)
                 ORDER BY start_date ASC
-            ''', (today_kst_str,))
+            ''', (today_kst_str, jongno_pattern, jongno_pattern))
             
             events = []
             for row in cursor.fetchall():


### PR DESCRIPTION
## Summary

- `get_today_events()` SQL 쿼리에 종로 필터 조건 추가
- `location_name` 또는 `location_address`에 '종로'가 포함된 이벤트만 반환
- 두 라우터(`events.py`, `kakao_skills.py`) 모두 서비스 레이어를 공유하므로 자동 반영

## Changes

`app/services/event_service.py` — `get_today_events()` 쿼리 수정:

```sql
WHERE status = 'active'
  AND date(start_date) = ?
  AND (location_name LIKE '%종로%' OR location_address LIKE '%종로%')
```

## Test plan

- [ ] 오늘 날짜에 종로 이벤트와 비-종로 이벤트가 각각 존재할 때 `/today-protests` 호출 → 종로 이벤트만 반환 확인
- [ ] 종로 이벤트가 없을 때 → `"오늘 예정된 집회가 없습니다."` 메시지 확인
- [ ] `events.py` 와 `kakao_skills.py` 양쪽 엔드포인트 동일하게 동작 확인

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event filtering now includes location-based criteria, limiting displayed results to a specific geographic area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->