### PR TITLE
[codex] Fix deploy readiness and EC2 health check handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,8 +176,8 @@ jobs:
             # Stop old stack (ignore if not running)
             docker compose down || true
 
-            # Remove all unused images (stack is down, so old app image is safe to remove)
-            docker image prune -a -f || true
+            # Remove only dangling image layers to keep deploy cleanup cheap.
+            docker image prune -f || true
 
             echo "=== Disk usage (after prune) ==="
             df -h
@@ -205,14 +205,25 @@ jobs:
               chown -R appuser:appuser /app/data /app/topis_attachments /app/topis_cache || true
 
             echo "Waiting for service health..."
+            service_healthy=0
             for i in {1..60}; do
               if curl -fsS http://localhost:8000/ > /dev/null 2>&1; then
                 echo "✅ Service is healthy on localhost:8000"
+                service_healthy=1
                 break
               fi
               echo "Attempt $i: not ready yet..."
               sleep 5
             done
+
+            if [ "$service_healthy" -ne 1 ]; then
+              echo "❌ Service did not become healthy on localhost:8000 within 300 seconds"
+              echo "docker compose ps:"
+              docker compose ps
+              echo "Recent logs:"
+              docker compose logs --tail=100
+              exit 1
+            fi
 
             echo "docker compose ps:"
             docker compose ps

--- a/app/services/bus_notice_service.py
+++ b/app/services/bus_notice_service.py
@@ -20,14 +20,14 @@ class BusNoticeService:
     
     @classmethod
     async def initialize(cls):
-        """크롤러 초기화 및 데이터 로드"""
+        """크롤러 초기화 및 데이터 로드 상태를 반환한다."""
         try:
             # 설정에서 키 존재 확인
             has_works_ai = bool(settings.WORKS_AI_API_KEY)
 
             if not has_works_ai:
                 logger.warning("⚠️ 분석을 위한 Works AI API 키가 설정되지 않아 서비스를 사용할 수 없습니다.")
-                return
+                return "skipped"
 
             logger.info("🚌 BusNoticeService 초기화 중... (Works AI 사용)")
             
@@ -49,10 +49,13 @@ class BusNoticeService:
 
             cls._image_task = asyncio.create_task(cls.generate_all_route_images())
             cls._image_task.add_done_callback(_log_task_error)
+            return "success"
             
         except Exception as e:
             logger.error(f"❌ BusNoticeService 초기화 실패: {e}")
+            cls.crawler = None
             cls.cached_notices = {}
+            return "failed"
 
     @classmethod
     async def refresh(cls):
@@ -430,4 +433,3 @@ class BusNoticeService:
                     logger.info(f"콜백 전송 결과: {response.status}")
         except Exception as e:
             logger.error(f"콜백 전송 실패: {e}")
-

--- a/app/services/bus_notice_service.py
+++ b/app/services/bus_notice_service.py
@@ -51,8 +51,8 @@ class BusNoticeService:
             cls._image_task.add_done_callback(_log_task_error)
             return "success"
             
-        except Exception as e:
-            logger.error(f"❌ BusNoticeService 초기화 실패: {e}")
+        except Exception:
+            logger.exception("❌ BusNoticeService 초기화 실패")
             cls.crawler = None
             cls.cached_notices = {}
             return "failed"

--- a/app/services/bus_notice_service.py
+++ b/app/services/bus_notice_service.py
@@ -51,8 +51,8 @@ class BusNoticeService:
             cls._image_task.add_done_callback(_log_task_error)
             return "success"
             
-        except Exception:
-            logger.exception("❌ BusNoticeService 초기화 실패")
+        except Exception as e:
+            logger.error(f"❌ BusNoticeService 초기화 실패: {e}")
             cls.crawler = None
             cls.cached_notices = {}
             return "failed"

--- a/main.py
+++ b/main.py
@@ -39,10 +39,22 @@ def _log_bus_notice_init_result(task: asyncio.Task) -> None:
 
     exc = task.exception()
     if exc:
-        logger.error(f"❌ BusNoticeService 백그라운드 초기화 실패: {exc}")
+        logger.error(
+            "❌ BusNoticeService 백그라운드 초기화 실패",
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
         return
 
-    logger.info("✅ BusNoticeService 백그라운드 초기화 완료")
+    result = task.result()
+    if result == "success" or getattr(BusNoticeService, "crawler", None) is not None:
+        logger.info("✅ BusNoticeService 백그라운드 초기화 완료")
+        return
+
+    if result == "skipped":
+        logger.info("⏭️ BusNoticeService 백그라운드 초기화 스킵: WORKS_AI_API_KEY 미설정")
+        return
+
+    logger.error("❌ BusNoticeService 백그라운드 초기화 실패: 초기화 결과가 유효하지 않습니다.")
 
 
 @asynccontextmanager
@@ -88,6 +100,8 @@ async def lifespan(app: FastAPI):
             await bus_notice_init_task
         except asyncio.CancelledError:
             logger.info("🛑 종료 중 BusNoticeService 초기화 태스크를 정리했습니다.")
+        except Exception:
+            logger.exception("종료 중 BusNoticeService 초기화 태스크 정리 과정에서 예외가 발생했습니다.")
 
     shutdown_scheduler()
 

--- a/main.py
+++ b/main.py
@@ -54,6 +54,10 @@ def _log_bus_notice_init_result(task: asyncio.Task) -> None:
         logger.info("⏭️ BusNoticeService 백그라운드 초기화 스킵: WORKS_AI_API_KEY 미설정")
         return
 
+    if result == "failed":
+        logger.error("❌ BusNoticeService 백그라운드 초기화 실패")
+        return
+
     logger.error("❌ BusNoticeService 백그라운드 초기화 실패: 초기화 결과가 유효하지 않습니다.")
 
 

--- a/main.py
+++ b/main.py
@@ -54,10 +54,6 @@ def _log_bus_notice_init_result(task: asyncio.Task) -> None:
         logger.info("⏭️ BusNoticeService 백그라운드 초기화 스킵: WORKS_AI_API_KEY 미설정")
         return
 
-    if result == "failed":
-        logger.error("❌ BusNoticeService 백그라운드 초기화 실패")
-        return
-
     logger.error("❌ BusNoticeService 백그라운드 초기화 실패: 초기화 결과가 유효하지 않습니다.")
 
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ KT Demo Alarm API - Main Application
 Router-Service-Repository 패턴을 적용한 깔끔한 아키텍처
 """
 
+import asyncio
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
@@ -28,6 +29,20 @@ from app.models.responses import HealthCheckResponse
 # 로깅 설정
 setup_logging()
 logger = logging.getLogger(__name__)
+
+
+def _log_bus_notice_init_result(task: asyncio.Task) -> None:
+    """백그라운드 초기화 태스크 종료 상태를 기록한다."""
+    if task.cancelled():
+        logger.info("🛑 BusNoticeService 초기화 태스크가 취소되었습니다.")
+        return
+
+    exc = task.exception()
+    if exc:
+        logger.error(f"❌ BusNoticeService 백그라운드 초기화 실패: {exc}")
+        return
+
+    logger.info("✅ BusNoticeService 백그라운드 초기화 완료")
 
 
 @asynccontextmanager
@@ -56,15 +71,24 @@ async def lifespan(app: FastAPI):
         f"{settings.ROUTE_CHECK_HOUR:02d}:{settings.ROUTE_CHECK_MINUTE:02d} 경로체크, "
         f"{settings.ZONE_CHECK_HOUR:02d}:{settings.ZONE_CHECK_MINUTE:02d} 구역체크"
     )
-    
-    # 버스 알림 서비스 초기화 (서버 시작 시 즉시 크롤러 생성 및 데이터 로드)
-    # 이제 사용자가 서버 재시작 직후에도 버스 검색을 바로할 수 있습니다.
-    await BusNoticeService.initialize()
+
+    # 버스 알림 초기화는 백그라운드로 넘겨서 헬스체크를 즉시 받을 수 있게 한다.
+    app.state.bus_notice_init_task = asyncio.create_task(BusNoticeService.initialize())
+    app.state.bus_notice_init_task.add_done_callback(_log_bus_notice_init_result)
     
     yield
-    
+
     # 애플리케이션 종료 시 실행
     logger.info("🛑 KT Demo Alarm API 종료")
+
+    bus_notice_init_task = getattr(app.state, "bus_notice_init_task", None)
+    if bus_notice_init_task and not bus_notice_init_task.done():
+        bus_notice_init_task.cancel()
+        try:
+            await bus_notice_init_task
+        except asyncio.CancelledError:
+            logger.info("🛑 종료 중 BusNoticeService 초기화 태스크를 정리했습니다.")
+
     shutdown_scheduler()
 
 


### PR DESCRIPTION
## Summary
- make bus notice initialization run in the background so the app can answer deploy health checks immediately
- fail the remote deploy step explicitly when localhost health never becomes ready
- avoid full image pruning on every deploy and keep only cheap dangling-layer cleanup

## Root cause
Deploy health checks were racing a heavy startup path because FastAPI waited for bus notice crawling to finish before exposing `/`. The workflow also waited for localhost health without exiting at the point of timeout, which made the failure mode misleading.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m pytest tests/test_api_basic.py -v`

Closes #87


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Application startup is now faster—bus notice initialization runs in the background instead of blocking startup
  * Deployment diagnostics enhanced with detailed error logs and service health checks

* **Bug Fixes**
  * Strengthened service readiness verification with improved retry logic and status reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->