### PR TITLE
fix(mock-callback): keep test-only callback opt-in

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
     ADMIN_USER: Optional[str] = None
     ADMIN_PASS: Optional[str] = None
 
+    # --- Development/Test Utilities ---
+    ENABLE_MOCK_CALLBACK: bool = False
+
     # --- Server ---
     APP_NAME: str = "KT Demo Alarm API"
     APP_VERSION: str = "1.0.0"

--- a/main.py
+++ b/main.py
@@ -29,6 +29,9 @@ from app.models.responses import HealthCheckResponse
 setup_logging()
 logger = logging.getLogger(__name__)
 
+MOCK_CALLBACK_PATH = "/mock_callback"
+CALLBACK_OUTPUT_SEPARATOR = "═" * 50
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -117,22 +120,21 @@ def read_root():
         status="healthy"
     )
 
-@app.post("/mock_callback")
-async def mock_callback_receiver(request: Request):
-    """콜백 결과를 터미널에 예쁘게 출력해주는 테스트용 엔드포인트"""
-    import json
-    try:
-        body = await request.json()
-        print("\n" + "═"*50)
-        print("📢 [실전 시뮬레이션 결과] - 카톡 유저가 받게 될 메시지")
-        print("═"*50)
-        print(json.dumps(body, indent=2, ensure_ascii=False))
-        print("═"*50 + "\n")
-    except Exception as e:
-        print(f"콜백 수신 중 오류: {e}")
-    return {"status": "ok"}
-
-
+if settings.ENABLE_MOCK_CALLBACK:
+    @app.post(MOCK_CALLBACK_PATH)
+    async def mock_callback_receiver(request: Request):
+        """콜백 결과를 터미널에 예쁘게 출력해주는 테스트용 엔드포인트"""
+        import json
+        try:
+            body = await request.json()
+            print("\n" + CALLBACK_OUTPUT_SEPARATOR)
+            print("📢 [실전 시뮬레이션 결과] - 카톡 유저가 받게 될 메시지")
+            print(CALLBACK_OUTPUT_SEPARATOR)
+            print(json.dumps(body, indent=2, ensure_ascii=False))
+            print(CALLBACK_OUTPUT_SEPARATOR + "\n")
+        except Exception as e:
+            print(f"콜백 수신 중 오류: {e}")
+        return {"status": "ok"}
 
 
 # 애플리케이션 진입점

--- a/tests/test_api_basic.py
+++ b/tests/test_api_basic.py
@@ -1,7 +1,14 @@
 """Test basic API functionality"""
-import pytest
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 from unittest.mock import AsyncMock
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 
 def test_root_endpoint(test_client):
@@ -113,3 +120,68 @@ def test_removed_manual_crawling_endpoints_return_404(test_client):
         "/events/crawl-and-sync",
         headers={"X-API-Key": "test-api-key"},
     ).status_code == 404
+
+
+def test_mock_callback_not_registered_by_default(test_client):
+    """Test-only callback receiver must not be exposed unless explicitly enabled."""
+    response = test_client.post("/mock_callback", json={"message": "hello"})
+
+    assert response.status_code == 404
+
+
+def test_mock_callback_hidden_from_openapi_by_default(test_client):
+    """Default OpenAPI schema must not advertise the test-only callback receiver."""
+    response = test_client.get("/openapi.json")
+
+    assert response.status_code == 200
+    assert "/mock_callback" not in response.json()["paths"]
+
+
+def test_mock_callback_registered_when_explicitly_enabled():
+    """Explicit opt-in should preserve the local callback simulation endpoint."""
+    script = """
+import json
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+valid_response = client.post("/mock_callback", json={"message": "hello"})
+invalid_response = client.post(
+    "/mock_callback",
+    content="not-json",
+    headers={"content-type": "application/json"},
+)
+openapi_response = client.get("/openapi.json")
+
+print("RESULT:" + json.dumps({
+    "valid_status": valid_response.status_code,
+    "valid_body": valid_response.json(),
+    "invalid_status": invalid_response.status_code,
+    "invalid_body": invalid_response.json(),
+    "openapi_has_mock_callback": "/mock_callback" in openapi_response.json()["paths"],
+}, ensure_ascii=False))
+"""
+    env = os.environ.copy()
+    env["ENABLE_MOCK_CALLBACK"] = "true"
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=PROJECT_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result_line = next(
+        line for line in reversed(completed.stdout.splitlines())
+        if line.startswith("RESULT:")
+    )
+    result = json.loads(result_line.removeprefix("RESULT:"))
+
+    assert result == {
+        "valid_status": 200,
+        "valid_body": {"status": "ok"},
+        "invalid_status": 200,
+        "invalid_body": {"status": "ok"},
+        "openapi_has_mock_callback": True,
+    }


### PR DESCRIPTION
## Summary
- Hide `/mock_callback` by default in runtime routing and OpenAPI.
- Add `ENABLE_MOCK_CALLBACK=false` default setting.
- Preserve explicit local simulation behavior when `ENABLE_MOCK_CALLBACK=true`.
- Address review feedback by making subprocess test cwd independent of pytest launch directory.

## Why
Issue #96 requires the production/default app surface to avoid exposing a development-only callback receiver while still allowing explicit local callback simulation.

## Tests
- `uv run pytest tests/test_api_basic.py -q`
- `uv run pytest -q`
- `git diff --check`
- `uv run python -m compileall -q main.py app/config/settings.py tests/test_api_basic.py`

Resolves #96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mock callback endpoint is now disabled by default for improved security and a cleaner API surface. It can be optionally enabled via configuration settings when needed for development or testing purposes.

* **Tests**
  * Added comprehensive test coverage to verify the mock callback endpoint is properly disabled by default and functions correctly when explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->