### PR TITLE
[codex] Consolidate manual crawling triggers under admin auth

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -28,13 +28,14 @@ router = APIRouter(
 )
 
 security = HTTPBasic(auto_error=False)
+admin_credentials = Depends(security)
 templates = Jinja2Templates(directory=os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates"))
 
 # Task registry and lock to prevent duplicate runs and race conditions
 _background_tasks: Dict[str, asyncio.Task] = {}
 _task_lock = asyncio.Lock()
 
-def verify_admin(credentials: HTTPBasicCredentials = Depends(security)):
+def verify_admin(credentials: HTTPBasicCredentials | None = admin_credentials):
     # Using environment variables for admin credentials.
     # These must be configured via environment (.env, deployment config).
     admin_user = settings.ADMIN_USER
@@ -67,7 +68,7 @@ def verify_admin(credentials: HTTPBasicCredentials = Depends(security)):
 
 def verify_admin_action(
     request: Request,
-    credentials: HTTPBasicCredentials | None = Depends(security),
+    credentials: HTTPBasicCredentials | None = admin_credentials,
 ):
     """Allow admin UI Basic Auth or API-key based operational trigger calls."""
     x_api_key = request.headers.get("x-api-key")

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -27,7 +27,7 @@ router = APIRouter(
     tags=["admin"]
 )
 
-security = HTTPBasic()
+security = HTTPBasic(auto_error=False)
 templates = Jinja2Templates(directory=os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates"))
 
 # Task registry and lock to prevent duplicate runs and race conditions
@@ -39,6 +39,13 @@ def verify_admin(credentials: HTTPBasicCredentials = Depends(security)):
     # These must be configured via environment (.env, deployment config).
     admin_user = settings.ADMIN_USER
     admin_pass = settings.ADMIN_PASS
+
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Basic"},
+        )
     
     # Fail fast if admin credentials are not configured
     if not admin_user or not admin_user.strip() or not admin_pass or not admin_pass.strip():
@@ -57,6 +64,29 @@ def verify_admin(credentials: HTTPBasicCredentials = Depends(security)):
             headers={"WWW-Authenticate": "Basic"},
         )
     return credentials.username
+
+def verify_admin_action(
+    request: Request,
+    credentials: HTTPBasicCredentials | None = Depends(security),
+):
+    """Allow admin UI Basic Auth or API-key based operational trigger calls."""
+    x_api_key = request.headers.get("x-api-key")
+    if x_api_key is not None:
+        if not settings.API_KEY:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Server Authorization not configured",
+            )
+        if not secrets.compare_digest(x_api_key, settings.API_KEY):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid API Key",
+            )
+        return "api-key"
+
+    username = verify_admin(credentials)
+    verify_csrf_origin(request)
+    return username
 
 def verify_csrf_origin(request: Request):
     """
@@ -293,8 +323,7 @@ def _task_done_callback(task_key: str):
 
 @router.post("/trigger-crawling")
 async def trigger_crawling(
-    _username: str = Depends(verify_admin),
-    _csrf: None = Depends(verify_csrf_origin)
+    _auth: str = Depends(verify_admin_action),
 ):
     """수동으로 서울경찰청 집회 정보 크롤링을 트리거합니다."""
     task_key = "trigger-crawling"
@@ -309,8 +338,7 @@ async def trigger_crawling(
 
 @router.post("/trigger-bus-notice")
 async def trigger_bus_notice(
-    _username: str = Depends(verify_admin),
-    _csrf: None = Depends(verify_csrf_origin)
+    _auth: str = Depends(verify_admin_action),
 ):
     """수동으로 TOPIS 버스 우회 공지 크롤링을 트리거합니다."""
     task_key = "trigger-bus-notice"
@@ -326,8 +354,7 @@ async def trigger_bus_notice(
 @router.post("/trigger-test-alarm-for-user")
 async def trigger_test_alarm_for_user(
     user_id: str = Query(..., description="Target user ID to test"), 
-    _username: str = Depends(verify_admin),
-    _csrf: None = Depends(verify_csrf_origin)
+    _auth: str = Depends(verify_admin_action),
 ):
     """수동으로 특정 사용자의 경로 점검 및 알림 발송 로직을 테스트합니다."""
     task_key = f"test-alarm-{user_id}"

--- a/app/routers/bus_notice.py
+++ b/app/routers/bus_notice.py
@@ -143,18 +143,6 @@ async def get_bus_service_status():
         "last_update": BusNoticeService.last_update.isoformat() if BusNoticeService.last_update else None,
     }
 
-@router.post("/refresh")
-async def manual_bus_refresh():
-    """버스 통제 공지 수동 재크롤링 (테스트/운영용)"""
-    if not BusNoticeService.crawler:
-        raise HTTPException(status_code=503, detail="크롤러가 초기화되지 않았습니다. (WORKS_AI_API_KEY 확인)")
-    await BusNoticeService.refresh()
-    return {
-        "message": "버스 통제 공지 재크롤링 완료",
-        "cached_count": len(BusNoticeService.cached_notices),
-        "last_update": BusNoticeService.last_update.isoformat() if BusNoticeService.last_update else None,
-    }
-
 @router.get("/notices")
 async def get_notices(date: Optional[str] = None):
     """공지사항 목록"""

--- a/app/routers/events.py
+++ b/app/routers/events.py
@@ -203,30 +203,6 @@ async def auto_check_all_routes(
     }
 
 
-@router.post("/crawl-and-sync")
-async def crawl_and_sync_events(api_key: str = Depends(verify_api_key)):
-    """SMPA 집회 데이터 크롤링 및 동기화"""
-    try:
-        from app.services.crawling_service import CrawlingService
-        result = await CrawlingService.crawl_and_sync_events()
-        
-        if result["success"]:
-            return {
-                "message": result["message"],
-                "total_crawled": result["total_crawled"],
-                "status": "completed"
-            }
-        else:
-            raise HTTPException(
-                status_code=500, 
-                detail=f"크롤링 실패: {result['error']}"
-            )
-        
-    except Exception as e:
-        logger.error(f"크롤링 중 오류: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"크롤링 실패: {str(e)}")
-
-
 @router.post("/upcoming-protests")
 async def get_upcoming_protests(
     request: dict,

--- a/app/routers/scheduler.py
+++ b/app/routers/scheduler.py
@@ -1,8 +1,6 @@
 """스케줄러 관련 라우터"""
 from fastapi import APIRouter, HTTPException
 import logging
-from app.services.crawling_service import CrawlingService
-from app.services.event_service import EventService
 from app.utils.scheduler_utils import get_scheduler_status
 
 logger = logging.getLogger(__name__)
@@ -21,57 +19,3 @@ async def scheduler_status():
     except Exception as e:
         logger.error(f"스케줄러 상태 조회 실패: {str(e)}")
         raise HTTPException(status_code=500, detail="스케줄러 상태 조회 실패")
-
-
-@router.post("/manual-test")
-async def manual_schedule_test():
-    """
-    수동 스케줄 테스트 실행
-    개발/테스트용으로 스케줄된 작업을 즉시 실행
-    """
-    try:
-        # 스케줄된 함수들을 수동으로 실행
-        from app.database.connection import DATABASE_PATH
-        import sqlite3
-        
-        logger.info("🧪 수동 스케줄 테스트 시작")
-        
-        # scheduled_route_check 함수 실행
-        from app.services.event_service import EventService
-        await EventService.scheduled_route_check()
-        
-        return {
-            "message": "수동 스케줄 테스트가 성공적으로 실행되었습니다",
-            "test_completed": True
-        }
-        
-    except Exception as e:
-        logger.error(f"수동 스케줄 테스트 실패: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"테스트 실행 실패: {str(e)}")
-
-@router.post("/crawl-events")
-async def crawl_events():
-    """
-    ✅ v4.2: 집회 데이터 크롤링 수동 트리거
-    
-    SMPA + SPATIC에서 데이터를 크롤링하고 지오코딩을 수행합니다.
-    
-    Returns:
-        dict: 크롤링 결과 (성공 여부, 저장된 데이터 수 등)
-    """
-    logger.info("🔄 [API] 크롤링 엔드포인트 호출됨")
-    
-    try:
-        # 크롤링 서비스 실행
-        result = await CrawlingService.crawl_and_sync_events()
-        
-        logger.info(f"✅ [API] 크롤링 완료: {result}")
-        return result
-        
-    except Exception as e:
-        logger.error(f"❌ [API] 크롤링 실패: {e}", exc_info=True)
-        return {
-            "success": False,
-            "error": str(e),
-            "total_crawled": 0
-        }

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ KT Demo Alarm API - Main Application
 Router-Service-Repository 패턴을 적용한 깔끔한 아키텍처
 """
 
-import asyncio
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
@@ -29,32 +28,6 @@ from app.models.responses import HealthCheckResponse
 # 로깅 설정
 setup_logging()
 logger = logging.getLogger(__name__)
-
-
-def _log_bus_notice_init_result(task: asyncio.Task) -> None:
-    """백그라운드 초기화 태스크 종료 상태를 기록한다."""
-    if task.cancelled():
-        logger.info("🛑 BusNoticeService 초기화 태스크가 취소되었습니다.")
-        return
-
-    exc = task.exception()
-    if exc:
-        logger.error(
-            "❌ BusNoticeService 백그라운드 초기화 실패",
-            exc_info=(type(exc), exc, exc.__traceback__),
-        )
-        return
-
-    result = task.result()
-    if result == "success" or getattr(BusNoticeService, "crawler", None) is not None:
-        logger.info("✅ BusNoticeService 백그라운드 초기화 완료")
-        return
-
-    if result == "skipped":
-        logger.info("⏭️ BusNoticeService 백그라운드 초기화 스킵: WORKS_AI_API_KEY 미설정")
-        return
-
-    logger.error("❌ BusNoticeService 백그라운드 초기화 실패: 초기화 결과가 유효하지 않습니다.")
 
 
 @asynccontextmanager
@@ -84,24 +57,10 @@ async def lifespan(app: FastAPI):
         f"{settings.ZONE_CHECK_HOUR:02d}:{settings.ZONE_CHECK_MINUTE:02d} 구역체크"
     )
 
-    # 버스 알림 초기화는 백그라운드로 넘겨서 헬스체크를 즉시 받을 수 있게 한다.
-    app.state.bus_notice_init_task = asyncio.create_task(BusNoticeService.initialize())
-    app.state.bus_notice_init_task.add_done_callback(_log_bus_notice_init_result)
-    
     yield
 
     # 애플리케이션 종료 시 실행
     logger.info("🛑 KT Demo Alarm API 종료")
-
-    bus_notice_init_task = getattr(app.state, "bus_notice_init_task", None)
-    if bus_notice_init_task and not bus_notice_init_task.done():
-        bus_notice_init_task.cancel()
-        try:
-            await bus_notice_init_task
-        except asyncio.CancelledError:
-            logger.info("🛑 종료 중 BusNoticeService 초기화 태스크를 정리했습니다.")
-        except Exception:
-            logger.exception("종료 중 BusNoticeService 초기화 태스크 정리 과정에서 예외가 발생했습니다.")
 
     shutdown_scheduler()
 

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -115,6 +115,19 @@ def test_trigger_crawling_authorized(test_client, monkeypatch):
     assert response.status_code == 200
     assert response.json() == {"message": "Scheduled"}
 
+def test_trigger_crawling_authorized_with_api_key(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "API_KEY", "test-api-key")
+
+    mock_crawl = AsyncMock()
+    headers = {"X-API-Key": "test-api-key"}
+
+    with monkeypatch.context() as m:
+        m.setattr("app.services.crawling_service.CrawlingService.crawl_and_sync_events", mock_crawl)
+        response = test_client.post("/admin/trigger-crawling", headers=headers)
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Scheduled"}
+
 def test_trigger_bus_notice_authorized(test_client, monkeypatch):
     monkeypatch.setattr(settings, "ADMIN_USER", "admin")
     monkeypatch.setattr(settings, "ADMIN_PASS", "secret123")
@@ -129,6 +142,29 @@ def test_trigger_bus_notice_authorized(test_client, monkeypatch):
     assert response.status_code == 200
     assert response.json() == {"message": "Scheduled"}
 
+def test_trigger_bus_notice_authorized_with_api_key(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "API_KEY", "test-api-key")
+
+    mock_refresh = AsyncMock()
+    headers = {"X-API-Key": "test-api-key"}
+
+    with monkeypatch.context() as m:
+        m.setattr("app.services.bus_notice_service.BusNoticeService.refresh", mock_refresh)
+        response = test_client.post("/admin/trigger-bus-notice", headers=headers)
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Scheduled"}
+
+def test_trigger_bus_notice_rejects_invalid_api_key(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "API_KEY", "test-api-key")
+
+    response = test_client.post(
+        "/admin/trigger-bus-notice",
+        headers={"X-API-Key": "wrong-key"},
+    )
+
+    assert response.status_code == 401
+
 def test_trigger_test_alarm_for_user_authorized(test_client, monkeypatch):
     monkeypatch.setattr(settings, "ADMIN_USER", "admin")
     monkeypatch.setattr(settings, "ADMIN_PASS", "secret123")
@@ -140,5 +176,20 @@ def test_trigger_test_alarm_for_user_authorized(test_client, monkeypatch):
         m.setattr("app.services.event_service.EventService.check_route_events", mock_route_check)
         response = test_client.post("/admin/trigger-test-alarm-for-user?user_id=12345", auth=("admin", "secret123"), headers=headers)
         
+    assert response.status_code == 200
+    assert response.json() == {"message": "Scheduled"}
+
+def test_trigger_test_alarm_for_user_authorized_with_api_key(test_client, monkeypatch):
+    monkeypatch.setattr(settings, "API_KEY", "test-api-key")
+
+    mock_route_check = AsyncMock()
+
+    with monkeypatch.context() as m:
+        m.setattr("app.services.event_service.EventService.check_route_events", mock_route_check)
+        response = test_client.post(
+            "/admin/trigger-test-alarm-for-user?user_id=12345",
+            headers={"X-API-Key": "test-api-key"},
+        )
+
     assert response.status_code == 200
     assert response.json() == {"message": "Scheduled"}

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -127,6 +127,7 @@ def test_trigger_crawling_authorized_with_api_key(test_client, monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == {"message": "Scheduled"}
+    mock_crawl.assert_called_once()
 
 def test_trigger_bus_notice_authorized(test_client, monkeypatch):
     monkeypatch.setattr(settings, "ADMIN_USER", "admin")
@@ -154,6 +155,7 @@ def test_trigger_bus_notice_authorized_with_api_key(test_client, monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == {"message": "Scheduled"}
+    mock_refresh.assert_called_once()
 
 def test_trigger_bus_notice_rejects_invalid_api_key(test_client, monkeypatch):
     monkeypatch.setattr(settings, "API_KEY", "test-api-key")
@@ -184,12 +186,11 @@ def test_trigger_test_alarm_for_user_authorized_with_api_key(test_client, monkey
 
     mock_route_check = AsyncMock()
 
-    with monkeypatch.context() as m:
-        m.setattr("app.services.event_service.EventService.check_route_events", mock_route_check)
-        response = test_client.post(
-            "/admin/trigger-test-alarm-for-user?user_id=12345",
-            headers={"X-API-Key": "test-api-key"},
-        )
+    monkeypatch.setattr("app.services.event_service.EventService.check_route_events", mock_route_check)
+    response = test_client.post(
+        "/admin/trigger-test-alarm-for-user?user_id=12345",
+        headers={"X-API-Key": "test-api-key"},
+    )
 
     assert response.status_code == 200
     assert response.json() == {"message": "Scheduled"}

--- a/tests/test_api_basic.py
+++ b/tests/test_api_basic.py
@@ -87,7 +87,7 @@ def test_scheduler_status(test_client):
     assert "jobs" in data["scheduler"]
 
 
-def test_startup_does_not_initialize_bus_notice(monkeypatch):
+def test_startup_does_not_initialize_bus_notice(test_db, monkeypatch):
     """Server startup should not crawl TOPIS bus notices."""
     from main import app
 
@@ -104,17 +104,8 @@ def test_startup_does_not_initialize_bus_notice(monkeypatch):
     mock_initialize.assert_not_called()
 
 
-def test_removed_manual_crawling_endpoints_return_404(test_client, monkeypatch):
+def test_removed_manual_crawling_endpoints_return_404(test_client):
     """Manual crawling should be consolidated under /admin/trigger-*."""
-    monkeypatch.setattr(
-        "app.services.crawling_service.CrawlingService.crawl_and_sync_events",
-        AsyncMock(return_value={"success": True}),
-    )
-    monkeypatch.setattr(
-        "app.services.event_service.EventService.scheduled_route_check",
-        AsyncMock(return_value={"success": True}),
-    )
-
     assert test_client.post("/bus/refresh").status_code == 404
     assert test_client.post("/scheduler/crawl-events").status_code == 404
     assert test_client.post("/scheduler/manual-test").status_code == 404

--- a/tests/test_api_basic.py
+++ b/tests/test_api_basic.py
@@ -1,6 +1,7 @@
 """Test basic API functionality"""
 import pytest
 from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock
 
 
 def test_root_endpoint(test_client):
@@ -84,3 +85,40 @@ def test_scheduler_status(test_client):
     assert "scheduler" in data
     assert "status" in data["scheduler"]
     assert "jobs" in data["scheduler"]
+
+
+def test_startup_does_not_initialize_bus_notice(monkeypatch):
+    """Server startup should not crawl TOPIS bus notices."""
+    from main import app
+
+    mock_initialize = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.bus_notice_service.BusNoticeService.initialize",
+        mock_initialize,
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/")
+
+    assert response.status_code == 200
+    mock_initialize.assert_not_called()
+
+
+def test_removed_manual_crawling_endpoints_return_404(test_client, monkeypatch):
+    """Manual crawling should be consolidated under /admin/trigger-*."""
+    monkeypatch.setattr(
+        "app.services.crawling_service.CrawlingService.crawl_and_sync_events",
+        AsyncMock(return_value={"success": True}),
+    )
+    monkeypatch.setattr(
+        "app.services.event_service.EventService.scheduled_route_check",
+        AsyncMock(return_value={"success": True}),
+    )
+
+    assert test_client.post("/bus/refresh").status_code == 404
+    assert test_client.post("/scheduler/crawl-events").status_code == 404
+    assert test_client.post("/scheduler/manual-test").status_code == 404
+    assert test_client.post(
+        "/events/crawl-and-sync",
+        headers={"X-API-Key": "test-api-key"},
+    ).status_code == 404


### PR DESCRIPTION
## Summary
- stop BusNoticeService startup initialization so deployments do not crawl TOPIS immediately
- consolidate manual crawling execution under /admin/trigger-* and remove duplicate non-admin trigger endpoints
- allow admin trigger endpoints through either dashboard Basic Auth + Origin/Referer or X-API-Key for external operational calls

## Validation
- uv run pytest

Closes #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin trigger endpoints now support API key authentication via `X-API-Key` header for secure access.

* **Removed**
  * `/bus/refresh` endpoint for manual bus notice updates.
  * `/events/crawl-and-sync` endpoint for event synchronization.
  * `/scheduler/manual-test` and `/scheduler/crawl-events` endpoints for scheduler operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->