### PR TITLE
fix(database): DB 경로를 호출 시점 설정 기준으로 해석

### DIFF
--- a/app/database/connection.py
+++ b/app/database/connection.py
@@ -6,12 +6,16 @@ from app.config.settings import settings
 from app.database.models import USERS_TABLE_SCHEMA, EVENTS_TABLE_SCHEMA, ALARM_TASKS_TABLE_SCHEMA
 
 logger = logging.getLogger(__name__)
-DATABASE_PATH = settings.DATABASE_PATH
+
+
+def get_database_path() -> str:
+    """현재 설정의 데이터베이스 경로를 반환한다."""
+    return settings.DATABASE_PATH
 
 
 def get_db():
     """데이터베이스 연결을 위한 의존성 주입 함수 (FastAPI 용)"""
-    db = sqlite3.connect(DATABASE_PATH, check_same_thread=False)
+    db = sqlite3.connect(get_database_path(), check_same_thread=False)
     db.row_factory = sqlite3.Row
     try:
         yield db
@@ -22,7 +26,7 @@ def get_db():
 @contextmanager
 def get_db_connection():
     """컨텍스트 매니저를 사용한 DB 연결 (일반 함수용)"""
-    conn = sqlite3.connect(DATABASE_PATH, check_same_thread=False)
+    conn = sqlite3.connect(get_database_path(), check_same_thread=False)
     conn.row_factory = sqlite3.Row
     try:
         yield conn
@@ -32,7 +36,7 @@ def get_db_connection():
 
 def init_db():
     """데이터베이스 초기화 - 중앙집중식 스키마 사용"""
-    conn = sqlite3.connect(DATABASE_PATH, check_same_thread=False)
+    conn = sqlite3.connect(get_database_path(), check_same_thread=False)
     cursor = conn.cursor()
 
     # Users 테이블 생성 (통합 스키마 사용)

--- a/app/services/crawling_service.py
+++ b/app/services/crawling_service.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from collections import OrderedDict
 from typing import List, Dict, Tuple, Optional
 
-from app.database.connection import get_db_connection, DATABASE_PATH
+from app.database.connection import get_db_connection, get_database_path
 from app.config.settings import settings
 
 import requests
@@ -53,11 +53,19 @@ logger = logging.getLogger(__name__)
 
 # 상수/설정
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent.parent
-if not pathlib.Path(DATABASE_PATH).is_absolute():
-    DB_ABS_PATH = BASE_DIR / DATABASE_PATH
-else:
-    DB_ABS_PATH = pathlib.Path(DATABASE_PATH)
-DATA_DIR = DB_ABS_PATH.parent
+
+
+def get_db_abs_path() -> pathlib.Path:
+    """현재 설정 기준 DB 절대 경로를 반환한다."""
+    database_path = pathlib.Path(get_database_path())
+    if database_path.is_absolute():
+        return database_path
+    return BASE_DIR / database_path
+
+
+def get_data_dir() -> pathlib.Path:
+    """현재 DB 경로 기준 데이터 디렉터리를 반환한다."""
+    return get_db_abs_path().parent
 
 KAKAO_KEYWORD_URL = "https://dapi.kakao.com/v2/local/search/keyword.json"
 KAKAO_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json"
@@ -411,7 +419,7 @@ class CrawlingService:
     async def crawl_and_sync_events(cls) -> Dict:
         """스케줄러 진입점"""
         logger.info("🔄 [스케줄러] 집회 정보 크롤링을 시작합니다.")
-        ensure_dir(DATA_DIR)
+        ensure_dir(get_data_dir())
 
         if PDFPLUMBER_AVAILABLE:
             logger.info("ℹ️ [PDF] pdfplumber가 사용 가능합니다 (폴백 지원)")
@@ -701,7 +709,7 @@ class CrawlingService:
                 return []
 
             logger.info(f"[SMPA] PDF 다운로드 시작: {pdf_url}")
-            pdf_path = DATA_DIR / f"smpa_{today_str}.pdf"
+            pdf_path = get_data_dir() / f"smpa_{today_str}.pdf"
 
             r = session.get(pdf_url, headers=SMPA_HEADERS, timeout=10)
             r.raise_for_status()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import os
 import sqlite3
 import tempfile
 from fastapi.testclient import TestClient
-from app.database.connection import init_db, DATABASE_PATH
+from app.database.connection import init_db
 
 
 @pytest.fixture(scope="session")
@@ -19,12 +19,6 @@ def test_db():
     # Patch settings
     with patch("app.config.settings.settings.DATABASE_PATH", test_db_path), \
          patch("app.config.settings.settings.API_KEY", "test-api-key"):
-        
-        # Also need to patch the variable in connection module if it was already imported
-        import app.database.connection as db_module
-        original_db_path = db_module.DATABASE_PATH
-        db_module.DATABASE_PATH = test_db_path
-        
         # Initialize test database
         init_db()
         
@@ -35,9 +29,6 @@ def test_db():
             os.remove(test_db_path)
         except FileNotFoundError:
             pass
-        
-        # Restore original database path (although patch handles settings, module var needs manual restore)
-        db_module.DATABASE_PATH = original_db_path
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_admin_dashboard_schema_compat.py
+++ b/tests/test_admin_dashboard_schema_compat.py
@@ -143,13 +143,7 @@ def test_init_db_preserves_user_column_mapping_during_not_null_migration(monkeyp
         conn.close()
 
         monkeypatch.setattr("app.config.settings.settings.DATABASE_PATH", db_path)
-        import app.database.connection as db_module
-        original_db_path = db_module.DATABASE_PATH
-        db_module.DATABASE_PATH = db_path
-        try:
-            init_db()
-        finally:
-            db_module.DATABASE_PATH = original_db_path
+        init_db()
 
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row

--- a/tests/test_database_connection_settings.py
+++ b/tests/test_database_connection_settings.py
@@ -1,0 +1,70 @@
+"""DB 연결 설정 경계 회귀 테스트"""
+import sqlite3
+
+from app.config.settings import settings
+from app.database.connection import get_db, get_db_connection, init_db
+
+
+def _table_names(db_path: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT name FROM sqlite_master
+            WHERE type = 'table'
+            """
+        ).fetchall()
+        return {row[0] for row in rows}
+    finally:
+        conn.close()
+
+
+def test_database_connections_use_current_settings_path_without_module_patch(
+    monkeypatch,
+    tmp_path,
+):
+    """settings 변경만으로 init/get_db/get_db_connection이 같은 임시 DB를 사용한다."""
+    db_path = tmp_path / "runtime-settings.db"
+    monkeypatch.setattr(settings, "DATABASE_PATH", str(db_path))
+
+    init_db()
+
+    assert {"users", "events", "alarm_tasks"}.issubset(_table_names(str(db_path)))
+
+    with get_db_connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO users (bot_user_key, active)
+            VALUES (?, ?)
+            """,
+            ("settings-user", True),
+        )
+        conn.commit()
+
+    db_generator = get_db()
+    db = next(db_generator)
+    try:
+        row = db.execute(
+            "SELECT bot_user_key FROM users WHERE bot_user_key = ?",
+            ("settings-user",),
+        ).fetchone()
+        assert row["bot_user_key"] == "settings-user"
+    finally:
+        db_generator.close()
+
+
+def test_crawling_service_db_paths_use_current_settings(monkeypatch, tmp_path):
+    """크롤링 서비스의 DB 파생 경로는 import-time 캐시가 아니라 현재 settings를 따른다."""
+    from app.services.crawling_service import BASE_DIR, get_data_dir, get_db_abs_path
+
+    relative_db_path = "relative-test.db"
+    monkeypatch.setattr(settings, "DATABASE_PATH", relative_db_path)
+
+    assert get_db_abs_path() == BASE_DIR / relative_db_path
+    assert get_data_dir() == BASE_DIR
+
+    absolute_db_path = tmp_path / "absolute-test.db"
+    monkeypatch.setattr(settings, "DATABASE_PATH", str(absolute_db_path))
+
+    assert get_db_abs_path() == absolute_db_path
+    assert get_data_dir() == tmp_path


### PR DESCRIPTION
## 요약

Closes #95

- `app.database.connection`의 import-time `DATABASE_PATH` 캐싱을 제거하고 호출 시점 `settings.DATABASE_PATH`를 읽는 resolver를 추가했습니다.
- `get_db`, `get_db_connection`, `init_db`가 동일한 DB path resolver를 사용하도록 정렬했습니다.
- `crawling_service`는 외부 URL/크롤링 로직을 건드리지 않고 DB 경로 파생값만 지연 계산하도록 바꿨습니다.
- 테스트 fixture에서 `db_module.DATABASE_PATH` 수동 덮어쓰기를 제거했습니다.
- 런타임 settings 반영과 crawling DB path 지연 계산 회귀 테스트를 추가했습니다.

## 범위

포함:
- DB connection 설정 경계 정리
- 테스트 DB 격리 단순화
- DB 경로 파생 계산 지연화

제외:
- Repository 계층 도입 (#99 후속)
- 크롤링 URL 하드코딩 정리 (#97 범위)
- 외부 API/라우터 계약 변경
- 신규 의존성 추가

## 검증

- `uv run python -m pytest tests/ -v` → `111 passed, 13 warnings`
- `rg -n 'db_module\.DATABASE_PATH\s*=' tests` → 결과 없음
- `rg -n 'from app\.database\.connection import .*DATABASE_PATH|DATABASE_PATH = settings\.DATABASE_PATH' app tests` → 결과 없음
- `git diff --check` → 통과

## 비고

- warnings는 기존 테스트 실행 경고이며 PR blocker는 아닙니다.
- Live external crawling endpoints는 실행하지 않았습니다. 이번 PR은 URL/크롤링 동작 변경을 범위에서 제외하고 DB 경로 계산 경계만 검증했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Database path resolution improved to support dynamic runtime configuration without requiring module reimports.

* **Tests**
  * Added comprehensive regression tests for database connection configuration and schema migration compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->