### PR TITLE
Fix Kakao sync collisions and admin dashboard schema compatibility

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -242,7 +242,7 @@ async def dashboard(
         )
     except Exception as e:
         logger.exception("Admin dashboard rendering failed")
-        raise HTTPException(status_code=500, detail=f"Admin dashboard failed: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Admin dashboard failed") from e
 
 def _task_done_callback(task_key: str):
     def callback(task: asyncio.Task):

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -129,17 +129,50 @@ def get_total_users() -> int:
         result = cursor.fetchone()
         return result[0] if result else 0
 
+def _get_table_columns(cursor, table_name: str) -> Set[str]:
+    cursor.execute(f"PRAGMA table_info({table_name})")
+    columns = set()
+    for row in cursor.fetchall():
+        if isinstance(row, dict):
+            columns.add(row["name"])
+        else:
+            columns.add(row[1])
+    return columns
+
 def fetch_paginated_users(limit: int, offset: int) -> List[Dict[str, Any]]:
     with get_db_connection() as conn:
         conn.row_factory = dict_factory
         cursor = conn.cursor()
-        cursor.execute("""
-            SELECT id, bot_user_key, plusfriend_user_key, open_id, active, is_alarm_on, 
-                   departure_name, arrival_name, marked_bus, 
-                   COALESCE(favorite_zone, 0) as favorite_zone,
-                   first_message_at as created_at, message_count 
-            FROM users 
-            ORDER BY id DESC 
+
+        user_columns = _get_table_columns(cursor, "users")
+        select_fields = [
+            "id",
+            "bot_user_key",
+            "active",
+            "departure_name",
+            "arrival_name",
+            "marked_bus",
+            "first_message_at as created_at",
+            "message_count",
+        ]
+
+        optional_fields = {
+            "plusfriend_user_key": "plusfriend_user_key",
+            "open_id": "open_id",
+            "is_alarm_on": "is_alarm_on",
+            "favorite_zone": "COALESCE(favorite_zone, 0) as favorite_zone",
+        }
+
+        for column_name, sql in optional_fields.items():
+            if column_name in user_columns:
+                select_fields.append(sql)
+            else:
+                select_fields.append(f"NULL as {column_name}" if column_name != "favorite_zone" else "0 as favorite_zone")
+
+        cursor.execute(f"""
+            SELECT {', '.join(select_fields)}
+            FROM users
+            ORDER BY id DESC
             LIMIT ? OFFSET ?
         """, (limit, offset))
         return cursor.fetchall()
@@ -152,60 +185,64 @@ async def dashboard(
     _username: str = Depends(verify_admin)
 ):
     """Render the back-office dashboard"""
-    
-    offset = (page - 1) * page_size
-    
-    # Run database queries in parallel
-    events, alarms, users, total_users = await asyncio.gather(
-        asyncio.to_thread(fetch_recent_events),
-        asyncio.to_thread(fetch_recent_alarms),
-        asyncio.to_thread(fetch_paginated_users, page_size, offset),
-        asyncio.to_thread(get_total_users)
-    )
-    
-    total_pages = math.ceil(total_users / page_size) if total_users > 0 else 1
-    
-    # Get Scheduler Status
-    scheduler_status = get_scheduler_status()
-    
-    # Calculate some summary statistics
-    total_events = len(events)
-    total_alarms = len(alarms)
-    total_alarms_sent = sum(a.get("total_recipients", 0) for a in alarms)
-    successful_sends = sum(a.get("successful_sends", 0) for a in alarms)
-    failed_sends = sum(a.get("failed_sends", 0) for a in alarms)
-    
-    success_rate = 0
-    if total_alarms_sent > 0:
-        success_rate = round((successful_sends / total_alarms_sent) * 100, 1)
 
-    return templates.TemplateResponse(
-        "admin_dashboard.html",
-        {
-            "request": request,
-            "events": events,
-            "alarms": alarms,
-            "users": users,
-            "scheduler_status": scheduler_status,
-            "pagination": {
-                "page": page,
-                "page_size": page_size,
-                "total_users": total_users,
-                "total_pages": total_pages,
-                "has_previous": page > 1,
-                "has_next": page < total_pages,
-                "previous_page": page - 1,
-                "next_page": page + 1
-            },
-            "stats": {
-                "total_events": total_events,
-                "total_alarms": total_alarms,
-                "total_alarms_sent": total_alarms_sent,
-                "success_rate": success_rate,
-                "failed_sends": failed_sends
+    try:
+        offset = (page - 1) * page_size
+
+        # Run database queries in parallel
+        events, alarms, users, total_users = await asyncio.gather(
+            asyncio.to_thread(fetch_recent_events),
+            asyncio.to_thread(fetch_recent_alarms),
+            asyncio.to_thread(fetch_paginated_users, page_size, offset),
+            asyncio.to_thread(get_total_users)
+        )
+
+        total_pages = math.ceil(total_users / page_size) if total_users > 0 else 1
+
+        # Get Scheduler Status
+        scheduler_status = get_scheduler_status()
+
+        # Calculate some summary statistics
+        total_events = len(events)
+        total_alarms = len(alarms)
+        total_alarms_sent = sum(a.get("total_recipients", 0) for a in alarms)
+        successful_sends = sum(a.get("successful_sends", 0) for a in alarms)
+        failed_sends = sum(a.get("failed_sends", 0) for a in alarms)
+
+        success_rate = 0
+        if total_alarms_sent > 0:
+            success_rate = round((successful_sends / total_alarms_sent) * 100, 1)
+
+        return templates.TemplateResponse(
+            "admin_dashboard.html",
+            {
+                "request": request,
+                "events": events,
+                "alarms": alarms,
+                "users": users,
+                "scheduler_status": scheduler_status,
+                "pagination": {
+                    "page": page,
+                    "page_size": page_size,
+                    "total_users": total_users,
+                    "total_pages": total_pages,
+                    "has_previous": page > 1,
+                    "has_next": page < total_pages,
+                    "previous_page": page - 1,
+                    "next_page": page + 1
+                },
+                "stats": {
+                    "total_events": total_events,
+                    "total_alarms": total_alarms,
+                    "total_alarms_sent": total_alarms_sent,
+                    "success_rate": success_rate,
+                    "failed_sends": failed_sends
+                }
             }
-        }
-    )
+        )
+    except Exception as e:
+        logger.exception("Admin dashboard rendering failed")
+        raise HTTPException(status_code=500, detail=f"Admin dashboard failed: {str(e)}") from e
 
 def _task_done_callback(task_key: str):
     def callback(task: asyncio.Task):
@@ -273,4 +310,3 @@ async def trigger_test_alarm_for_user(
         _background_tasks[task_key] = task
         task.add_done_callback(_task_done_callback(task_key))
     return {"message": "Scheduled"}
-

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -66,6 +66,7 @@ class UserService:
         """
         try:
             cursor = db.cursor()
+            now = datetime.now()
             
             if not plusfriend_key:
                 # plusfriend_key가 없는 경우 기존 레거시 로직(bot_user_key 기준) 사용
@@ -75,19 +76,49 @@ class UserService:
 
             # plusfriend_key로 조회 (primary identifier)
             cursor.execute(
-                "SELECT id, open_id FROM users WHERE plusfriend_user_key = ?",
+                "SELECT id, open_id, bot_user_key FROM users WHERE plusfriend_user_key = ?",
                 (plusfriend_key,)
             )
-            existing = cursor.fetchone()
+            existing_plusfriend = cursor.fetchone()
 
-            if existing:
-                # 기존 사용자 업데이트
+            # plusfriend 미연동 레거시 사용자를 bot_user_key로 조회
+            cursor.execute(
+                "SELECT id, plusfriend_user_key, open_id FROM users WHERE bot_user_key = ?",
+                (bot_user_key,)
+            )
+            existing_bot = cursor.fetchone()
+
+            if existing_plusfriend:
+                # plusfriend_key로 이미 연결된 기존 사용자 업데이트
                 logger.debug(f"✅ 기존 사용자 발견: plusfriend={plusfriend_key}")
                 cursor.execute("""
                     UPDATE users
-                    SET bot_user_key = ?, last_message_at = ?, message_count = message_count + 1
+                    SET last_message_at = ?, message_count = message_count + 1, active = 1
                     WHERE plusfriend_user_key = ?
-                """, (bot_user_key, datetime.now(), plusfriend_key))
+                """, (now, plusfriend_key))
+
+                if existing_plusfriend[2] != bot_user_key:
+                    if existing_bot and existing_bot[0] != existing_plusfriend[0]:
+                        logger.warning(
+                            "bot_user_key(%s)와 plusfriend_key(%s)가 서로 다른 사용자 행에 연결되어 있습니다. "
+                            "기존 plusfriend 매핑은 유지하고 활동 시간만 갱신합니다.",
+                            bot_user_key,
+                            plusfriend_key,
+                        )
+                    else:
+                        cursor.execute("""
+                            UPDATE users
+                            SET bot_user_key = ?
+                            WHERE plusfriend_user_key = ?
+                        """, (bot_user_key, plusfriend_key))
+            elif existing_bot:
+                # 기존 bot_user_key 사용자에 plusfriend_key 연결
+                logger.info(f"✅ 기존 bot_user_key 사용자에 plusfriend 연결: {bot_user_key} → {plusfriend_key}")
+                cursor.execute("""
+                    UPDATE users
+                    SET plusfriend_user_key = ?, last_message_at = ?, message_count = message_count + 1, active = 1
+                    WHERE bot_user_key = ?
+                """, (plusfriend_key, now, bot_user_key))
             else:
                 # 웹훅 사용자 찾기 시도 (open_id만 있는 경우)
                 cursor.execute("""
@@ -103,16 +134,16 @@ class UserService:
                     logger.info(f"✅ 웹훅 사용자 연결: open_id={orphan[1]} → plusfriend={plusfriend_key}")
                     cursor.execute("""
                         UPDATE users
-                        SET bot_user_key = ?, plusfriend_user_key = ?, last_message_at = ?
+                        SET bot_user_key = ?, plusfriend_user_key = ?, last_message_at = ?, active = 1
                         WHERE id = ?
-                    """, (bot_user_key, plusfriend_key, datetime.now(), orphan[0]))
+                    """, (bot_user_key, plusfriend_key, now, orphan[0]))
                 else:
                     # 완전 신규 사용자
                     logger.info(f"✅ 신규 사용자 생성: plusfriend={plusfriend_key}")
                     cursor.execute("""
                         INSERT INTO users (bot_user_key, plusfriend_user_key, first_message_at, last_message_at, message_count, active)
                         VALUES (?, ?, ?, ?, 1, 1)
-                    """, (bot_user_key, plusfriend_key, datetime.now(), datetime.now()))
+                    """, (bot_user_key, plusfriend_key, now, now))
             
             db.commit()
             

--- a/tests/test_admin_dashboard_schema_compat.py
+++ b/tests/test_admin_dashboard_schema_compat.py
@@ -1,0 +1,82 @@
+import sqlite3
+import tempfile
+from contextlib import contextmanager
+
+from app.config.settings import settings
+
+
+def test_admin_dashboard_works_with_legacy_user_schema(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "ADMIN_USER", "admin")
+    monkeypatch.setattr(settings, "ADMIN_PASS", "secret123")
+
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    legacy_conn = sqlite3.connect(db_path)
+    cursor = legacy_conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            bot_user_key TEXT UNIQUE NOT NULL,
+            first_message_at DATETIME,
+            last_message_at DATETIME,
+            message_count INTEGER DEFAULT 1,
+            location TEXT,
+            active BOOLEAN DEFAULT TRUE,
+            departure_name TEXT,
+            arrival_name TEXT,
+            marked_bus TEXT
+        )
+        """
+    )
+    cursor.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, first_message_at, last_message_at, message_count, active, departure_name, arrival_name, marked_bus
+        ) VALUES (
+            'legacy-user', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 3, 1, '영통역', '광화문역', '470'
+        )
+        """
+    )
+    cursor.execute(
+        """
+        CREATE TABLE events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            location_name TEXT NOT NULL,
+            severity_level INTEGER DEFAULT 1,
+            start_date DATETIME,
+            created_at DATETIME,
+            status TEXT
+        )
+        """
+    )
+    cursor.execute(
+        """
+        CREATE TABLE alarm_tasks (
+            task_id TEXT PRIMARY KEY,
+            alarm_type TEXT,
+            status TEXT,
+            total_recipients INTEGER,
+            successful_sends INTEGER,
+            failed_sends INTEGER,
+            created_at DATETIME
+        )
+        """
+    )
+    legacy_conn.commit()
+    legacy_conn.close()
+
+    @contextmanager
+    def legacy_db_connection():
+        conn = sqlite3.connect(db_path, check_same_thread=False)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    monkeypatch.setattr("app.routers.admin.get_db_connection", legacy_db_connection)
+
+    response = test_client.get("/admin/dashboard", auth=("admin", "secret123"))
+
+    assert response.status_code == 200
+    assert "legacy-user" in response.text

--- a/tests/test_admin_dashboard_schema_compat.py
+++ b/tests/test_admin_dashboard_schema_compat.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 import tempfile
 from contextlib import contextmanager
@@ -10,73 +11,78 @@ def test_admin_dashboard_works_with_legacy_user_schema(test_client, monkeypatch)
     monkeypatch.setattr(settings, "ADMIN_PASS", "secret123")
 
     fd, db_path = tempfile.mkstemp(suffix=".db")
-    legacy_conn = sqlite3.connect(db_path)
-    cursor = legacy_conn.cursor()
-    cursor.execute(
-        """
-        CREATE TABLE users (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            bot_user_key TEXT UNIQUE NOT NULL,
-            first_message_at DATETIME,
-            last_message_at DATETIME,
-            message_count INTEGER DEFAULT 1,
-            location TEXT,
-            active BOOLEAN DEFAULT TRUE,
-            departure_name TEXT,
-            arrival_name TEXT,
-            marked_bus TEXT
-        )
-        """
-    )
-    cursor.execute(
-        """
-        INSERT INTO users (
-            bot_user_key, first_message_at, last_message_at, message_count, active, departure_name, arrival_name, marked_bus
-        ) VALUES (
-            'legacy-user', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 3, 1, '영통역', '광화문역', '470'
-        )
-        """
-    )
-    cursor.execute(
-        """
-        CREATE TABLE events (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            title TEXT NOT NULL,
-            location_name TEXT NOT NULL,
-            severity_level INTEGER DEFAULT 1,
-            start_date DATETIME,
-            created_at DATETIME,
-            status TEXT
-        )
-        """
-    )
-    cursor.execute(
-        """
-        CREATE TABLE alarm_tasks (
-            task_id TEXT PRIMARY KEY,
-            alarm_type TEXT,
-            status TEXT,
-            total_recipients INTEGER,
-            successful_sends INTEGER,
-            failed_sends INTEGER,
-            created_at DATETIME
-        )
-        """
-    )
-    legacy_conn.commit()
-    legacy_conn.close()
+    os.close(fd)
 
-    @contextmanager
-    def legacy_db_connection():
-        conn = sqlite3.connect(db_path, check_same_thread=False)
-        try:
-            yield conn
-        finally:
-            conn.close()
+    try:
+        legacy_conn = sqlite3.connect(db_path)
+        cursor = legacy_conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                bot_user_key TEXT UNIQUE NOT NULL,
+                first_message_at DATETIME,
+                last_message_at DATETIME,
+                message_count INTEGER DEFAULT 1,
+                location TEXT,
+                active BOOLEAN DEFAULT TRUE,
+                departure_name TEXT,
+                arrival_name TEXT,
+                marked_bus TEXT
+            )
+            """
+        )
+        cursor.execute(
+            """
+            INSERT INTO users (
+                bot_user_key, first_message_at, last_message_at, message_count, active, departure_name, arrival_name, marked_bus
+            ) VALUES (
+                'legacy-user', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 3, 1, '영통역', '광화문역', '470'
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                location_name TEXT NOT NULL,
+                severity_level INTEGER DEFAULT 1,
+                start_date DATETIME,
+                created_at DATETIME,
+                status TEXT
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE alarm_tasks (
+                task_id TEXT PRIMARY KEY,
+                alarm_type TEXT,
+                status TEXT,
+                total_recipients INTEGER,
+                successful_sends INTEGER,
+                failed_sends INTEGER,
+                created_at DATETIME
+            )
+            """
+        )
+        legacy_conn.commit()
+        legacy_conn.close()
 
-    monkeypatch.setattr("app.routers.admin.get_db_connection", legacy_db_connection)
+        @contextmanager
+        def legacy_db_connection():
+            conn = sqlite3.connect(db_path, check_same_thread=False)
+            try:
+                yield conn
+            finally:
+                conn.close()
 
-    response = test_client.get("/admin/dashboard", auth=("admin", "secret123"))
+        monkeypatch.setattr("app.routers.admin.get_db_connection", legacy_db_connection)
 
-    assert response.status_code == 200
-    assert "legacy-user" in response.text
+        response = test_client.get("/admin/dashboard", auth=("admin", "secret123"))
+
+        assert response.status_code == 200
+        assert "legacy-user" in response.text
+    finally:
+        os.unlink(db_path)

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -52,3 +52,43 @@ def test_sync_kakao_user_updates_existing_plusfriend_user(clean_test_db):
 
     assert row == ("bot_user_key_123", "pf_123", 2, 1)
     conn.close()
+
+
+def test_sync_kakao_user_does_not_merge_conflicting_rows(clean_test_db):
+    conn = sqlite3.connect(clean_test_db)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO users (bot_user_key, first_message_at, last_message_at, message_count, active)
+        VALUES (?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, 1)
+        """,
+        ("bot_a",),
+    )
+    cursor.execute(
+        """
+        INSERT INTO users (bot_user_key, plusfriend_user_key, first_message_at, last_message_at, message_count, active)
+        VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, 0)
+        """,
+        ("bot_b", "pf_x"),
+    )
+    conn.commit()
+
+    UserService.sync_kakao_user("bot_a", "pf_x", conn)
+
+    cursor.execute(
+        "SELECT bot_user_key, plusfriend_user_key, message_count, active FROM users WHERE bot_user_key = ?",
+        ("bot_a",),
+    )
+    bot_a_row = cursor.fetchone()
+    cursor.execute(
+        "SELECT bot_user_key, plusfriend_user_key, message_count, active FROM users WHERE plusfriend_user_key = ?",
+        ("pf_x",),
+    )
+    pf_x_row = cursor.fetchone()
+
+    assert bot_a_row == ("bot_a", None, 1, 1)
+    assert pf_x_row == ("bot_b", "pf_x", 2, 1)
+
+    cursor.execute("SELECT COUNT(*) FROM users")
+    assert cursor.fetchone()[0] == 2
+    conn.close()

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -1,0 +1,54 @@
+import sqlite3
+
+from app.services.user_service import UserService
+
+
+def test_sync_kakao_user_links_existing_bot_user(clean_test_db):
+    conn = sqlite3.connect(clean_test_db)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO users (bot_user_key, first_message_at, last_message_at, message_count, active)
+        VALUES (?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, 1)
+        """,
+        ("bot_user_key_123",),
+    )
+    conn.commit()
+
+    UserService.sync_kakao_user("bot_user_key_123", "pf_123", conn)
+
+    cursor.execute(
+        "SELECT bot_user_key, plusfriend_user_key, message_count, active FROM users WHERE bot_user_key = ?",
+        ("bot_user_key_123",),
+    )
+    row = cursor.fetchone()
+
+    assert row == ("bot_user_key_123", "pf_123", 2, 1)
+
+    cursor.execute("SELECT COUNT(*) FROM users")
+    assert cursor.fetchone()[0] == 1
+    conn.close()
+
+
+def test_sync_kakao_user_updates_existing_plusfriend_user(clean_test_db):
+    conn = sqlite3.connect(clean_test_db)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO users (bot_user_key, plusfriend_user_key, first_message_at, last_message_at, message_count, active)
+        VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, 0)
+        """,
+        ("bot_user_key_123", "pf_123"),
+    )
+    conn.commit()
+
+    UserService.sync_kakao_user("bot_user_key_123", "pf_123", conn)
+
+    cursor.execute(
+        "SELECT bot_user_key, plusfriend_user_key, message_count, active FROM users WHERE plusfriend_user_key = ?",
+        ("pf_123",),
+    )
+    row = cursor.fetchone()
+
+    assert row == ("bot_user_key_123", "pf_123", 2, 1)
+    conn.close()


### PR DESCRIPTION
## Summary
- fix Kakao user syncing so existing bot_user_key rows are linked instead of re-inserted when plusfriend data arrives later
- make the admin dashboard tolerate legacy users table schemas by selecting optional fields only when they exist
- add regression coverage for both paths

## Testing
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_user_service.py tests/test_api_admin.py tests/test_admin_dashboard_schema_compat.py tests/test_favorite_zone.py tests/test_alarm_setting.py tests/test_route_setting.py

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved compatibility with legacy database schemas by dynamically detecting available columns, preventing errors on older system configurations.
  * Enhanced dashboard error handling with improved logging for troubleshooting failed requests.
  * Fixed user synchronization logic to prevent mapping collisions and ensure consistent record updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->