### PR TITLE
chore: 환경 변수 정리 및 배포 설정 일체화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,19 +5,23 @@
 
 # --- Kakao ---
 KAKAO_REST_API_KEY=your_kakao_rest_api_key_here
-TMAP_APP_KEY=your_tmap_app_key_here
 BOT_ID=your_bot_id_here
+
+# --- Block IDs for Kakao Chatbot ---
 ALARM_SAVE_BLOCK_ID=your_alarm_save_block_id_here
 FAVORITE_ZONE_SAVE_BLOCK_ID=your_favorite_zone_save_block_id_here
 ROUTE_SETUP_BLOCK_ID=your_route_setup_block_id_here
 ROUTE_DELETE_BLOCK_ID=your_route_delete_block_id_here
 
-# --- AI ---
-GEMINI_API_KEY=your_gemini_api_key_here
-WORKS_AI_API_KEY=your_works_ai_api_key_here
+# --- TMAP ---
+TMAP_APP_KEY=your_tmap_app_key_here
 
 # --- Bus API ---
 SEOUL_BUS_API_KEY=your_seoul_bus_api_key_here
+
+# --- AI ---
+GEMINI_API_KEY=your_gemini_api_key_here
+WORKS_AI_API_KEY=your_works_ai_api_key_here
 
 # --- Security ---
 API_KEY=your_secure_random_api_key_here

--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ API_KEY=your_secure_random_api_key_here
 ADMIN_USER=admin
 ADMIN_PASS=your_secure_admin_password
 
-# --- 로컬 개발 전용 (운영 환경은 docker-compose.yml에서 관리) ---
+# --- 로컬 개발 예시값 (운영 환경에서는 별도 배포 설정 또는 settings.py 기본값을 따름) ---
 DEBUG=true
 RENDER_EXTERNAL_URL=http://localhost:8000
 PUBLIC_DOMAIN=your_public_domain_here

--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,9 @@ TMAP_APP_KEY=your_tmap_app_key_here
 # 카카오톡 채널 봇 ID (알림 발송용)
 BOT_ID=your_bot_id_here
 
-# 카카오 봇 API URL (기본값 사용 권장)
-KAKAO_BOT_API_URL=https://bot-api.kakao.com/v1/bots/message/send
+# 카카오 봇 API URL (기본값 사용 권장 — 생략 가능)
+# settings.py 기본값: https://bot-api.kakao.com/v2/bots/{bot_id}/talk
+# KAKAO_BOT_API_URL=https://bot-api.kakao.com/v2/bots/{bot_id}/talk
 
 # --- Security Configuration ---
 # 내부 API 보안 키 (필수) - 무작위 문자열 생성 권장
@@ -24,18 +25,21 @@ ADMIN_USER=admin
 ADMIN_PASS=your_secure_admin_password
 
 # --- Server Configuration ---
-# 서버 포트 (Docker Compose 및 실행 시 참조)
-PORT=8000
-
-# 디버그 모드 (true/false) - 운영 환경에서는 false 권장
+# 디버그 모드 (true/false) - 운영 환경에서는 false 권장 (settings.py 기본값: false)
 DEBUG=true
 
-# 로깅 레벨 (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-LOG_LEVEL=INFO
+# 외부 공개 URL - 로컬 개발 시 localhost, 운영 시 실제 도메인 입력
+RENDER_EXTERNAL_URL=http://localhost:8000
+
+# 서버 포트 (settings.py 기본값: 8000 — 변경 시에만 설정)
+# PORT=8000
+
+# 로깅 레벨 (settings.py 기본값: INFO — 변경 시에만 설정)
+# LOG_LEVEL=INFO
 
 # --- Database Configuration ---
-# SQLite 데이터베이스 파일 경로
-DATABASE_PATH=kt_demo_alarm.db
+# SQLite 데이터베이스 파일 경로 (settings.py 기본값: kt_demo_alarm.db — 변경 시에만 설정)
+# DATABASE_PATH=kt_demo_alarm.db
 
 # --- Gemini AI Configuration (Fallback용) ---
 # Gemini API 설정 (버스 통제 알림의 보조 엔진으로 사용)
@@ -52,34 +56,28 @@ SEOUL_BUS_API_KEY=your_seoul_bus_api_key_here
 
 # ※ CACHE_FILE 및 ATTACHMENT_FOLDER 경로는 settings.py에서 관리됩니다.
 
-# --- Server Configuration ---
-EC2_HOST=your_ec2_host_ip_here
-EC2_USERNAME=your_ec2_username_here
-
 # --- Scheduling Configuration ---
-# 집회 정보 크롤링 시간 (24시간제)
-CRAWLING_HOUR=8
-CRAWLING_MINUTE=30
+# 아래 값들은 settings.py 기본값과 동일합니다. 변경이 필요한 경우에만 설정하세요.
+# 집회 정보 크롤링 시간 (24시간제, 기본값: 8시 30분)
+# CRAWLING_HOUR=8
+# CRAWLING_MINUTE=30
 
-# 사용자 경로 집회 확인 시간 (24시간제)
-ROUTE_CHECK_HOUR=7
-ROUTE_CHECK_MINUTE=0
+# 사용자 경로 집회 확인 시간 (24시간제, 기본값: 7시 0분)
+# ROUTE_CHECK_HOUR=7
+# ROUTE_CHECK_MINUTE=0
 
-# 관심장소 구역 집회 확인 시간 (24시간제)
-ZONE_CHECK_HOUR=8
-ZONE_CHECK_MINUTE=0
+# 관심장소 구역 집회 확인 시간 (24시간제, 기본값: 8시 0분)
+# ZONE_CHECK_HOUR=8
+# ZONE_CHECK_MINUTE=0
 
 # --- Notification Configuration ---
-# 알림 대량 발송 시 배치 크기
-BATCH_SIZE=100
-
-# 알림 전송 타임아웃 (초)
-NOTIFICATION_TIMEOUT=10.0
+# 아래 값들은 settings.py 기본값과 동일합니다. 변경이 필요한 경우에만 설정하세요.
+# BATCH_SIZE=100
+# NOTIFICATION_TIMEOUT=10.0
 
 # --- Geo/Route Configuration ---
-# 경로상 집회 감지 거리 임계값 (미터)
-# 이 거리 이내에 집회가 있으면 알림 대상이 됨
-ROUTE_THRESHOLD_METERS=500
+# 경로상 집회 감지 거리 임계값 (미터, 기본값: 500)
+# ROUTE_THRESHOLD_METERS=500
 
 # --- Public Domain Configuration ---
 PUBLIC_DOMAIN=your_public_domain_here

--- a/.env.example
+++ b/.env.example
@@ -1,95 +1,30 @@
 # -----------------------------------------------------------------------------
-# KT Demo Alarm - Environment Variables Configuration
+# KT Demo Alarm - Environment Variables
+# 비밀값과 로컬 개발 전용 값만 포함합니다. 나머지 설정은 settings.py 참조.
 # -----------------------------------------------------------------------------
 
-# --- Kakao API Configuration ---
-# 카카오 디벨로퍼스 REST API 키 (지도/로컬 API 사용)
+# --- Kakao ---
 KAKAO_REST_API_KEY=your_kakao_rest_api_key_here
-
-# TMAP API 키
 TMAP_APP_KEY=your_tmap_app_key_here
-
-# 카카오톡 채널 봇 ID (알림 발송용)
 BOT_ID=your_bot_id_here
+ALARM_SAVE_BLOCK_ID=your_alarm_save_block_id_here
+FAVORITE_ZONE_SAVE_BLOCK_ID=your_favorite_zone_save_block_id_here
+ROUTE_SETUP_BLOCK_ID=your_route_setup_block_id_here
+ROUTE_DELETE_BLOCK_ID=your_route_delete_block_id_here
 
-# 카카오 봇 API URL (기본값 사용 권장 — 생략 가능)
-# settings.py 기본값: https://bot-api.kakao.com/v2/bots/{bot_id}/talk
-# KAKAO_BOT_API_URL=https://bot-api.kakao.com/v2/bots/{bot_id}/talk
+# --- AI ---
+GEMINI_API_KEY=your_gemini_api_key_here
+WORKS_AI_API_KEY=your_works_ai_api_key_here
 
-# --- Security Configuration ---
-# 내부 API 보안 키 (필수) - 무작위 문자열 생성 권장
+# --- Bus API ---
+SEOUL_BUS_API_KEY=your_seoul_bus_api_key_here
+
+# --- Security ---
 API_KEY=your_secure_random_api_key_here
-
-# 어드민 대시보드 로그인 정보 (필수)
 ADMIN_USER=admin
 ADMIN_PASS=your_secure_admin_password
 
-# --- Server Configuration ---
-# 디버그 모드 (true/false) - 운영 환경에서는 false 권장 (settings.py 기본값: false)
+# --- 로컬 개발 전용 (운영 환경은 docker-compose.yml에서 관리) ---
 DEBUG=true
-
-# 외부 공개 URL - 로컬 개발 시 localhost, 운영 시 실제 도메인 입력
 RENDER_EXTERNAL_URL=http://localhost:8000
-
-# 서버 포트 (settings.py 기본값: 8000 — 변경 시에만 설정)
-# PORT=8000
-
-# 로깅 레벨 (settings.py 기본값: INFO — 변경 시에만 설정)
-# LOG_LEVEL=INFO
-
-# --- Database Configuration ---
-# SQLite 데이터베이스 파일 경로 (settings.py 기본값: kt_demo_alarm.db — 변경 시에만 설정)
-# DATABASE_PATH=kt_demo_alarm.db
-
-# --- Gemini AI Configuration (Fallback용) ---
-# Gemini API 설정 (버스 통제 알림의 보조 엔진으로 사용)
-GEMINI_API_KEY=your_gemini_api_key_here
-
-# --- Works AI (BizRouter) Configuration (주 분석 엔진) ---
-# Works AI(BizRouter) API 키 (필수)
-WORKS_AI_API_KEY=your_works_ai_api_key_here
-# ※ WORKS_AI_BASE_URL 및 MODEL은 settings.py의 기본값을 사용하므로 설정하지 않아도 됩니다.
-
-# --- Seoul Bus API Configuration ---
-# 서울특별시 정류소정보조회 서비스 API 키 (https://www.data.go.kr/data/15000303/openapi.do)
-SEOUL_BUS_API_KEY=your_seoul_bus_api_key_here
-
-# ※ CACHE_FILE 및 ATTACHMENT_FOLDER 경로는 settings.py에서 관리됩니다.
-
-# --- Scheduling Configuration ---
-# 아래 값들은 settings.py 기본값과 동일합니다. 변경이 필요한 경우에만 설정하세요.
-# 집회 정보 크롤링 시간 (24시간제, 기본값: 8시 30분)
-# CRAWLING_HOUR=8
-# CRAWLING_MINUTE=30
-
-# 사용자 경로 집회 확인 시간 (24시간제, 기본값: 7시 0분)
-# ROUTE_CHECK_HOUR=7
-# ROUTE_CHECK_MINUTE=0
-
-# 관심장소 구역 집회 확인 시간 (24시간제, 기본값: 8시 0분)
-# ZONE_CHECK_HOUR=8
-# ZONE_CHECK_MINUTE=0
-
-# --- Notification Configuration ---
-# 아래 값들은 settings.py 기본값과 동일합니다. 변경이 필요한 경우에만 설정하세요.
-# BATCH_SIZE=100
-# NOTIFICATION_TIMEOUT=10.0
-
-# --- Geo/Route Configuration ---
-# 경로상 집회 감지 거리 임계값 (미터, 기본값: 500)
-# ROUTE_THRESHOLD_METERS=500
-
-# --- Public Domain Configuration ---
 PUBLIC_DOMAIN=your_public_domain_here
-
-# --- Kakao Chatbot setting ---
-# 알람 On/Off ListCard 저장 스킬 블록 ID
-ALARM_SAVE_BLOCK_ID=your_alarm_save_block_id_here
-
-# 관심장소 ListCard 저장 스킬 블록 ID
-FAVORITE_ZONE_SAVE_BLOCK_ID=your_favorite_zone_save_block_id_here
-
-# 이동경로 "설정" 버튼에서 호출할 기존 출발지 입력 블록 ID
-ROUTE_SETUP_BLOCK_ID=your_route_setup_block_id_here
-# 이동경로 "삭제" 버튼에서 호출할 /route-setting/delete 스킬 블록 ID
-ROUTE_DELETE_BLOCK_ID=your_route_delete_block_id_here

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,6 +115,7 @@ jobs:
           chmod 600 ec2-key.pem
 
           # Create .env on runner (printf prevents shell injection from special chars in secret values)
+          # 주의: DEBUG, DATABASE_PATH, 스케줄 값은 docker-compose.yml environment에서 관리
           printf '%s\n' \
             "KAKAO_REST_API_KEY=${KAKAO_REST_API_KEY}" \
             "BOT_ID=${BOT_ID}" \
@@ -126,13 +127,7 @@ jobs:
             "FAVORITE_ZONE_SAVE_BLOCK_ID=${FAVORITE_ZONE_SAVE_BLOCK_ID}" \
             "ROUTE_SETUP_BLOCK_ID=${ROUTE_SETUP_BLOCK_ID}" \
             "ROUTE_DELETE_BLOCK_ID=${ROUTE_DELETE_BLOCK_ID}" \
-            "DEBUG=false" \
-            "LOG_LEVEL=INFO" \
-            "DATABASE_PATH=/app/data/kt_demo_alarm.db" \
-            "CRAWLING_HOUR=7" \
-            "CRAWLING_MINUTE=00" \
-            "ROUTE_CHECK_HOUR=8" \
-            "ROUTE_CHECK_MINUTE=00" \
+            "RENDER_EXTERNAL_URL=https://${PUBLIC_DOMAIN}" \
             "ADMIN_USER=${ADMIN_USER}" \
             "ADMIN_PASS=${ADMIN_PASS}" \
             > .env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,6 +115,12 @@ jobs:
           echo "$EC2_SSH_KEY" > ec2-key.pem
           chmod 600 ec2-key.pem
 
+          # PUBLIC_DOMAIN 설정 확인
+          if [[ -z "${PUBLIC_DOMAIN}" ]]; then
+            echo "❌ PUBLIC_DOMAIN secret이 설정되지 않았습니다."
+            exit 1
+          fi
+
           # Create .env on runner (printf prevents shell injection from special chars in secret values)
           # 주의: 이 워크플로는 민감한 앱 설정만 .env로 전달하며, DATABASE_PATH 등 일부 기본/인프라 설정은 별도 설정(예: docker-compose.yml 또는 애플리케이션 기본값)에서 관리합니다.
           printf '%s\n' \
@@ -142,12 +148,6 @@ jobs:
           scp -o StrictHostKeyChecking=no -i ec2-key.pem \
             docker-compose.yml .env \
             ${EC2_USERNAME}@${EC2_HOST}:/opt/kt-demo-alarm/
-
-          # PUBLIC_DOMAIN 설정 확인
-          if [[ -z "${PUBLIC_DOMAIN}" ]]; then
-            echo "❌ PUBLIC_DOMAIN secret이 설정되지 않았습니다."
-            exit 1
-          fi
 
           # DOMAIN_PLACEHOLDER를 실제 도메인으로 치환한 뒤 EC2로 전송
           # /tmp 대신 예측 불가능한 임시 파일 사용

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,7 +116,7 @@ jobs:
           chmod 600 ec2-key.pem
 
           # Create .env on runner (printf prevents shell injection from special chars in secret values)
-          # 주의: DEBUG, DATABASE_PATH, 스케줄 값은 docker-compose.yml environment에서 관리
+          # 주의: 이 워크플로는 민감한 앱 설정만 .env로 전달하며, DATABASE_PATH 등 일부 기본/인프라 설정은 별도 설정(예: docker-compose.yml 또는 애플리케이션 기본값)에서 관리합니다.
           printf '%s\n' \
             "KAKAO_REST_API_KEY=${KAKAO_REST_API_KEY}" \
             "BOT_ID=${BOT_ID}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,7 @@ jobs:
           FAVORITE_ZONE_SAVE_BLOCK_ID: ${{ secrets.FAVORITE_ZONE_SAVE_BLOCK_ID }}
           ROUTE_SETUP_BLOCK_ID: ${{ secrets.ROUTE_SETUP_BLOCK_ID }}
           ROUTE_DELETE_BLOCK_ID: ${{ secrets.ROUTE_DELETE_BLOCK_ID }}
+          WORKS_AI_API_KEY: ${{ secrets.WORKS_AI_API_KEY }}
         run: |
           set -euo pipefail
 
@@ -128,6 +129,7 @@ jobs:
             "ROUTE_SETUP_BLOCK_ID=${ROUTE_SETUP_BLOCK_ID}" \
             "ROUTE_DELETE_BLOCK_ID=${ROUTE_DELETE_BLOCK_ID}" \
             "RENDER_EXTERNAL_URL=https://${PUBLIC_DOMAIN}" \
+            "WORKS_AI_API_KEY=${WORKS_AI_API_KEY}" \
             "ADMIN_USER=${ADMIN_USER}" \
             "ADMIN_PASS=${ADMIN_PASS}" \
             > .env

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -9,6 +9,8 @@ class Settings(BaseSettings):
     # --- Kakao API ---
     KAKAO_REST_API_KEY: str = ""
     BOT_ID: str = ""
+
+    # --- Block IDs for Kakao Chatbot ---
     ALARM_SAVE_BLOCK_ID: Optional[str] = None
     FAVORITE_ZONE_SAVE_BLOCK_ID: Optional[str] = None
     ROUTE_SETUP_BLOCK_ID: Optional[str] = None

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -5,67 +5,60 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     """애플리케이션 설정 클래스"""
-    
-    # --- Kakao API Configuration ---
+
+    # --- Kakao API ---
     KAKAO_REST_API_KEY: str = ""
     BOT_ID: str = ""
-    # 알람 On/Off ListCard에서 사용할 저장 스킬 블록 ID (카카오 챗봇 관리자센터에서 확인)
     ALARM_SAVE_BLOCK_ID: Optional[str] = None
-    # 관심장소 ListCard에서 사용할 저장 스킬 블록 ID (카카오 챗봇 관리자센터에서 확인)
     FAVORITE_ZONE_SAVE_BLOCK_ID: Optional[str] = None
-    # 이동경로 2단계 UI 블록 ID (카카오 챗봇 관리자센터에서 확인)
-    ROUTE_SETUP_BLOCK_ID: Optional[str] = None   # "설정" 버튼 → 기존 출발지 입력 블록
-    ROUTE_DELETE_BLOCK_ID: Optional[str] = None  # "삭제" 버튼 → /route-setting/delete 블록
+    ROUTE_SETUP_BLOCK_ID: Optional[str] = None
+    ROUTE_DELETE_BLOCK_ID: Optional[str] = None
 
-    # --- TMAP API Configuration ---
+    # --- TMAP API ---
     TMAP_APP_KEY: str = ""
 
-    # Gemini API 설정 (버스 통제 알림용)
+    # --- AI ---
     GEMINI_API_KEY: str = ""
-
-    # Works AI (BizRouter) 설정
     WORKS_AI_API_KEY: Optional[str] = None
     WORKS_AI_BASE_URL: str = "https://api.bizrouter.ai/v1"
     WORKS_AI_MODEL: str = "google/gemini-3.1-pro-preview"
 
-    # 파일 및 경로 설정 (비민감 정보)
-    CACHE_FILE: str = "topis_cache/topis_cache.json"
-    ATTACHMENT_FOLDER: str = "topis_attachments"
-
-    # --- Bus API Configuration ---
+    # --- Bus API ---
     SEOUL_BUS_API_KEY: str = ""
     RENDER_EXTERNAL_URL: str = "http://localhost:8000"
-    
-    # --- Security Configuration ---
+
+    # --- Security ---
     API_KEY: str = ""
-    
-    # 어드민 대시보드 로그인 정보
     ADMIN_USER: Optional[str] = None
     ADMIN_PASS: Optional[str] = None
-    
-    # --- Server Configuration ---
+
+    # --- Server ---
     APP_NAME: str = "KT Demo Alarm API"
     APP_VERSION: str = "1.0.0"
     PORT: int = 8000
     DEBUG: bool = False
     LOG_LEVEL: str = "INFO"
-    
-    # --- Database Configuration ---
+
+    # --- Database ---
     DATABASE_PATH: str = "kt_demo_alarm.db"
-    
-    # --- Scheduling Configuration ---
+
+    # --- File Paths ---
+    CACHE_FILE: str = "topis_cache/topis_cache.json"
+    ATTACHMENT_FOLDER: str = "topis_attachments"
+
+    # --- Scheduling ---
     CRAWLING_HOUR: int = 7
     CRAWLING_MINUTE: int = 0
     ROUTE_CHECK_HOUR: int = 8
     ROUTE_CHECK_MINUTE: int = 0
     ZONE_CHECK_HOUR: int = 8
     ZONE_CHECK_MINUTE: int = 0
-    
-    # --- Notification Configuration ---
+
+    # --- Notification ---
     BATCH_SIZE: int = 100
     NOTIFICATION_TIMEOUT: float = 10.0
-    
-    # --- Geo/Route Configuration ---
+
+    # --- Geo/Route ---
     ROUTE_THRESHOLD_METERS: int = 500
 
     model_config = SettingsConfigDict(

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -55,9 +55,9 @@ class Settings(BaseSettings):
     DATABASE_PATH: str = "kt_demo_alarm.db"
     
     # --- Scheduling Configuration ---
-    CRAWLING_HOUR: int = 8
-    CRAWLING_MINUTE: int = 30
-    ROUTE_CHECK_HOUR: int = 7
+    CRAWLING_HOUR: int = 7
+    CRAWLING_MINUTE: int = 0
+    ROUTE_CHECK_HOUR: int = 8
     ROUTE_CHECK_MINUTE: int = 0
     ZONE_CHECK_HOUR: int = 8
     ZONE_CHECK_MINUTE: int = 0

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -9,7 +9,6 @@ class Settings(BaseSettings):
     # --- Kakao API Configuration ---
     KAKAO_REST_API_KEY: str = ""
     BOT_ID: str = ""
-    KAKAO_BOT_API_URL: str = "https://bot-api.kakao.com/v2/bots/{bot_id}/talk"
     # 알람 On/Off ListCard에서 사용할 저장 스킬 블록 ID (카카오 챗봇 관리자센터에서 확인)
     ALARM_SAVE_BLOCK_ID: Optional[str] = None
     # 관심장소 ListCard에서 사용할 저장 스킬 블록 ID (카카오 챗봇 관리자센터에서 확인)

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -88,7 +88,7 @@ class NotificationService:
                 params=None
             )
 
-            url = settings.KAKAO_BOT_API_URL.format(bot_id=settings.BOT_ID)
+            url = f"https://bot-api.kakao.com/v2/bots/{settings.BOT_ID}/talk"
             headers = {
                 "Content-Type": "application/json",
                 "Authorization": f"KakaoAK {settings.KAKAO_REST_API_KEY}",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,15 +8,7 @@ services:
       - .env
     environment:
       - TZ=Asia/Seoul
-      - DEBUG=false
       - DATABASE_PATH=/app/data/kt_demo_alarm.db
-      # production 스케줄 (settings.py 기본값과 다른 운영 시간)
-      - CRAWLING_HOUR=7
-      - CRAWLING_MINUTE=00
-      - ROUTE_CHECK_HOUR=8
-      - ROUTE_CHECK_MINUTE=00
-      - ZONE_CHECK_HOUR=8
-      - ZONE_CHECK_MINUTE=0
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,14 @@ services:
     environment:
       - TZ=Asia/Seoul
       - DEBUG=false
-      - LOG_LEVEL=INFO
       - DATABASE_PATH=/app/data/kt_demo_alarm.db
+      # production 스케줄 (settings.py 기본값과 다른 운영 시간)
+      - CRAWLING_HOUR=7
+      - CRAWLING_MINUTE=00
+      - ROUTE_CHECK_HOUR=8
+      - ROUTE_CHECK_MINUTE=00
+      - ZONE_CHECK_HOUR=8
+      - ZONE_CHECK_MINUTE=0
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs


### PR DESCRIPTION
## Summary

Closes #83

- **버그 수정**: `.env`의 `TMAP_API_KEY` → `TMAP_APP_KEY` (로컬에서 TMAP 기능 미동작 원인)
- **`KAKAO_BOT_API_URL` 제거**: 고정 API endpoint를 settings 변수로 관리할 이유 없음. `notification_service.py`에서 f-string으로 직접 조합
- **`settings.py` 정리**: 주석 스타일 `# --- Section ---` 통일, 스케줄 기본값을 production 값으로 업데이트
- **`.env.example` 정리**: 비밀값과 로컬 개발 전용 값만 유지. `settings.py`에 기본값이 있는 변수 제거
- **`docker-compose.yml`**: Docker 인프라 전용(`TZ`, `DATABASE_PATH`)만 유지. `DEBUG`, 스케줄 등 앱 설정 제거
- **`deploy.yml`**: `WORKS_AI_API_KEY` 추가. docker-compose가 관리하던 중복 값 제거, `RENDER_EXTERNAL_URL=https://${PUBLIC_DOMAIN}` 추가

## 환경별 책임 분리 (변경 후)

| 설정 | `settings.py` | 로컬 `.env` | `docker-compose.yml` | `deploy.yml` generated .env |
|------|:-------------:|:-----------:|:--------------------:|:---------------------------:|
| API Keys/비밀값 | 빈 문자열 기본값 | ✓ 실제값 | - | ✓ GitHub Secrets |
| DEBUG | `False` (기본값) | `true` (로컬 오버라이드) | - | - |
| DATABASE_PATH | `kt_demo_alarm.db` | - | `/app/data/...` (Docker 볼륨) | - |
| 스케줄 | ✓ 기본값으로 관리 | - | - | - |
| RENDER_EXTERNAL_URL | `http://localhost:8000` | `http://localhost:8000` | - | `https://${PUBLIC_DOMAIN}` |

## Test plan

- [ ] `uv run python -m pytest tests/ -v` — 기존 88개 테스트 통과
- [ ] `docker compose config` — docker-compose.yml 문법 검증
- [ ] 로컬에서 `.env`에 `TMAP_APP_KEY` 설정 후 TMAP 경로 조회 정상 동작 확인
- [ ] 배포 후 `RENDER_EXTERNAL_URL`이 실제 도메인으로 주입되는지 확인
- [ ] GitHub Actions Secrets에 `WORKS_AI_API_KEY` 등록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)