### PR TITLE
Draft: Repository boundary extraction for issue #99

### DIFF
--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -1,0 +1,31 @@
+"""데이터베이스 저장소 패키지."""
+
+from app.repositories.alarm_task_repository import AlarmTaskRepository
+from app.repositories.alarm_recipient_read_repository import AlarmRecipientReadRepository
+from app.repositories.admin_dashboard_read_repository import AdminDashboardReadRepository
+from app.repositories.event_repository import EventRepository
+from app.repositories.route_event_query_repository import RouteEventQueryRepository
+from app.repositories.user_identity_repository import UserIdentityRepository
+from app.repositories.user_preference_repository import UserPreferenceRepository
+from app.repositories.user_profile_repository import UserProfileRepository
+from app.repositories.user_read_repository import UserReadRepository
+from app.repositories.user_route_repository import UserRouteRepository
+from app.repositories.user_route_read_repository import UserRouteReadRepository
+from app.repositories.user_settings_repository import UserSettingsRepository
+from app.repositories.zone_alarm_read_repository import ZoneAlarmReadRepository
+
+__all__ = [
+    "AlarmRecipientReadRepository",
+    "AlarmTaskRepository",
+    "AdminDashboardReadRepository",
+    "EventRepository",
+    "RouteEventQueryRepository",
+    "UserIdentityRepository",
+    "UserPreferenceRepository",
+    "UserProfileRepository",
+    "UserReadRepository",
+    "UserRouteRepository",
+    "UserRouteReadRepository",
+    "UserSettingsRepository",
+    "ZoneAlarmReadRepository",
+]

--- a/app/repositories/admin_dashboard_read_repository.py
+++ b/app/repositories/admin_dashboard_read_repository.py
@@ -1,0 +1,154 @@
+"""관리자 대시보드 읽기 저장소."""
+import sqlite3
+from collections.abc import Sequence
+from typing import cast
+
+
+type DashboardRow = dict[str, object]
+type SqliteRowSequence = Sequence[object]
+
+
+ADMIN_DASHBOARD_RECENT_LIMIT = 100
+USERS_TABLE_NAME = "users"
+ALLOWED_SCHEMA_TABLES = frozenset({USERS_TABLE_NAME})
+
+PAGINATED_USER_BASE_FIELDS = [
+    "id",
+    "bot_user_key",
+    "active",
+    "departure_name",
+    "arrival_name",
+    "marked_bus",
+    "first_message_at as created_at",
+    "message_count",
+]
+
+PAGINATED_USER_OPTIONAL_FIELDS = {
+    "plusfriend_user_key": "plusfriend_user_key",
+    "open_id": "open_id",
+    "is_alarm_on": "is_alarm_on",
+    "favorite_zone": "COALESCE(favorite_zone, 0) as favorite_zone",
+}
+
+
+class AdminDashboardReadRepository:
+    """관리자 대시보드의 read-model SQL을 담당한다."""
+
+    @staticmethod
+    def list_recent_events(
+        db: sqlite3.Connection,
+        limit: int = ADMIN_DASHBOARD_RECENT_LIMIT,
+    ) -> list[DashboardRow]:
+        cursor = db.cursor()
+        try:
+            _ = cursor.execute(
+                """
+                SELECT id, title, location_name, severity_level, start_date, created_at, status
+                FROM events
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            )
+        except sqlite3.OperationalError as exc:
+            if AdminDashboardReadRepository._is_missing_table_error(exc):
+                return []
+            raise
+        return AdminDashboardReadRepository._fetch_dicts(cursor)
+
+    @staticmethod
+    def list_recent_alarms(
+        db: sqlite3.Connection,
+        limit: int = ADMIN_DASHBOARD_RECENT_LIMIT,
+    ) -> list[DashboardRow]:
+        cursor = db.cursor()
+        try:
+            _ = cursor.execute(
+                """
+                SELECT task_id, alarm_type, status, total_recipients, successful_sends, failed_sends, created_at
+                FROM alarm_tasks
+                ORDER BY created_at DESC
+                LIMIT ?
+                """,
+                (limit,),
+            )
+        except sqlite3.OperationalError as exc:
+            if AdminDashboardReadRepository._is_missing_table_error(exc):
+                return []
+            raise
+        return AdminDashboardReadRepository._fetch_dicts(cursor)
+
+    @staticmethod
+    def count_users(db: sqlite3.Connection) -> int:
+        cursor = db.cursor()
+        try:
+            _ = cursor.execute("SELECT COUNT(*) FROM users")
+        except sqlite3.OperationalError as exc:
+            if AdminDashboardReadRepository._is_missing_table_error(exc):
+                return 0
+            raise
+        result = cast(SqliteRowSequence | None, cursor.fetchone())
+        return cast(int, result[0]) if result else 0
+
+    @staticmethod
+    def list_paginated_users(
+        db: sqlite3.Connection,
+        *,
+        limit: int,
+        offset: int,
+    ) -> list[DashboardRow]:
+        try:
+            user_columns = AdminDashboardReadRepository._get_table_columns(db, USERS_TABLE_NAME)
+        except sqlite3.OperationalError as exc:
+            if AdminDashboardReadRepository._is_missing_table_error(exc):
+                return []
+            raise
+        if not user_columns:
+            return []
+        select_fields = list(PAGINATED_USER_BASE_FIELDS)
+
+        for column_name, sql in PAGINATED_USER_OPTIONAL_FIELDS.items():
+            if column_name in user_columns:
+                select_fields.append(sql)
+            elif column_name == "favorite_zone":
+                select_fields.append("0 as favorite_zone")
+            else:
+                select_fields.append(f"NULL as {column_name}")
+
+        cursor = db.cursor()
+        _ = cursor.execute(
+            f"""
+            SELECT {', '.join(select_fields)}
+            FROM users
+            ORDER BY id DESC
+            LIMIT ? OFFSET ?
+            """,
+            (limit, offset),
+        )
+        return AdminDashboardReadRepository._fetch_dicts(cursor)
+
+    @staticmethod
+    def _get_table_columns(db: sqlite3.Connection, table_name: str) -> set[str]:
+        if table_name not in ALLOWED_SCHEMA_TABLES:
+            raise ValueError(f"Unsupported table for dashboard schema inspection: {table_name}")
+
+        cursor = db.cursor()
+        _ = cursor.execute(f"PRAGMA table_info({table_name})")
+        columns: set[str] = set()
+        for row in cast(list[sqlite3.Row | SqliteRowSequence], cursor.fetchall()):
+            if isinstance(row, sqlite3.Row):
+                column_name = cast(object, row["name"])
+                columns.add(str(column_name))
+            else:
+                columns.add(str(row[1]))
+        return columns
+
+    @staticmethod
+    def _fetch_dicts(cursor: sqlite3.Cursor) -> list[DashboardRow]:
+        rows = cast(list[SqliteRowSequence], cursor.fetchall())
+        columns = [str(desc[0]) for desc in cursor.description or ()]
+        return [dict(zip(columns, row)) for row in rows]
+
+    @staticmethod
+    def _is_missing_table_error(exc: sqlite3.OperationalError) -> bool:
+        return "no such table" in str(exc).lower()

--- a/app/repositories/alarm_recipient_read_repository.py
+++ b/app/repositories/alarm_recipient_read_repository.py
@@ -1,0 +1,95 @@
+"""알림 수신자 읽기 저장소."""
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+
+RecipientGroups = Dict[str, List[str]]
+
+
+class AlarmRecipientReadRepository:
+    """알림 발송 대상 사용자 읽기 SQL을 담당한다."""
+
+    @staticmethod
+    def list_active_recipients(db: sqlite3.Connection) -> RecipientGroups:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            SELECT plusfriend_user_key
+            FROM users
+            WHERE active = 1
+              AND is_alarm_on = 1
+              AND plusfriend_user_key IS NOT NULL
+            """
+        )
+        plusfriend_users = AlarmRecipientReadRepository._dedupe(
+            [row["plusfriend_user_key"] for row in cursor.fetchall()]
+        )
+
+        cursor.execute(
+            """
+            SELECT bot_user_key
+            FROM users
+            WHERE active = 1
+              AND is_alarm_on = 1
+              AND plusfriend_user_key IS NULL
+              AND bot_user_key IS NOT NULL
+            """
+        )
+        bot_users = AlarmRecipientReadRepository._dedupe(
+            [row["bot_user_key"] for row in cursor.fetchall()]
+        )
+
+        return {
+            "plusfriend_user_keys": plusfriend_users,
+            "bot_user_keys": bot_users,
+        }
+
+    @staticmethod
+    def list_filtered_recipients(
+        db: sqlite3.Connection,
+        *,
+        filter_location: Optional[str],
+        filter_marked_bus: Optional[str],
+        filter_has_route: Optional[bool],
+    ) -> RecipientGroups:
+        query = """
+            SELECT plusfriend_user_key, bot_user_key
+            FROM users
+            WHERE active = 1 AND is_alarm_on = 1
+              AND (plusfriend_user_key IS NOT NULL OR bot_user_key IS NOT NULL)
+        """
+        params: List[Any] = []
+
+        if filter_location:
+            query += " AND location LIKE ?"
+            params.append(f"%{filter_location}%")
+
+        if filter_marked_bus:
+            query += " AND marked_bus = ?"
+            params.append(filter_marked_bus)
+
+        if filter_has_route is not None:
+            if filter_has_route:
+                query += " AND departure_x IS NOT NULL AND arrival_x IS NOT NULL"
+            else:
+                query += " AND (departure_x IS NULL OR arrival_x IS NULL)"
+
+        cursor = db.cursor()
+        cursor.execute(query, params)
+        rows = cursor.fetchall()
+
+        plusfriend_users_raw = [row["plusfriend_user_key"] for row in rows if row["plusfriend_user_key"] is not None]
+        bot_users_raw = [
+            row["bot_user_key"]
+            for row in rows
+            if row["plusfriend_user_key"] is None and row["bot_user_key"] is not None
+        ]
+
+        return {
+            "plusfriend_user_keys": AlarmRecipientReadRepository._dedupe(plusfriend_users_raw),
+            "bot_user_keys": AlarmRecipientReadRepository._dedupe(bot_users_raw),
+        }
+
+    @staticmethod
+    def _dedupe(values: List[str]) -> List[str]:
+        return list(dict.fromkeys(values))

--- a/app/repositories/alarm_task_repository.py
+++ b/app/repositories/alarm_task_repository.py
@@ -1,0 +1,146 @@
+"""alarm_tasks 테이블 저장소."""
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+
+class AlarmTaskRepository:
+    """호출자가 제공한 SQLite 연결로 alarm_tasks SQL을 실행한다."""
+
+    @staticmethod
+    def create_task(
+        db: sqlite3.Connection,
+        *,
+        task_id: str,
+        alarm_type: str,
+        total_recipients: int,
+        event_id: Optional[int],
+        request_data: Optional[str],
+        created_at: str,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            INSERT INTO alarm_tasks
+            (task_id, alarm_type, status, total_recipients, event_id, request_data, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                task_id,
+                alarm_type,
+                "pending",
+                total_recipients,
+                event_id,
+                request_data,
+                created_at,
+            ),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def update_status(
+        db: sqlite3.Connection,
+        *,
+        task_id: str,
+        status: str,
+        updated_at: str,
+        successful_sends: Optional[int] = None,
+        failed_sends: Optional[int] = None,
+        error_messages: Optional[str] = None,
+        total_recipients: Optional[int] = None,
+        completed_at: Optional[str] = None,
+    ) -> int:
+        update_fields = ["status = ?", "updated_at = ?"]
+        update_values: List[Any] = [status, updated_at]
+
+        if successful_sends is not None:
+            update_fields.append("successful_sends = ?")
+            update_values.append(successful_sends)
+
+        if failed_sends is not None:
+            update_fields.append("failed_sends = ?")
+            update_values.append(failed_sends)
+
+        if error_messages is not None:
+            update_fields.append("error_messages = ?")
+            update_values.append(error_messages)
+
+        if total_recipients is not None:
+            update_fields.append("total_recipients = ?")
+            update_values.append(total_recipients)
+
+        if completed_at is not None:
+            update_fields.append("completed_at = ?")
+            update_values.append(completed_at)
+
+        update_values.append(task_id)
+        cursor = db.cursor()
+        cursor.execute(
+            f"UPDATE alarm_tasks SET {', '.join(update_fields)} WHERE task_id = ?",
+            update_values,
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def get_status(
+        db: sqlite3.Connection,
+        task_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            SELECT
+                task_id, alarm_type, status, total_recipients,
+                successful_sends, failed_sends, event_id,
+                request_data, error_messages,
+                created_at, updated_at, completed_at
+            FROM alarm_tasks
+            WHERE task_id = ?
+            """,
+            (task_id,),
+        )
+
+        row = cursor.fetchone()
+        if not row:
+            return None
+
+        columns = [desc[0] for desc in cursor.description]
+        return dict(zip(columns, row))
+
+    @staticmethod
+    def list_recent(
+        db: sqlite3.Connection,
+        limit: int,
+    ) -> List[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            SELECT
+                task_id, alarm_type, status, total_recipients,
+                successful_sends, failed_sends, event_id,
+                created_at, updated_at, completed_at
+            FROM alarm_tasks
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+
+        rows = cursor.fetchall()
+        columns = [desc[0] for desc in cursor.description]
+        return [dict(zip(columns, row)) for row in rows]
+
+    @staticmethod
+    def delete_older_than(
+        db: sqlite3.Connection,
+        *,
+        cutoff_date: str,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            DELETE FROM alarm_tasks
+            WHERE created_at < ?
+            """,
+            (cutoff_date,),
+        )
+        return cursor.rowcount

--- a/app/repositories/event_bulk_import_repository.py
+++ b/app/repositories/event_bulk_import_repository.py
@@ -1,0 +1,52 @@
+"""크롤링 이벤트 bulk import 저장소."""
+import sqlite3
+from collections.abc import Sequence
+
+
+type EventBulkImportRow = tuple[
+    object,
+    object,
+    object,
+    object,
+    object,
+    object,
+    object,
+    object,
+    object,
+    object,
+    object,
+]
+
+EVENT_LOCATION_DATE_INDEX_NAME = "idx_events_location_date"
+
+
+class EventBulkImportRepository:
+    """호출자가 제공한 SQLite 연결로 크롤링 이벤트 bulk import SQL을 실행한다."""
+
+    @staticmethod
+    def ensure_location_date_unique_index(db: sqlite3.Connection) -> None:
+        cursor = db.cursor()
+        _ = cursor.execute(
+            f"""
+            CREATE UNIQUE INDEX IF NOT EXISTS {EVENT_LOCATION_DATE_INDEX_NAME}
+            ON events(location_name, start_date)
+            """
+        )
+
+    @staticmethod
+    def insert_or_ignore_events(
+        db: sqlite3.Connection,
+        rows: Sequence[EventBulkImportRow],
+    ) -> int:
+        cursor = db.cursor()
+        _ = cursor.executemany(
+            """
+            INSERT OR IGNORE INTO events (
+                title, description, location_name, location_address,
+                latitude, longitude, start_date, end_date,
+                category, severity_level, status
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        return cursor.rowcount

--- a/app/repositories/event_repository.py
+++ b/app/repositories/event_repository.py
@@ -1,0 +1,156 @@
+"""events 테이블 저장소."""
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+
+EVENT_COLUMNS = """
+    id, title, description, location_name, location_address,
+    latitude, longitude, start_date, end_date, category,
+    severity_level, status, created_at, updated_at
+"""
+
+
+class EventRepository:
+    """호출자가 제공한 SQLite 연결로 events SQL을 실행한다."""
+
+    @staticmethod
+    def create_event(
+        db: sqlite3.Connection,
+        *,
+        title: str,
+        description: Optional[str],
+        location_name: str,
+        location_address: Optional[str],
+        latitude: float,
+        longitude: float,
+        start_date: Any,
+        end_date: Any,
+        category: Optional[str],
+        severity_level: int,
+        status: str,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            INSERT INTO events (title, description, location_name, location_address,
+                                latitude, longitude, start_date, end_date, category,
+                                severity_level, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                title,
+                description,
+                location_name,
+                location_address,
+                latitude,
+                longitude,
+                start_date,
+                end_date,
+                category,
+                severity_level,
+                status,
+            ),
+        )
+        return int(cursor.lastrowid)
+
+    @staticmethod
+    def get_by_id(
+        db: sqlite3.Connection,
+        event_id: int,
+    ) -> Optional[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {EVENT_COLUMNS}
+            FROM events
+            WHERE id = ?
+            """,
+            (event_id,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+
+        columns = [desc[0] for desc in cursor.description]
+        return dict(zip(columns, row))
+
+    @staticmethod
+    def list_events(
+        db: sqlite3.Connection,
+        *,
+        category: Optional[str],
+        status: Optional[str],
+        limit: int,
+    ) -> List[Dict[str, Any]]:
+        where_conditions = []
+        params: List[Any] = []
+
+        if category:
+            where_conditions.append("category = ?")
+            params.append(category)
+
+        if status:
+            where_conditions.append("status = ?")
+            params.append(status)
+
+        where_clause = " WHERE " + " AND ".join(where_conditions) if where_conditions else ""
+        params.append(limit)
+
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {EVENT_COLUMNS}
+            FROM events{where_clause}
+            ORDER BY start_date DESC
+            LIMIT ?
+            """,
+            params,
+        )
+        return EventRepository._fetch_dicts(cursor)
+
+    @staticmethod
+    def list_upcoming(
+        db: sqlite3.Connection,
+        *,
+        now: str,
+        limit: int,
+    ) -> List[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {EVENT_COLUMNS}
+            FROM events
+            WHERE status = 'active' AND start_date >= ?
+            ORDER BY start_date ASC
+            LIMIT ?
+            """,
+            (now, limit),
+        )
+        return EventRepository._fetch_dicts(cursor)
+
+    @staticmethod
+    def list_today_by_location_pattern(
+        db: sqlite3.Connection,
+        *,
+        today: str,
+        location_pattern: str,
+    ) -> List[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {EVENT_COLUMNS}
+            FROM events
+            WHERE status = 'active'
+              AND date(start_date) = ?
+              AND (location_name LIKE ? OR location_address LIKE ?)
+            ORDER BY start_date ASC
+            """,
+            (today, location_pattern, location_pattern),
+        )
+        return EventRepository._fetch_dicts(cursor)
+
+    @staticmethod
+    def _fetch_dicts(cursor: sqlite3.Cursor) -> List[Dict[str, Any]]:
+        rows = cursor.fetchall()
+        columns = [desc[0] for desc in cursor.description]
+        return [dict(zip(columns, row)) for row in rows]

--- a/app/repositories/route_event_query_repository.py
+++ b/app/repositories/route_event_query_repository.py
@@ -1,0 +1,24 @@
+"""경로 기반 이벤트 조회 저장소."""
+import sqlite3
+from typing import Any, Dict, List
+
+from app.repositories.event_repository import EVENT_COLUMNS
+
+
+class RouteEventQueryRepository:
+    """호출자가 제공한 SQLite 연결로 route-check용 events SQL을 실행한다."""
+
+    @staticmethod
+    def list_active_future_events(db: sqlite3.Connection) -> List[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {EVENT_COLUMNS}
+            FROM events
+            WHERE status = 'active' AND start_date > datetime('now', '+9 hours')
+            ORDER BY start_date
+            """
+        )
+        rows = cursor.fetchall()
+        columns = [desc[0] for desc in cursor.description]
+        return [dict(zip(columns, row)) for row in rows]

--- a/app/repositories/user_identity_repository.py
+++ b/app/repositories/user_identity_repository.py
@@ -1,0 +1,321 @@
+"""사용자 식별 정보 저장소."""
+import sqlite3
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+IDENTITY_COLUMNS = """
+    id, bot_user_key, plusfriend_user_key, open_id, message_count, active
+"""
+
+
+class UserIdentityRepository:
+    """호출자가 제공한 SQLite 연결로 사용자 식별 SQL을 실행한다."""
+
+    @staticmethod
+    def find_by_bot_user_key(
+        db: sqlite3.Connection,
+        bot_user_key: str,
+    ) -> Optional[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {IDENTITY_COLUMNS}
+            FROM users
+            WHERE bot_user_key = ?
+            """,
+            (bot_user_key,),
+        )
+        return UserIdentityRepository._fetch_one_dict(cursor)
+
+    @staticmethod
+    def find_by_plusfriend_key(
+        db: sqlite3.Connection,
+        plusfriend_key: str,
+    ) -> Optional[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {IDENTITY_COLUMNS}
+            FROM users
+            WHERE plusfriend_user_key = ?
+            """,
+            (plusfriend_key,),
+        )
+        return UserIdentityRepository._fetch_one_dict(cursor)
+
+    @staticmethod
+    def find_by_open_id(
+        db: sqlite3.Connection,
+        open_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {IDENTITY_COLUMNS}
+            FROM users
+            WHERE open_id = ?
+            """,
+            (open_id,),
+        )
+        return UserIdentityRepository._fetch_one_dict(cursor)
+
+    @staticmethod
+    def find_oldest_unlinked_user(db: sqlite3.Connection) -> Optional[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            SELECT id, open_id
+            FROM users
+            WHERE bot_user_key IS NULL AND plusfriend_user_key IS NULL
+            ORDER BY first_message_at ASC, id ASC
+            LIMIT 1
+            """
+        )
+        return UserIdentityRepository._fetch_one_dict(cursor)
+
+    @staticmethod
+    def find_first_unlinked_user(db: sqlite3.Connection) -> Optional[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            SELECT id, open_id
+            FROM users
+            WHERE bot_user_key IS NULL AND plusfriend_user_key IS NULL
+            LIMIT 1
+            """
+        )
+        return UserIdentityRepository._fetch_one_dict(cursor)
+
+    @staticmethod
+    def insert_bot_user(
+        db: sqlite3.Connection,
+        *,
+        bot_user_key: str,
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            INSERT INTO users (bot_user_key, first_message_at, last_message_at, message_count)
+            VALUES (?, ?, ?, 1)
+            """,
+            (bot_user_key, now, now),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def insert_open_id_user(
+        db: sqlite3.Connection,
+        *,
+        open_id: str,
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            INSERT INTO users (open_id, first_message_at, last_message_at, message_count, active)
+            VALUES (?, ?, ?, 1, 1)
+            """,
+            (open_id, now, now),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def increment_bot_user_message(
+        db: sqlite3.Connection,
+        *,
+        bot_user_key: str,
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            UPDATE users
+            SET last_message_at = ?, message_count = message_count + 1
+            WHERE bot_user_key = ?
+            """,
+            (now, bot_user_key),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def touch_chat_plusfriend_user(
+        db: sqlite3.Connection,
+        *,
+        plusfriend_key: str,
+        bot_user_key: str,
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            UPDATE users
+            SET bot_user_key = ?,
+                last_message_at = ?,
+                message_count = message_count + 1
+            WHERE plusfriend_user_key = ?
+            """,
+            (bot_user_key, now, plusfriend_key),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def touch_plusfriend_user(
+        db: sqlite3.Connection,
+        *,
+        plusfriend_key: str,
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            UPDATE users
+            SET last_message_at = ?, message_count = message_count + 1, active = 1
+            WHERE plusfriend_user_key = ?
+            """,
+            (now, plusfriend_key),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def set_active_by_plusfriend_key(
+        db: sqlite3.Connection,
+        *,
+        plusfriend_key: str,
+        active: bool,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            UPDATE users
+            SET active = ?
+            WHERE plusfriend_user_key = ?
+            """,
+            (active, plusfriend_key),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def set_active_by_open_id(
+        db: sqlite3.Connection,
+        *,
+        open_id: str,
+        active: bool,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            UPDATE users
+            SET active = ?
+            WHERE open_id = ?
+            """,
+            (active, open_id),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def set_bot_user_key_for_plusfriend(
+        db: sqlite3.Connection,
+        *,
+        plusfriend_key: str,
+        bot_user_key: str,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            UPDATE users
+            SET bot_user_key = ?
+            WHERE plusfriend_user_key = ?
+            """,
+            (bot_user_key, plusfriend_key),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def link_plusfriend_to_bot(
+        db: sqlite3.Connection,
+        *,
+        bot_user_key: str,
+        plusfriend_key: str,
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            UPDATE users
+            SET plusfriend_user_key = ?, last_message_at = ?, message_count = message_count + 1, active = 1
+            WHERE bot_user_key = ?
+            """,
+            (plusfriend_key, now, bot_user_key),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def link_unlinked_user_from_chat(
+        db: sqlite3.Connection,
+        *,
+        user_id: int,
+        bot_user_key: str,
+        plusfriend_key: str,
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            UPDATE users
+            SET bot_user_key = ?,
+                plusfriend_user_key = ?,
+                last_message_at = ?
+            WHERE id = ?
+            """,
+            (bot_user_key, plusfriend_key, now, user_id),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def link_orphan_identity(
+        db: sqlite3.Connection,
+        *,
+        user_id: int,
+        bot_user_key: str,
+        plusfriend_key: str,
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            UPDATE users
+            SET bot_user_key = ?, plusfriend_user_key = ?, last_message_at = ?, active = 1
+            WHERE id = ?
+            """,
+            (bot_user_key, plusfriend_key, now, user_id),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def insert_kakao_identity(
+        db: sqlite3.Connection,
+        *,
+        bot_user_key: str,
+        plusfriend_key: str,
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            INSERT INTO users (bot_user_key, plusfriend_user_key, first_message_at, last_message_at, message_count, active)
+            VALUES (?, ?, ?, ?, 1, 1)
+            """,
+            (bot_user_key, plusfriend_key, now, now),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def _fetch_one_dict(cursor: sqlite3.Cursor) -> Optional[Dict[str, Any]]:
+        row = cursor.fetchone()
+        if not row:
+            return None
+
+        columns = [desc[0] for desc in cursor.description]
+        return dict(zip(columns, row))

--- a/app/repositories/user_preference_repository.py
+++ b/app/repositories/user_preference_repository.py
@@ -1,0 +1,43 @@
+"""사용자 개인화 설정 저장소."""
+import sqlite3
+from typing import Any, Optional
+
+
+class UserPreferenceRepository:
+    """bot_user_key 기준 사용자 선호 설정 SQL을 실행한다."""
+
+    @staticmethod
+    def exists_by_bot_user_key(db: sqlite3.Connection, user_id: str) -> bool:
+        cursor = db.cursor()
+        cursor.execute("SELECT id FROM users WHERE bot_user_key = ?", (user_id,))
+        return cursor.fetchone() is not None
+
+    @staticmethod
+    def update_preferences(
+        db: sqlite3.Connection,
+        *,
+        user_id: str,
+        marked_bus: Optional[str],
+        language: Optional[str],
+    ) -> int:
+        update_fields = []
+        update_values: list[Any] = []
+
+        if marked_bus:
+            update_fields.append("marked_bus = ?")
+            update_values.append(marked_bus)
+
+        if language:
+            update_fields.append("language = ?")
+            update_values.append(language)
+
+        if not update_fields:
+            return 0
+
+        update_values.append(user_id)
+        cursor = db.cursor()
+        cursor.execute(
+            f"UPDATE users SET {', '.join(update_fields)} WHERE bot_user_key = ?",
+            update_values,
+        )
+        return cursor.rowcount

--- a/app/repositories/user_profile_repository.py
+++ b/app/repositories/user_profile_repository.py
@@ -1,0 +1,59 @@
+"""사용자 프로필 쓰기 저장소."""
+import sqlite3
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+
+class UserProfileRepository:
+    """호출자가 제공한 SQLite 연결로 사용자 profile SQL을 실행한다."""
+
+    @staticmethod
+    def update_profile(
+        db: sqlite3.Connection,
+        *,
+        plusfriend_user_key: str,
+        departure_info: Optional[Dict[str, Any]],
+        arrival_info: Optional[Dict[str, Any]],
+        marked_bus: Optional[str],
+        language: Optional[str],
+        now: datetime,
+    ) -> int:
+        update_query = "UPDATE users SET route_updated_at = ?"
+        params: List[Any] = [now]
+
+        if departure_info:
+            update_query += ", departure_name=?, departure_address=?, departure_x=?, departure_y=?"
+            params.extend(
+                [
+                    departure_info["name"],
+                    departure_info["address"],
+                    departure_info["x"],
+                    departure_info["y"],
+                ]
+            )
+
+        if arrival_info:
+            update_query += ", arrival_name=?, arrival_address=?, arrival_x=?, arrival_y=?"
+            params.extend(
+                [
+                    arrival_info["name"],
+                    arrival_info["address"],
+                    arrival_info["x"],
+                    arrival_info["y"],
+                ]
+            )
+
+        if marked_bus:
+            update_query += ", marked_bus=?"
+            params.append(marked_bus)
+
+        if language:
+            update_query += ", language=?"
+            params.append(language)
+
+        update_query += " WHERE plusfriend_user_key = ?"
+        params.append(plusfriend_user_key)
+
+        cursor = db.cursor()
+        cursor.execute(update_query, params)
+        return cursor.rowcount

--- a/app/repositories/user_read_repository.py
+++ b/app/repositories/user_read_repository.py
@@ -1,0 +1,108 @@
+"""사용자 읽기 저장소."""
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+
+USER_INFO_FIELDS = """
+    is_alarm_on, favorite_zone, marked_bus,
+    departure_name, arrival_name,
+    plusfriend_user_key, bot_user_key
+"""
+
+USER_ROUTE_INFO_FIELDS = """
+    departure_name, departure_address, departure_x, departure_y,
+    arrival_name, arrival_address, arrival_x, arrival_y,
+    route_updated_at
+"""
+
+USER_LIST_FIELDS = """
+    bot_user_key, first_message_at, last_message_at, message_count,
+    location, active, departure_name, departure_address,
+    departure_x, departure_y, arrival_name, arrival_address,
+    arrival_x, arrival_y, route_updated_at, marked_bus, language
+"""
+
+
+class UserReadRepository:
+    """호출자가 제공한 SQLite 연결로 사용자 read SQL을 실행한다."""
+
+    @staticmethod
+    def list_users_with_route_info(db: sqlite3.Connection) -> List[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {USER_LIST_FIELDS}
+            FROM users
+            ORDER BY last_message_at DESC
+            """
+        )
+        return UserReadRepository._fetch_dicts(cursor)
+
+    @staticmethod
+    def get_route_info_by_bot_user_key(
+        db: sqlite3.Connection,
+        bot_user_key: str,
+    ) -> Optional[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {USER_ROUTE_INFO_FIELDS}
+            FROM users
+            WHERE bot_user_key = ?
+            """,
+            (bot_user_key,),
+        )
+        return UserReadRepository._fetch_one_dict(cursor)
+
+    @staticmethod
+    def get_user_info(
+        db: sqlite3.Connection,
+        user_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        row = UserReadRepository._find_user_info_by_identifier(
+            db,
+            identifier_column="plusfriend_user_key",
+            user_id=user_id,
+        )
+        if row:
+            return row
+
+        return UserReadRepository._find_user_info_by_identifier(
+            db,
+            identifier_column="bot_user_key",
+            user_id=user_id,
+        )
+
+    @staticmethod
+    def _find_user_info_by_identifier(
+        db: sqlite3.Connection,
+        *,
+        identifier_column: str,
+        user_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {USER_INFO_FIELDS}
+            FROM users
+            WHERE {identifier_column} = ?
+            LIMIT 1
+            """,
+            (user_id,),
+        )
+        return UserReadRepository._fetch_one_dict(cursor)
+
+    @staticmethod
+    def _fetch_one_dict(cursor: sqlite3.Cursor) -> Optional[Dict[str, Any]]:
+        row = cursor.fetchone()
+        if not row:
+            return None
+
+        columns = [desc[0] for desc in cursor.description]
+        return dict(zip(columns, row))
+
+    @staticmethod
+    def _fetch_dicts(cursor: sqlite3.Cursor) -> List[Dict[str, Any]]:
+        rows = cursor.fetchall()
+        columns = [desc[0] for desc in cursor.description]
+        return [dict(zip(columns, row)) for row in rows]

--- a/app/repositories/user_route_read_repository.py
+++ b/app/repositories/user_route_read_repository.py
@@ -1,0 +1,80 @@
+"""사용자 경로 읽기 저장소."""
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+
+ROUTE_FIELDS = """
+    departure_name, departure_address, departure_x, departure_y,
+    arrival_name, arrival_address, arrival_x, arrival_y
+"""
+
+
+class UserRouteReadRepository:
+    """사용자 경로 조회 SQL을 담당한다."""
+
+    @staticmethod
+    def get_route_for_user(
+        db: sqlite3.Connection,
+        user_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            SELECT {ROUTE_FIELDS}
+            FROM users
+            WHERE plusfriend_user_key = ? OR bot_user_key = ?
+            """,
+            (user_id, user_id),
+        )
+        return UserRouteReadRepository._fetch_one_dict(cursor)
+
+    @staticmethod
+    def list_scheduled_route_users(db: sqlite3.Connection) -> List[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            SELECT plusfriend_user_key, departure_name, arrival_name
+            FROM users
+            WHERE active = 1
+              AND is_alarm_on = 1
+              AND plusfriend_user_key IS NOT NULL
+              AND departure_x IS NOT NULL
+              AND departure_y IS NOT NULL
+              AND arrival_x IS NOT NULL
+              AND arrival_y IS NOT NULL
+            """
+        )
+        return UserRouteReadRepository._fetch_dicts(cursor)
+
+    @staticmethod
+    def list_auto_check_route_user_ids(db: sqlite3.Connection) -> List[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            SELECT COALESCE(plusfriend_user_key, bot_user_key) as user_id
+            FROM users
+            WHERE active = 1
+              AND is_alarm_on = 1
+              AND departure_x IS NOT NULL
+              AND departure_y IS NOT NULL
+              AND arrival_x IS NOT NULL
+              AND arrival_y IS NOT NULL
+              AND (plusfriend_user_key IS NOT NULL OR bot_user_key IS NOT NULL)
+            """
+        )
+        return UserRouteReadRepository._fetch_dicts(cursor)
+
+    @staticmethod
+    def _fetch_one_dict(cursor: sqlite3.Cursor) -> Optional[Dict[str, Any]]:
+        row = cursor.fetchone()
+        if not row:
+            return None
+
+        columns = [desc[0] for desc in cursor.description]
+        return dict(zip(columns, row))
+
+    @staticmethod
+    def _fetch_dicts(cursor: sqlite3.Cursor) -> List[Dict[str, Any]]:
+        rows = cursor.fetchall()
+        columns = [desc[0] for desc in cursor.description]
+        return [dict(zip(columns, row)) for row in rows]

--- a/app/repositories/user_route_repository.py
+++ b/app/repositories/user_route_repository.py
@@ -1,0 +1,86 @@
+"""사용자 경로 쓰기 저장소."""
+import sqlite3
+from datetime import datetime
+from typing import Any, Dict
+
+
+class UserRouteRepository:
+    """호출자가 제공한 SQLite 연결로 사용자 route SQL을 실행한다."""
+
+    @staticmethod
+    def update_route(
+        db: sqlite3.Connection,
+        *,
+        user_id: str,
+        departure_info: Dict[str, Any],
+        arrival_info: Dict[str, Any],
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            UPDATE users SET
+                departure_name = ?, departure_address = ?, departure_x = ?, departure_y = ?,
+                arrival_name = ?, arrival_address = ?, arrival_x = ?, arrival_y = ?,
+                route_updated_at = ?
+            WHERE plusfriend_user_key = ?
+            """,
+            (
+                departure_info["name"],
+                departure_info["address"],
+                departure_info["x"],
+                departure_info["y"],
+                arrival_info["name"],
+                arrival_info["address"],
+                arrival_info["x"],
+                arrival_info["y"],
+                now,
+                user_id,
+            ),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def clear_route(
+        db: sqlite3.Connection,
+        *,
+        user_id: str,
+        now: datetime,
+    ) -> int:
+        rowcount = UserRouteRepository._clear_route_by_identifier(
+            db,
+            identifier_column="plusfriend_user_key",
+            user_id=user_id,
+            now=now,
+        )
+        if rowcount == 0:
+            rowcount = UserRouteRepository._clear_route_by_identifier(
+                db,
+                identifier_column="bot_user_key",
+                user_id=user_id,
+                now=now,
+            )
+        return rowcount
+
+    @staticmethod
+    def _clear_route_by_identifier(
+        db: sqlite3.Connection,
+        *,
+        identifier_column: str,
+        user_id: str,
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            UPDATE users SET
+                departure_name = NULL, departure_address = NULL,
+                departure_x = NULL, departure_y = NULL,
+                arrival_name = NULL, arrival_address = NULL,
+                arrival_x = NULL, arrival_y = NULL,
+                route_updated_at = ?
+            WHERE {identifier_column} = ?
+            """,
+            (now, user_id),
+        )
+        return cursor.rowcount

--- a/app/repositories/user_settings_repository.py
+++ b/app/repositories/user_settings_repository.py
@@ -1,0 +1,122 @@
+"""사용자 설정 저장소."""
+import sqlite3
+from datetime import datetime
+from typing import Optional
+
+
+class UserSettingsRepository:
+    """plusfriend 우선, bot fallback 규칙을 유지하는 사용자 설정 SQL."""
+
+    @staticmethod
+    def update_alarm_setting(
+        db: sqlite3.Connection,
+        *,
+        user_id: str,
+        is_alarm_on: bool,
+    ) -> int:
+        rowcount = UserSettingsRepository._update_single_value(
+            db,
+            column="is_alarm_on",
+            value=is_alarm_on,
+            identifier_column="plusfriend_user_key",
+            user_id=user_id,
+        )
+        if rowcount == 0:
+            rowcount = UserSettingsRepository._update_single_value(
+                db,
+                column="is_alarm_on",
+                value=is_alarm_on,
+                identifier_column="bot_user_key",
+                user_id=user_id,
+            )
+        return rowcount
+
+    @staticmethod
+    def update_favorite_zone(
+        db: sqlite3.Connection,
+        *,
+        user_id: str,
+        zone: Optional[int],
+    ) -> int:
+        rowcount = UserSettingsRepository._update_single_value(
+            db,
+            column="favorite_zone",
+            value=zone,
+            identifier_column="plusfriend_user_key",
+            user_id=user_id,
+        )
+        if rowcount == 0:
+            rowcount = UserSettingsRepository._update_single_value(
+                db,
+                column="favorite_zone",
+                value=zone,
+                identifier_column="bot_user_key",
+                user_id=user_id,
+            )
+        return rowcount
+
+    @staticmethod
+    def update_marked_bus(
+        db: sqlite3.Connection,
+        *,
+        user_id: str,
+        marked_bus: str,
+        now: datetime,
+    ) -> int:
+        rowcount = UserSettingsRepository._update_marked_bus_by_identifier(
+            db,
+            identifier_column="plusfriend_user_key",
+            user_id=user_id,
+            marked_bus=marked_bus,
+            now=now,
+        )
+        if rowcount == 0:
+            rowcount = UserSettingsRepository._update_marked_bus_by_identifier(
+                db,
+                identifier_column="bot_user_key",
+                user_id=user_id,
+                marked_bus=marked_bus,
+                now=now,
+            )
+        return rowcount
+
+    @staticmethod
+    def _update_single_value(
+        db: sqlite3.Connection,
+        *,
+        column: str,
+        value: object,
+        identifier_column: str,
+        user_id: str,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            UPDATE users
+            SET {column} = ?
+            WHERE {identifier_column} = ?
+            """,
+            (value, user_id),
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def _update_marked_bus_by_identifier(
+        db: sqlite3.Connection,
+        *,
+        identifier_column: str,
+        user_id: str,
+        marked_bus: str,
+        now: datetime,
+    ) -> int:
+        cursor = db.cursor()
+        cursor.execute(
+            f"""
+            UPDATE users
+            SET marked_bus = ?,
+                last_message_at = ?
+            WHERE {identifier_column} = ?
+            """,
+            (marked_bus, now, user_id),
+        )
+        return cursor.rowcount

--- a/app/repositories/zone_alarm_read_repository.py
+++ b/app/repositories/zone_alarm_read_repository.py
@@ -1,0 +1,45 @@
+"""구역 알림 읽기 저장소."""
+import sqlite3
+from typing import Any, Dict, List
+
+
+class ZoneAlarmReadRepository:
+    """구역 알림 사용자/이벤트 읽기 SQL을 담당한다."""
+
+    @staticmethod
+    def list_zone_users(db: sqlite3.Connection) -> List[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            SELECT plusfriend_user_key, favorite_zone
+            FROM users
+            WHERE active = 1
+              AND is_alarm_on = 1
+              AND favorite_zone IS NOT NULL
+              AND plusfriend_user_key IS NOT NULL
+            """
+        )
+        return ZoneAlarmReadRepository._fetch_dicts(cursor)
+
+    @staticmethod
+    def list_active_future_events(db: sqlite3.Connection) -> List[Dict[str, Any]]:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            SELECT id, title, location_name, location_address,
+                   latitude, longitude, start_date, category, severity_level
+            FROM events
+            WHERE status = 'active'
+              AND latitude IS NOT NULL
+              AND longitude IS NOT NULL
+              AND start_date > datetime('now', '+9 hours')
+            ORDER BY start_date
+            """
+        )
+        return ZoneAlarmReadRepository._fetch_dicts(cursor)
+
+    @staticmethod
+    def _fetch_dicts(cursor: sqlite3.Cursor) -> List[Dict[str, Any]]:
+        rows = cursor.fetchall()
+        columns = [desc[0] for desc in cursor.description]
+        return [dict(zip(columns, row)) for row in rows]

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -3,7 +3,7 @@ import secrets
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Dict, Any, List, Set
+from typing import Dict, Any, List
 
 from fastapi import APIRouter, Depends, HTTPException, status, Request, Query
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
@@ -11,6 +11,7 @@ from fastapi.templating import Jinja2Templates
 
 from app.database.connection import get_db_connection
 from app.config.settings import settings
+from app.repositories.admin_dashboard_read_repository import AdminDashboardReadRepository
 import math
 
 from app.utils.scheduler_utils import get_scheduler_status
@@ -122,92 +123,24 @@ def verify_csrf_origin(request: Request):
         raise HTTPException(status_code=403, detail="Forbidden: CSRF/Origin mismatch")
 
 def fetch_recent_events() -> List[Dict[str, Any]]:
-    # Synchronous DB query
     with get_db_connection() as conn:
-        conn.row_factory = dict_factory
-        cursor = conn.cursor()
-        cursor.execute("""
-            SELECT id, title, location_name, severity_level, start_date, created_at, status 
-            FROM events 
-            ORDER BY id DESC 
-            LIMIT 100
-        """)
-        return cursor.fetchall()
+        return AdminDashboardReadRepository.list_recent_events(conn)
 
 def fetch_recent_alarms() -> List[Dict[str, Any]]:
-    # Synchronous DB query
     with get_db_connection() as conn:
-        conn.row_factory = dict_factory
-        cursor = conn.cursor()
-        cursor.execute("""
-            SELECT task_id, alarm_type, status, total_recipients, successful_sends, failed_sends, created_at
-            FROM alarm_tasks 
-            ORDER BY created_at DESC 
-            LIMIT 100
-        """)
-        return cursor.fetchall()
-
-# Helper for sqlite row to dict
-def dict_factory(cursor, row):
-    d = {}
-    for idx, col in enumerate(cursor.description):
-        d[col[0]] = row[idx]
-    return d
+        return AdminDashboardReadRepository.list_recent_alarms(conn)
 
 def get_total_users() -> int:
     with get_db_connection() as conn:
-        cursor = conn.cursor()
-        cursor.execute("SELECT COUNT(*) FROM users")
-        result = cursor.fetchone()
-        return result[0] if result else 0
-
-def _get_table_columns(cursor, table_name: str) -> Set[str]:
-    cursor.execute(f"PRAGMA table_info({table_name})")
-    columns = set()
-    for row in cursor.fetchall():
-        if isinstance(row, dict):
-            columns.add(row["name"])
-        else:
-            columns.add(row[1])
-    return columns
+        return AdminDashboardReadRepository.count_users(conn)
 
 def fetch_paginated_users(limit: int, offset: int) -> List[Dict[str, Any]]:
     with get_db_connection() as conn:
-        conn.row_factory = dict_factory
-        cursor = conn.cursor()
-
-        user_columns = _get_table_columns(cursor, "users")
-        select_fields = [
-            "id",
-            "bot_user_key",
-            "active",
-            "departure_name",
-            "arrival_name",
-            "marked_bus",
-            "first_message_at as created_at",
-            "message_count",
-        ]
-
-        optional_fields = {
-            "plusfriend_user_key": "plusfriend_user_key",
-            "open_id": "open_id",
-            "is_alarm_on": "is_alarm_on",
-            "favorite_zone": "COALESCE(favorite_zone, 0) as favorite_zone",
-        }
-
-        for column_name, sql in optional_fields.items():
-            if column_name in user_columns:
-                select_fields.append(sql)
-            else:
-                select_fields.append(f"NULL as {column_name}" if column_name != "favorite_zone" else "0 as favorite_zone")
-
-        cursor.execute(f"""
-            SELECT {', '.join(select_fields)}
-            FROM users
-            ORDER BY id DESC
-            LIMIT ? OFFSET ?
-        """, (limit, offset))
-        return cursor.fetchall()
+        return AdminDashboardReadRepository.list_paginated_users(
+            conn,
+            limit=limit,
+            offset=offset,
+        )
 
 def _format_user_created_at(value: Any) -> str:
     if value in (None, ""):

--- a/app/routers/alarms.py
+++ b/app/routers/alarms.py
@@ -10,6 +10,7 @@ from app.models.responses import (
     BulkAlarmSendResponse, FilteredAlarmSendResponse, CleanupResponse, ErrorResponse
 )
 from app.database.connection import get_db
+from app.repositories.alarm_recipient_read_repository import AlarmRecipientReadRepository
 from app.services.notification_service import NotificationService
 from app.services.alarm_status_service import AlarmStatusService
 from app.services.auth_service import verify_api_key
@@ -99,14 +100,9 @@ async def send_alarm_to_all(
 ):
     """전체 활성 사용자에게 알림 전송"""
     try:
-        cursor = db.cursor()
-        # plusfriend_user_key 우선 조회
-        cursor.execute("SELECT plusfriend_user_key FROM users WHERE active = 1 AND is_alarm_on = 1 AND plusfriend_user_key IS NOT NULL")
-        plusfriend_users = list(dict.fromkeys([row["plusfriend_user_key"] for row in cursor.fetchall()]))
-
-        # bot_user_key만 있는 사용자
-        cursor.execute("SELECT bot_user_key FROM users WHERE active = 1 AND is_alarm_on = 1 AND plusfriend_user_key IS NULL AND bot_user_key IS NOT NULL")
-        bot_users = list(dict.fromkeys([row["bot_user_key"] for row in cursor.fetchall()]))
+        recipients = AlarmRecipientReadRepository.list_active_recipients(db)
+        plusfriend_users = recipients["plusfriend_user_keys"]
+        bot_users = recipients["bot_user_keys"]
         
         if not plusfriend_users and not bot_users:
             raise HTTPException(status_code=404, detail="활성 사용자가 없습니다")
@@ -167,39 +163,14 @@ async def send_filtered_alarm(
 ):
     """필터링된 사용자에게 알림 전송"""
     try:
-        cursor = db.cursor()
-        
-        # 기본 쿼리
-        query = """
-            SELECT plusfriend_user_key, bot_user_key 
-            FROM users 
-            WHERE active = 1 AND is_alarm_on = 1
-            AND (plusfriend_user_key IS NOT NULL OR bot_user_key IS NOT NULL)
-        """
-        params = []
-        
-        # 필터 조건 추가
-        if request.filter_location:
-            query += " AND location LIKE ?"
-            params.append(f"%{request.filter_location}%")
-        
-        if request.filter_marked_bus:
-            query += " AND marked_bus = ?"
-            params.append(request.filter_marked_bus)
-        
-        if request.filter_has_route is not None:
-            if request.filter_has_route:
-                query += " AND departure_x IS NOT NULL AND arrival_x IS NOT NULL"
-            else:
-                query += " AND (departure_x IS NULL OR arrival_x IS NULL)"
-        
-        cursor.execute(query, params)
-        rows = cursor.fetchall()
-        
-        plusfriend_users_raw = [r[0] for r in rows if r[0] is not None]
-        bot_users_raw = [r[1] for r in rows if r[0] is None and r[1] is not None]
-        plusfriend_users = list(dict.fromkeys(plusfriend_users_raw))
-        bot_users = list(dict.fromkeys(bot_users_raw))
+        recipients = AlarmRecipientReadRepository.list_filtered_recipients(
+            db,
+            filter_location=request.filter_location,
+            filter_marked_bus=request.filter_marked_bus,
+            filter_has_route=request.filter_has_route,
+        )
+        plusfriend_users = recipients["plusfriend_user_keys"]
+        bot_users = recipients["bot_user_keys"]
         
         if not plusfriend_users and not bot_users:
             raise HTTPException(status_code=404, detail="조건에 맞는 사용자가 없습니다")

--- a/app/routers/events.py
+++ b/app/routers/events.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import logging
 import asyncio
 
-from app.models.event import EventCreate, EventResponse, RouteEventCheck
+from app.models.event import EventCreate, EventResponse
 from app.database.connection import get_db
 from app.services.event_service import EventService
 from app.services.auth_service import verify_api_key
@@ -23,21 +23,8 @@ async def create_event(
     """새로운 집회/이벤트 생성"""
     result = EventService.create_event(event_data, db)
     
-    if result["success"]:
-        # 생성된 이벤트 조회
-        cursor = db.cursor()
-        cursor.execute("SELECT * FROM events WHERE id = ?", (result["event_id"],))
-        row = cursor.fetchone()
-        
-        if row:
-            return EventResponse(
-                id=row["id"], title=row["title"], description=row["description"],
-                location_name=row["location_name"], location_address=row["location_address"],
-                latitude=row["latitude"], longitude=row["longitude"],
-                start_date=row["start_date"], end_date=row["end_date"], category=row["category"],
-                severity_level=row["severity_level"], status=row["status"],
-                created_at=row["created_at"], updated_at=row["updated_at"]
-            )
+    if result["success"] and result.get("event"):
+        return result["event"]
     
     raise HTTPException(status_code=400, detail=result.get("error", "이벤트 생성에 실패했습니다"))
 
@@ -136,22 +123,8 @@ async def auto_check_all_routes(
     모든 사용자의 경로를 확인하고 집회 발견 시 자동 알림 전송
     (관리자용 또는 수동 트리거)
     """
-    cursor = db.cursor()
-
     # 경로 등록된 활성 사용자 조회 (plusfriend_user_key 우선)
-    cursor.execute('''
-        SELECT COALESCE(plusfriend_user_key, bot_user_key) as user_id
-        FROM users
-        WHERE active = 1
-        AND is_alarm_on = 1
-        AND departure_x IS NOT NULL
-        AND departure_y IS NOT NULL
-        AND arrival_x IS NOT NULL
-        AND arrival_y IS NOT NULL
-        AND (plusfriend_user_key IS NOT NULL OR bot_user_key IS NOT NULL)
-    ''')
-    
-    users = cursor.fetchall()
+    users = EventService.list_auto_check_route_user_ids(db)
     
     # 병렬 처리를 위한 태스크 생성
     async def process_user(user_id: str):

--- a/app/routers/kakao.py
+++ b/app/routers/kakao.py
@@ -3,8 +3,11 @@ from fastapi import APIRouter, Request, HTTPException
 import logging
 import json
 from datetime import datetime
+from typing import Any, cast
 
+from app.database.connection import get_db_connection
 from app.models.kakao import KakaoRequest
+from app.repositories.user_identity_repository import UserIdentityRepository
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/kakao", tags=["kakao"])
@@ -18,53 +21,51 @@ async def kakao_chat_fallback(request: KakaoRequest):
     """
     user_message = request.userRequest.utterance
     bot_user_key = request.userRequest.user.id
-    properties = request.userRequest.user.properties
-    plusfriend_key = properties.get('plusfriendUserKey') if properties else None
+    properties = cast(dict[str, Any], request.userRequest.user.properties or {})
+    plusfriend_value = properties.get('plusfriendUserKey')
+    plusfriend_key = plusfriend_value if isinstance(plusfriend_value, str) else None
 
     logger.info(f"📨 사용자 메시지: {user_message} (botUserKey: {bot_user_key}, plusfriend: {plusfriend_key})")
 
-    from app.database.connection import get_db_connection
-
     with get_db_connection() as db:
-        cursor = db.cursor()
-
         # plusfriend_user_key로 기존 사용자 조회 (가장 안정적)
         if plusfriend_key:
-            cursor.execute(
-                "SELECT bot_user_key, open_id FROM users WHERE plusfriend_user_key = ?",
-                (plusfriend_key,)
-            )
-            existing = cursor.fetchone()
+            existing = UserIdentityRepository.find_by_plusfriend_key(db, plusfriend_key)
+            now = datetime.now()
 
             if existing:
                 # 이미 존재 → bot_user_key 업데이트
-                cursor.execute(
-                    "UPDATE users SET bot_user_key = ?, last_message_at = ?, message_count = message_count + 1 WHERE plusfriend_user_key = ?",
-                    (bot_user_key, datetime.now(), plusfriend_key)
+                UserIdentityRepository.touch_chat_plusfriend_user(
+                    db,
+                    plusfriend_key=plusfriend_key,
+                    bot_user_key=bot_user_key,
+                    now=now,
                 )
                 db.commit()
                 logger.info(f"사용자 업데이트: plusfriend={plusfriend_key}")
             else:
                 # 웹훅 사용자 찾기 시도
-                cursor.execute(
-                    "SELECT id FROM users WHERE bot_user_key IS NULL AND plusfriend_user_key IS NULL LIMIT 1"
-                )
-                orphan = cursor.fetchone()
+                orphan = UserIdentityRepository.find_first_unlinked_user(db)
 
                 if orphan:
                     # 웹훅 사용자 연결
-                    cursor.execute(
-                        "UPDATE users SET bot_user_key = ?, plusfriend_user_key = ?, last_message_at = ? WHERE id = ?",
-                        (bot_user_key, plusfriend_key, datetime.now(), orphan["id"])
+                    UserIdentityRepository.link_unlinked_user_from_chat(
+                        db,
+                        user_id=orphan["id"],
+                        bot_user_key=bot_user_key,
+                        plusfriend_key=plusfriend_key,
+                        now=now,
                     )
                     db.commit()
                     logger.info(f"✅ 웹훅 사용자 연결: botUserKey={bot_user_key}, plusfriend={plusfriend_key}")
                 else:
                     # 완전 신규 사용자
-                    cursor.execute('''
-                        INSERT INTO users (bot_user_key, plusfriend_user_key, first_message_at, last_message_at, message_count, active)
-                        VALUES (?, ?, ?, ?, 1, 1)
-                    ''', (bot_user_key, plusfriend_key, datetime.now(), datetime.now()))
+                    UserIdentityRepository.insert_kakao_identity(
+                        db,
+                        bot_user_key=bot_user_key,
+                        plusfriend_key=plusfriend_key,
+                        now=now,
+                    )
                     db.commit()
                     logger.info(f"새 사용자 등록: botUserKey={bot_user_key}, plusfriend={plusfriend_key}")
 
@@ -102,47 +103,52 @@ async def kakao_channel_webhook(request: Request):
     카카오톡 채널 추가/차단 웹훅 엔드포인트
     웹훅에서는 open_id만 제공됨
     """
-    body = await request.json()
+    body = cast(dict[str, Any], await request.json())
     logger.info(f"🔗 카카오 채널 웹훅 수신: {json.dumps(body, ensure_ascii=False)}")
 
-    event = body.get('event', '')
-    open_id = body.get('id', '')
+    event_value = body.get('event', '')
+    open_id_value = body.get('id', '')
+    event = event_value if isinstance(event_value, str) else ""
+    open_id = open_id_value if isinstance(open_id_value, str) else ""
 
     if not open_id:
         logger.warning("사용자 ID가 없는 웹훅 요청")
         return {"status": "error", "message": "사용자 ID 필요"}
 
-    from app.database.connection import get_db_connection
-
     try:
         with get_db_connection() as db:
-            cursor = db.cursor()
-
             # open_id로 기존 사용자 조회 (plusfriend_user_key도 확인)
-            cursor.execute(
-                "SELECT bot_user_key, plusfriend_user_key, active FROM users WHERE open_id = ?",
-                (open_id,)
-            )
-            existing_user = cursor.fetchone()
+            existing_user = UserIdentityRepository.find_by_open_id(db, open_id)
+            now = datetime.now()
 
             if event == 'added' or event == 'chat_room':
                 logger.info(f"✅ 채널 추가: open_id={open_id}")
 
                 if existing_user:
                     # 이미 존재 → active만 업데이트
-                    plusfriend_key = existing_user["plusfriend_user_key"]
+                    plusfriend_value = existing_user["plusfriend_user_key"]
+                    plusfriend_key = plusfriend_value if isinstance(plusfriend_value, str) else None
                     if plusfriend_key:
                         # plusfriend_key로 업데이트 (더 안정적)
-                        cursor.execute("UPDATE users SET active = 1 WHERE plusfriend_user_key = ?", (plusfriend_key,))
+                        UserIdentityRepository.set_active_by_plusfriend_key(
+                            db,
+                            plusfriend_key=plusfriend_key,
+                            active=True,
+                        )
                     else:
-                        cursor.execute("UPDATE users SET active = 1 WHERE open_id = ?", (open_id,))
+                        UserIdentityRepository.set_active_by_open_id(
+                            db,
+                            open_id=open_id,
+                            active=True,
+                        )
                     db.commit()
                 else:
                     # 신규 → open_id만 저장 (Skill Block 접속 시 나머지 추가)
-                    cursor.execute('''
-                        INSERT INTO users (open_id, first_message_at, last_message_at, message_count, active)
-                        VALUES (?, ?, ?, 1, 1)
-                    ''', (open_id, datetime.now(), datetime.now()))
+                    UserIdentityRepository.insert_open_id_user(
+                        db,
+                        open_id=open_id,
+                        now=now,
+                    )
                     db.commit()
                     logger.info(f"신규 사용자 생성 (open_id만): {open_id}")
 
@@ -150,11 +156,20 @@ async def kakao_channel_webhook(request: Request):
                 logger.info(f"❌ 채널 차단: open_id={open_id}")
 
                 if existing_user:
-                    plusfriend_key = existing_user["plusfriend_user_key"]
+                    plusfriend_value = existing_user["plusfriend_user_key"]
+                    plusfriend_key = plusfriend_value if isinstance(plusfriend_value, str) else None
                     if plusfriend_key:
-                        cursor.execute("UPDATE users SET active = 0 WHERE plusfriend_user_key = ?", (plusfriend_key,))
+                        UserIdentityRepository.set_active_by_plusfriend_key(
+                            db,
+                            plusfriend_key=plusfriend_key,
+                            active=False,
+                        )
                     else:
-                        cursor.execute("UPDATE users SET active = 0 WHERE open_id = ?", (open_id,))
+                        UserIdentityRepository.set_active_by_open_id(
+                            db,
+                            open_id=open_id,
+                            active=False,
+                        )
                     db.commit()
 
             else:

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -6,6 +6,7 @@ import logging
 
 from app.models.user import UserPreferences, InitialSetupRequest
 from app.database.connection import get_db
+from app.repositories.user_read_repository import UserReadRepository
 from app.services.user_service import UserService
 from app.services.auth_service import verify_api_key
 
@@ -20,18 +21,8 @@ async def get_users(
 ):
     """등록된 사용자 목록 조회 (경로 정보 포함)"""
     try:
-        cursor = db.cursor()
-        cursor.execute('''
-            SELECT bot_user_key, first_message_at, last_message_at, message_count, 
-                   location, active, departure_name, departure_address, 
-                   departure_x, departure_y, arrival_name, arrival_address, 
-                   arrival_x, arrival_y, route_updated_at, marked_bus, language
-            FROM users 
-            ORDER BY last_message_at DESC
-        ''')
-        
         users = []
-        for row in cursor.fetchall():
+        for row in UserReadRepository.list_users_with_route_info(db):
             user_data = {
                 "bot_user_key": row["bot_user_key"],
                 "first_message_at": row["first_message_at"],

--- a/app/services/alarm_status_service.py
+++ b/app/services/alarm_status_service.py
@@ -1,14 +1,16 @@
 """알림 상태 추적 서비스"""
 import json
-import sqlite3
 import uuid
 from datetime import datetime
 from typing import Dict, Any, Optional, List
 import logging
 
 from app.database.connection import get_db_connection
+from app.repositories.alarm_task_repository import AlarmTaskRepository
 
 logger = logging.getLogger(__name__)
+
+COMPLETED_ALARM_TASK_STATUSES = frozenset({"completed", "failed", "partial"})
 
 
 class AlarmStatusService:
@@ -36,22 +38,14 @@ class AlarmStatusService:
         task_id = str(uuid.uuid4())
         
         with get_db_connection() as db:
-            cursor = db.cursor()
-            cursor.execute(
-                """
-                INSERT INTO alarm_tasks 
-                (task_id, alarm_type, status, total_recipients, event_id, request_data, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    task_id,
-                    alarm_type,
-                    "pending",
-                    total_recipients,
-                    event_id,
-                    json.dumps(request_data) if request_data else None,
-                    datetime.now().isoformat()
-                )
+            AlarmTaskRepository.create_task(
+                db,
+                task_id=task_id,
+                alarm_type=alarm_type,
+                total_recipients=total_recipients,
+                event_id=event_id,
+                request_data=json.dumps(request_data) if request_data else None,
+                created_at=datetime.now().isoformat(),
             )
             db.commit()
         
@@ -82,42 +76,21 @@ class AlarmStatusService:
         """
         try:
             with get_db_connection() as db:
-                cursor = db.cursor()
-                
-                # 기본 업데이트 쿼리 구성
-                update_fields = ["status = ?", "updated_at = ?"]
-                update_values = [status, datetime.now().isoformat()]
-                
-                # 선택적 필드 추가
-                if successful_sends is not None:
-                    update_fields.append("successful_sends = ?")
-                    update_values.append(successful_sends)
-                
-                if failed_sends is not None:
-                    update_fields.append("failed_sends = ?")
-                    update_values.append(failed_sends)
-                
-                if error_messages is not None:
-                    update_fields.append("error_messages = ?")
-                    update_values.append(json.dumps(error_messages))
-
-                if total_recipients is not None:
-                    update_fields.append("total_recipients = ?")
-                    update_values.append(total_recipients)
-                
-                # 완료 상태인 경우 완료 시간 추가
-                if status in ["completed", "failed", "partial"]:
-                    update_fields.append("completed_at = ?")
-                    update_values.append(datetime.now().isoformat())
-                
-                # 쿼리 실행
-                query = f"UPDATE alarm_tasks SET {', '.join(update_fields)} WHERE task_id = ?"
-                update_values.append(task_id)
-                
-                cursor.execute(query, update_values)
+                now = datetime.now().isoformat()
+                updated_count = AlarmTaskRepository.update_status(
+                    db,
+                    task_id=task_id,
+                    status=status,
+                    updated_at=now,
+                    successful_sends=successful_sends,
+                    failed_sends=failed_sends,
+                    error_messages=json.dumps(error_messages) if error_messages is not None else None,
+                    total_recipients=total_recipients,
+                    completed_at=now if status in COMPLETED_ALARM_TASK_STATUSES else None,
+                )
                 db.commit()
                 
-                if cursor.rowcount == 0:
+                if updated_count == 0:
                     logger.warning(f"알림 작업 ID {task_id}를 찾을 수 없음")
                     return False
                 
@@ -141,27 +114,9 @@ class AlarmStatusService:
         """
         try:
             with get_db_connection() as db:
-                cursor = db.cursor()
-                cursor.execute(
-                    """
-                    SELECT 
-                        task_id, alarm_type, status, total_recipients,
-                        successful_sends, failed_sends, event_id,
-                        request_data, error_messages,
-                        created_at, updated_at, completed_at
-                    FROM alarm_tasks 
-                    WHERE task_id = ?
-                    """,
-                    (task_id,)
-                )
-                
-                row = cursor.fetchone()
-                if not row:
+                result = AlarmTaskRepository.get_status(db, task_id)
+                if not result:
                     return None
-                
-                # 결과를 dict로 변환
-                columns = [desc[0] for desc in cursor.description]
-                result = dict(zip(columns, row))
                 
                 # JSON 필드 파싱
                 if result['request_data']:
@@ -204,35 +159,14 @@ class AlarmStatusService:
         """
         try:
             with get_db_connection() as db:
-                cursor = db.cursor()
-                cursor.execute(
-                    """
-                    SELECT 
-                        task_id, alarm_type, status, total_recipients,
-                        successful_sends, failed_sends, event_id,
-                        created_at, updated_at, completed_at
-                    FROM alarm_tasks 
-                    ORDER BY created_at DESC
-                    LIMIT ?
-                    """,
-                    (limit,)
-                )
-                
-                rows = cursor.fetchall()
-                columns = [desc[0] for desc in cursor.description]
-                
-                results = []
-                for row in rows:
-                    task_data = dict(zip(columns, row))
-                    
+                results = AlarmTaskRepository.list_recent(db, limit)
+                for task_data in results:
                     # 진행률 계산
                     if task_data['total_recipients'] > 0:
                         success_rate = (task_data['successful_sends'] or 0) / task_data['total_recipients']
                         task_data['success_rate'] = round(success_rate * 100, 2)
                     else:
                         task_data['success_rate'] = 0.0
-                    
-                    results.append(task_data)
                 
                 return results
                 
@@ -258,16 +192,11 @@ class AlarmStatusService:
             cutoff_date = (datetime.now() - timedelta(days=days)).isoformat()
             
             with get_db_connection() as db:
-                cursor = db.cursor()
-                cursor.execute(
-                    """
-                    DELETE FROM alarm_tasks 
-                    WHERE created_at < ?
-                    """,
-                    (cutoff_date,)
+                deleted_count = AlarmTaskRepository.delete_older_than(
+                    db,
+                    cutoff_date=cutoff_date,
                 )
                 db.commit()
-                deleted_count = cursor.rowcount
                 
                 logger.info(f"오래된 알림 작업 {deleted_count}개 정리 완료 ({days}일 이전, {cutoff_date} 기준)")
                 return deleted_count

--- a/app/services/crawling_service.py
+++ b/app/services/crawling_service.py
@@ -25,6 +25,10 @@ from typing import List, Dict, Tuple, Optional
 
 from app.database.connection import get_db_connection, get_database_path
 from app.config.settings import settings
+from app.repositories.event_bulk_import_repository import (
+    EventBulkImportRepository,
+    EventBulkImportRow,
+)
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -795,7 +799,7 @@ class CrawlingService:
         - IntegrityError/OperationalError 구분 처리
         - 상세한 오류 로깅
         """
-        insert_data = []
+        insert_data: List[EventBulkImportRow] = []
         skipped_count = 0
 
         for r in data_list:
@@ -855,13 +859,8 @@ class CrawlingService:
 
         try:
             with get_db_connection() as conn:
-                cur = conn.cursor()
-
                 try:
-                    cur.execute("""
-                        CREATE UNIQUE INDEX IF NOT EXISTS idx_events_location_date
-                        ON events(location_name, start_date)
-                    """)
+                    EventBulkImportRepository.ensure_location_date_unique_index(conn)
                     logger.debug("[DB] UNIQUE INDEX 생성/확인 완료")
                 except sqlite3.OperationalError as e:
                     logger.debug(f"[DB] INDEX 이미 존재: {e}")
@@ -869,15 +868,7 @@ class CrawlingService:
                     logger.warning(f"[DB] INDEX 생성 중 예기치 않은 오류: {e}")
 
                 try:
-                    cur.executemany("""
-                        INSERT OR IGNORE INTO events (
-                            title, description, location_name, location_address,
-                            latitude, longitude, start_date, end_date,
-                            category, severity_level, status
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """, insert_data)
-
-                    inserted_count = cur.rowcount
+                    inserted_count = EventBulkImportRepository.insert_or_ignore_events(conn, insert_data)
                     conn.commit()
 
                     logger.info(f"✅ [DB] {len(insert_data)}건 중 {inserted_count}건의 이벤트 저장 완료")

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -1,12 +1,14 @@
 """이벤트/집회 관리 서비스"""
-import asyncio
 import logging
 import sqlite3
 from datetime import datetime
 from typing import List, Dict, Any, Optional
 from app.models.event import EventCreate, EventResponse, RouteEventCheck
-from app.utils.geo_utils import haversine_distance, get_route_coordinates, is_event_near_route_accurate, is_point_near_route
+from app.utils.geo_utils import get_route_coordinates, is_event_near_route_accurate, is_point_near_route
 from app.database.connection import get_db_connection
+from app.repositories.event_repository import EventRepository
+from app.repositories.route_event_query_repository import RouteEventQueryRepository
+from app.repositories.user_route_read_repository import UserRouteReadRepository
 from app.services.notification_service import NotificationService
 
 logger = logging.getLogger(__name__)
@@ -14,6 +16,25 @@ logger = logging.getLogger(__name__)
 
 class EventService:
     """이벤트/집회 관리 비즈니스 로직"""
+
+    @staticmethod
+    def _event_response_from_row(row: Dict[str, Any]) -> EventResponse:
+        return EventResponse(
+            id=row["id"],
+            title=row["title"],
+            description=row["description"],
+            location_name=row["location_name"],
+            location_address=row["location_address"],
+            latitude=row["latitude"],
+            longitude=row["longitude"],
+            start_date=row["start_date"],
+            end_date=row["end_date"],
+            category=row["category"],
+            severity_level=row["severity_level"],
+            status=row["status"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
 
     @staticmethod
     def create_event(event_data: EventCreate, db: sqlite3.Connection) -> Dict[str, Any]:
@@ -28,31 +49,29 @@ class EventService:
             Dict: 생성 결과
         """
         try:
-            cursor = db.cursor()
-            cursor.execute('''
-                INSERT INTO events (title, description, location_name, location_address,
-                                  latitude, longitude, start_date, end_date, category, 
-                                  severity_level, status)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ''', (
-                event_data.title,
-                event_data.description,
-                event_data.location_name,
-                event_data.location_address,
-                event_data.latitude,
-                event_data.longitude,
-                event_data.start_date,
-                event_data.end_date,
-                event_data.category,
-                event_data.severity_level,
-                'active'  # 기본값으로 'active' 설정
-            ))
-            
-            event_id = cursor.lastrowid
+            event_id = EventRepository.create_event(
+                db,
+                title=event_data.title,
+                description=event_data.description,
+                location_name=event_data.location_name,
+                location_address=event_data.location_address,
+                latitude=event_data.latitude,
+                longitude=event_data.longitude,
+                start_date=event_data.start_date,
+                end_date=event_data.end_date,
+                category=event_data.category,
+                severity_level=event_data.severity_level,
+                status="active",
+            )
             db.commit()
+            event_row = EventRepository.get_by_id(db, event_id)
             
             logger.info(f"새 집회 생성 완료: {event_id} - {event_data.title}")
-            return {"success": True, "event_id": event_id}
+            return {
+                "success": True,
+                "event_id": event_id,
+                "event": EventService._event_response_from_row(event_row) if event_row else None,
+            }
             
         except Exception as e:
             logger.error(f"집회 생성 실패: {str(e)}")
@@ -78,54 +97,13 @@ class EventService:
             List[EventResponse]: 집회 목록
         """
         try:
-            cursor = db.cursor()
-            
-            # 쿼리 조건 구성
-            where_conditions = []
-            params = []
-            
-            if category:
-                where_conditions.append("category = ?")
-                params.append(category)
-            
-            if status:
-                where_conditions.append("status = ?")
-                params.append(status)
-            
-            where_clause = " WHERE " + " AND ".join(where_conditions) if where_conditions else ""
-            
-            query = f'''
-                SELECT id, title, description, location_name, location_address,
-                       latitude, longitude, start_date, end_date, category,
-                       severity_level, status, created_at, updated_at
-                FROM events{where_clause}
-                ORDER BY start_date DESC
-                LIMIT ?
-            '''
-            
-            params.append(limit)
-            cursor.execute(query, params)
-            
-            events = []
-            for row in cursor.fetchall():
-                events.append(EventResponse(
-                    id=row["id"],
-                    title=row["title"],
-                    description=row["description"],
-                    location_name=row["location_name"],
-                    location_address=row["location_address"],
-                    latitude=row["latitude"],
-                    longitude=row["longitude"],
-                    start_date=row["start_date"],
-                    end_date=row["end_date"],
-                    category=row["category"],
-                    severity_level=row["severity_level"],
-                    status=row["status"],
-                    created_at=row["created_at"],
-                    updated_at=row["updated_at"]
-                ))
-
-            return events
+            rows = EventRepository.list_events(
+                db,
+                category=category,
+                status=status,
+                limit=limit,
+            )
+            return [EventService._event_response_from_row(row) for row in rows]
 
         except Exception as e:
             logger.error(f"집회 목록 조회 실패: {str(e)}")
@@ -149,16 +127,8 @@ class EventService:
             RouteEventCheck: 경로 확인 결과
         """
         try:
-            cursor = db.cursor()
-
             # 사용자 경로 정보 조회 (plusfriend_user_key 우선 조회)
-            cursor.execute('''
-                SELECT departure_name, departure_address, departure_x, departure_y,
-                       arrival_name, arrival_address, arrival_x, arrival_y
-                FROM users WHERE plusfriend_user_key = ? OR bot_user_key = ?
-            ''', (user_id, user_id))
-            
-            user_row = cursor.fetchone()
+            user_row = UserRouteReadRepository.get_route_for_user(db, user_id)
             if not user_row or any(user_row[k] is None for k in ("departure_x", "departure_y", "arrival_x", "arrival_y")):
                 return RouteEventCheck(
                     user_id=user_id,
@@ -169,14 +139,7 @@ class EventService:
 
             dep_lon, dep_lat, arr_lon, arr_lat = user_row["departure_x"], user_row["departure_y"], user_row["arrival_x"], user_row["arrival_y"]
             
-            # 활성 집회 목록 조회
-            cursor.execute('''
-                SELECT * FROM events 
-                WHERE status = 'active' AND start_date > datetime('now', '+9 hours')
-                ORDER BY start_date
-            ''')
-            
-            events_rows = cursor.fetchall()
+            events_rows = RouteEventQueryRepository.list_active_future_events(db)
             route_events = []
             
             # 카카오 Mobility API로 실제 경로 좌표 가져오기
@@ -273,20 +236,7 @@ class EventService:
 
             with get_db_connection() as db:
                 # 활성 사용자 조회 (plusfriend_user_key 필수!)
-                cursor = db.cursor()
-                cursor.execute('''
-                    SELECT plusfriend_user_key, departure_name, arrival_name
-                    FROM users
-                    WHERE active = 1
-                      AND is_alarm_on = 1
-                      AND plusfriend_user_key IS NOT NULL
-                      AND departure_x IS NOT NULL
-                      AND departure_y IS NOT NULL
-                      AND arrival_x IS NOT NULL
-                      AND arrival_y IS NOT NULL
-                ''')
-
-                users = cursor.fetchall()
+                users = UserRouteReadRepository.list_scheduled_route_users(db)
 
                 logger.info(f"경로 등록된 사용자 {len(users)}명 확인 중...")
 
@@ -379,6 +329,11 @@ class EventService:
             }
 
     @staticmethod
+    def list_auto_check_route_user_ids(db: sqlite3.Connection) -> List[Dict[str, Any]]:
+        """수동 전체 경로 확인 대상 사용자 ID를 조회한다."""
+        return UserRouteReadRepository.list_auto_check_route_user_ids(db)
+
+    @staticmethod
     def get_upcoming_events(
         limit: int = 5,
         db: sqlite3.Connection = None
@@ -395,7 +350,6 @@ class EventService:
         """
         try:
             from zoneinfo import ZoneInfo
-            cursor = db.cursor()
             
             # KST 현재 시간
             now_kst = datetime.now(ZoneInfo("Asia/Seoul"))
@@ -405,36 +359,8 @@ class EventService:
             # 여기서는 datetime 객체를 파라미터로 넘김 (adapter가 처리)
             # 또는 문자열로 변환하여 비교: now_kst.strftime("%Y-%m-%d %H:%M:%S")
             
-            cursor.execute('''
-                SELECT id, title, description, location_name, location_address,
-                       latitude, longitude, start_date, end_date, category,
-                       severity_level, status, created_at, updated_at
-                FROM events
-                WHERE status = 'active' AND start_date >= ?
-                ORDER BY start_date ASC
-                LIMIT ?
-            ''', (now_str, limit))
-            
-            events = []
-            for row in cursor.fetchall():
-                events.append(EventResponse(
-                    id=row["id"],
-                    title=row["title"],
-                    description=row["description"],
-                    location_name=row["location_name"],
-                    location_address=row["location_address"],
-                    latitude=row["latitude"],
-                    longitude=row["longitude"],
-                    start_date=row["start_date"],
-                    end_date=row["end_date"],
-                    category=row["category"],
-                    severity_level=row["severity_level"],
-                    status=row["status"],
-                    created_at=row["created_at"],
-                    updated_at=row["updated_at"]
-                ))
-
-            return events
+            rows = EventRepository.list_upcoming(db, now=now_str, limit=limit)
+            return [EventService._event_response_from_row(row) for row in rows]
 
         except Exception as e:
             logger.error(f"다가오는 집회 목록 조회 실패: {str(e)}")
@@ -455,43 +381,17 @@ class EventService:
         """
         try:
             from zoneinfo import ZoneInfo
-            cursor = db.cursor()
             
             # KST 오늘 날짜 문자열 (YYYY-MM-DD)
             today_kst_str = datetime.now(ZoneInfo("Asia/Seoul")).date().isoformat()
             
             jongno_pattern = '%종로%'
-            cursor.execute('''
-                SELECT id, title, description, location_name, location_address,
-                       latitude, longitude, start_date, end_date, category,
-                       severity_level, status, created_at, updated_at
-                FROM events
-                WHERE status = 'active'
-                  AND date(start_date) = ?
-                  AND (location_name LIKE ? OR location_address LIKE ?)
-                ORDER BY start_date ASC
-            ''', (today_kst_str, jongno_pattern, jongno_pattern))
-            
-            events = []
-            for row in cursor.fetchall():
-                events.append(EventResponse(
-                    id=row["id"],
-                    title=row["title"],
-                    description=row["description"],
-                    location_name=row["location_name"],
-                    location_address=row["location_address"],
-                    latitude=row["latitude"],
-                    longitude=row["longitude"],
-                    start_date=row["start_date"],
-                    end_date=row["end_date"],
-                    category=row["category"],
-                    severity_level=row["severity_level"],
-                    status=row["status"],
-                    created_at=row["created_at"],
-                    updated_at=row["updated_at"]
-                ))
-
-            return events
+            rows = EventRepository.list_today_by_location_pattern(
+                db,
+                today=today_kst_str,
+                location_pattern=jongno_pattern,
+            )
+            return [EventService._event_response_from_row(row) for row in rows]
 
         except Exception as e:
             logger.error(f"오늘 집회 목록 조회 실패: {str(e)}")

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -4,6 +4,12 @@ import sqlite3
 from datetime import datetime
 from typing import Optional, Dict, Any
 from app.models.user import UserPreferences, InitialSetupRequest
+from app.repositories.user_identity_repository import UserIdentityRepository
+from app.repositories.user_preference_repository import UserPreferenceRepository
+from app.repositories.user_profile_repository import UserProfileRepository
+from app.repositories.user_read_repository import UserReadRepository
+from app.repositories.user_route_repository import UserRouteRepository
+from app.repositories.user_settings_repository import UserSettingsRepository
 from app.utils.geo_utils import get_location_info
 
 logger = logging.getLogger(__name__)
@@ -11,14 +17,6 @@ logger = logging.getLogger(__name__)
 
 class UserService:
     """사용자 관리 비즈니스 로직"""
-
-    @staticmethod
-    def _row_value(row: Any, key: str, index: int) -> Any:
-        if row is None:
-            return None
-        if isinstance(row, sqlite3.Row):
-            return row[key]
-        return row[index]
 
     @staticmethod
     def save_or_update_user(bot_user_key: str, db: sqlite3.Connection, message: str = "") -> None:
@@ -31,27 +29,26 @@ class UserService:
             message: 메시지 (로깅용)
         """
         try:
-            cursor = db.cursor()
             now = datetime.now()
             
             # 기존 사용자 확인
-            cursor.execute('SELECT * FROM users WHERE bot_user_key = ?', (bot_user_key,))
-            user = cursor.fetchone()
+            user = UserIdentityRepository.find_by_bot_user_key(db, bot_user_key)
             
             if user:
                 # 기존 사용자 업데이트
-                cursor.execute('''
-                    UPDATE users 
-                    SET last_message_at = ?, message_count = message_count + 1 
-                    WHERE bot_user_key = ?
-                ''', (now, bot_user_key))
+                UserIdentityRepository.increment_bot_user_message(
+                    db,
+                    bot_user_key=bot_user_key,
+                    now=now,
+                )
                 logger.info(f"사용자 업데이트: {bot_user_key}")
             else:
                 # 새 사용자 생성
-                cursor.execute('''
-                    INSERT INTO users (bot_user_key, first_message_at, last_message_at, message_count)
-                    VALUES (?, ?, ?, 1)
-                ''', (bot_user_key, now, now))
+                UserIdentityRepository.insert_bot_user(
+                    db,
+                    bot_user_key=bot_user_key,
+                    now=now,
+                )
                 logger.info(f"새 사용자 등록: {bot_user_key}")
             
             db.commit()
@@ -73,7 +70,6 @@ class UserService:
             db: 데이터베이스 연결
         """
         try:
-            cursor = db.cursor()
             now = datetime.now()
             
             if not plusfriend_key:
@@ -83,31 +79,23 @@ class UserService:
                 return
 
             # plusfriend_key로 조회 (primary identifier)
-            cursor.execute(
-                "SELECT id, open_id, bot_user_key FROM users WHERE plusfriend_user_key = ?",
-                (plusfriend_key,)
-            )
-            existing_plusfriend = cursor.fetchone()
+            existing_plusfriend = UserIdentityRepository.find_by_plusfriend_key(db, plusfriend_key)
 
             # plusfriend 미연동 레거시 사용자를 bot_user_key로 조회
-            cursor.execute(
-                "SELECT id, plusfriend_user_key, open_id FROM users WHERE bot_user_key = ?",
-                (bot_user_key,)
-            )
-            existing_bot = cursor.fetchone()
+            existing_bot = UserIdentityRepository.find_by_bot_user_key(db, bot_user_key)
 
             if existing_plusfriend:
                 # plusfriend_key로 이미 연결된 기존 사용자 업데이트
                 logger.debug(f"✅ 기존 사용자 발견: plusfriend={plusfriend_key}")
-                cursor.execute("""
-                    UPDATE users
-                    SET last_message_at = ?, message_count = message_count + 1, active = 1
-                    WHERE plusfriend_user_key = ?
-                """, (now, plusfriend_key))
+                UserIdentityRepository.touch_plusfriend_user(
+                    db,
+                    plusfriend_key=plusfriend_key,
+                    now=now,
+                )
 
-                existing_plusfriend_bot_user_key = UserService._row_value(existing_plusfriend, "bot_user_key", 2)
-                existing_plusfriend_id = UserService._row_value(existing_plusfriend, "id", 0)
-                existing_bot_id = UserService._row_value(existing_bot, "id", 0)
+                existing_plusfriend_bot_user_key = existing_plusfriend["bot_user_key"]
+                existing_plusfriend_id = existing_plusfriend["id"]
+                existing_bot_id = existing_bot["id"] if existing_bot else None
 
                 if existing_plusfriend_bot_user_key != bot_user_key:
                     if existing_bot and existing_bot_id != existing_plusfriend_id:
@@ -118,46 +106,45 @@ class UserService:
                             plusfriend_key,
                         )
                     else:
-                        cursor.execute("""
-                            UPDATE users
-                            SET bot_user_key = ?
-                            WHERE plusfriend_user_key = ?
-                        """, (bot_user_key, plusfriend_key))
+                        UserIdentityRepository.set_bot_user_key_for_plusfriend(
+                            db,
+                            plusfriend_key=plusfriend_key,
+                            bot_user_key=bot_user_key,
+                        )
             elif existing_bot:
                 # 기존 bot_user_key 사용자에 plusfriend_key 연결
                 logger.info(f"✅ 기존 bot_user_key 사용자에 plusfriend 연결: {bot_user_key} → {plusfriend_key}")
-                cursor.execute("""
-                    UPDATE users
-                    SET plusfriend_user_key = ?, last_message_at = ?, message_count = message_count + 1, active = 1
-                    WHERE bot_user_key = ?
-                """, (plusfriend_key, now, bot_user_key))
+                UserIdentityRepository.link_plusfriend_to_bot(
+                    db,
+                    bot_user_key=bot_user_key,
+                    plusfriend_key=plusfriend_key,
+                    now=now,
+                )
             else:
                 # 웹훅 사용자 찾기 시도 (open_id만 있는 경우)
-                cursor.execute("""
-                    SELECT id, open_id FROM users
-                    WHERE bot_user_key IS NULL AND plusfriend_user_key IS NULL
-                    ORDER BY first_message_at ASC, id ASC
-                    LIMIT 1
-                """)
-                orphan = cursor.fetchone()
+                orphan = UserIdentityRepository.find_oldest_unlinked_user(db)
 
                 if orphan:
                     # 웹훅 사용자 연결 (Orphan Matching)
-                    orphan_open_id = UserService._row_value(orphan, "open_id", 1)
-                    orphan_id = UserService._row_value(orphan, "id", 0)
+                    orphan_open_id = orphan["open_id"]
+                    orphan_id = orphan["id"]
                     logger.info(f"✅ 웹훅 사용자 연결: open_id={orphan_open_id} → plusfriend={plusfriend_key}")
-                    cursor.execute("""
-                        UPDATE users
-                        SET bot_user_key = ?, plusfriend_user_key = ?, last_message_at = ?, active = 1
-                        WHERE id = ?
-                    """, (bot_user_key, plusfriend_key, now, orphan_id))
+                    UserIdentityRepository.link_orphan_identity(
+                        db,
+                        user_id=orphan_id,
+                        bot_user_key=bot_user_key,
+                        plusfriend_key=plusfriend_key,
+                        now=now,
+                    )
                 else:
                     # 완전 신규 사용자
                     logger.info(f"✅ 신규 사용자 생성: plusfriend={plusfriend_key}")
-                    cursor.execute("""
-                        INSERT INTO users (bot_user_key, plusfriend_user_key, first_message_at, last_message_at, message_count, active)
-                        VALUES (?, ?, ?, ?, 1, 1)
-                    """, (bot_user_key, plusfriend_key, now, now))
+                    UserIdentityRepository.insert_kakao_identity(
+                        db,
+                        bot_user_key=bot_user_key,
+                        plusfriend_key=plusfriend_key,
+                        now=now,
+                    )
             
             db.commit()
             
@@ -197,22 +184,13 @@ class UserService:
             Dict: 처리 결과
         """
         try:
-            cursor = db.cursor()
+            updated_count = UserSettingsRepository.update_alarm_setting(
+                db,
+                user_id=user_id,
+                is_alarm_on=is_alarm_on,
+            )
             
-            # 1. plusfriend_user_key로 우선 업데이트 시도
-            cursor.execute('''
-                UPDATE users SET is_alarm_on = ?
-                WHERE plusfriend_user_key = ?
-            ''', (is_alarm_on, user_id))
-            
-            # 2. 업데이트된 레코드가 없으면 bot_user_key로 폴백 시도
-            if cursor.rowcount == 0:
-                cursor.execute('''
-                    UPDATE users SET is_alarm_on = ?
-                    WHERE bot_user_key = ?
-                ''', (is_alarm_on, user_id))
-            
-            if cursor.rowcount == 0:
+            if updated_count == 0:
                 logger.warning(f"알람 설정 업데이트 대상 사용자를 찾을 수 없음: {user_id}")
                 return {"success": False, "error": "사용자를 찾을 수 없습니다"}
                 
@@ -239,22 +217,13 @@ class UserService:
             Dict: 처리 결과
         """
         try:
-            cursor = db.cursor()
+            updated_count = UserSettingsRepository.update_favorite_zone(
+                db,
+                user_id=user_id,
+                zone=zone,
+            )
 
-            # 1. plusfriend_user_key로 우선 업데이트 시도
-            cursor.execute('''
-                UPDATE users SET favorite_zone = ?
-                WHERE plusfriend_user_key = ?
-            ''', (zone, user_id))
-
-            # 2. 업데이트된 레코드가 없으면 bot_user_key로 폴백 시도
-            if cursor.rowcount == 0:
-                cursor.execute('''
-                    UPDATE users SET favorite_zone = ?
-                    WHERE bot_user_key = ?
-                ''', (zone, user_id))
-
-            if cursor.rowcount == 0:
+            if updated_count == 0:
                 logger.warning(f"관심장소 설정 업데이트 대상 사용자를 찾을 수 없음: {user_id}")
                 return {"success": False, "error": "사용자를 찾을 수 없습니다"}
 
@@ -281,8 +250,6 @@ class UserService:
             db: 데이터베이스 연결
         """
         try:
-            cursor = db.cursor()
-
             # 1. 지오코딩
             departure_info = await get_location_info(departure)
             if not departure_info:
@@ -293,22 +260,15 @@ class UserService:
                 return {"success": False, "error": "도착지를 찾을 수 없습니다"}
 
             # 2. 경로 정보만 업데이트
-            cursor.execute('''
-                UPDATE users SET
-                    departure_name = ?, departure_address = ?, departure_x = ?, departure_y = ?,
-                    arrival_name = ?, arrival_address = ?, arrival_x = ?, arrival_y = ?,
-                    route_updated_at = ?
-                WHERE plusfriend_user_key = ?
-            ''', (
-                departure_info["name"], departure_info["address"],
-                departure_info["x"], departure_info["y"],
-                arrival_info["name"], arrival_info["address"],
-                arrival_info["x"], arrival_info["y"],
-                datetime.now(),
-                user_id
-            ))
+            updated_count = UserRouteRepository.update_route(
+                db,
+                user_id=user_id,
+                departure_info=departure_info,
+                arrival_info=arrival_info,
+                now=datetime.now(),
+            )
 
-            if cursor.rowcount == 0:
+            if updated_count == 0:
                 logger.warning(f"경로 업데이트 대상 사용자를 찾을 수 없음: {user_id}")
                 return {"success": False, "error": "사용자를 찾을 수 없습니다"}
 
@@ -337,24 +297,13 @@ class UserService:
             db: 데이터베이스 연결
         """
         try:
-            cursor = db.cursor()
-            clear_sql = '''
-                UPDATE users SET
-                    departure_name = NULL, departure_address = NULL,
-                    departure_x = NULL, departure_y = NULL,
-                    arrival_name = NULL, arrival_address = NULL,
-                    arrival_x = NULL, arrival_y = NULL,
-                    route_updated_at = ?
-                WHERE {} = ?
-            '''
-            # 1. plusfriend_user_key로 우선 업데이트 시도
-            cursor.execute(clear_sql.format("plusfriend_user_key"), (datetime.now(), user_id))
+            updated_count = UserRouteRepository.clear_route(
+                db,
+                user_id=user_id,
+                now=datetime.now(),
+            )
 
-            # 2. 업데이트된 레코드가 없으면 bot_user_key로 폴백 시도
-            if cursor.rowcount == 0:
-                cursor.execute(clear_sql.format("bot_user_key"), (datetime.now(), user_id))
-
-            if cursor.rowcount == 0:
+            if updated_count == 0:
                 logger.warning(f"경로 삭제 대상 사용자를 찾을 수 없음: {user_id}")
                 return {"success": False, "error": "사용자를 찾을 수 없습니다"}
 
@@ -374,34 +323,14 @@ class UserService:
         - 없으면 bot_user_key로 fallback
         """
         try:
-            cursor = db.cursor()
+            updated_count = UserSettingsRepository.update_marked_bus(
+                db,
+                user_id=user_id,
+                marked_bus=marked_bus,
+                now=datetime.now(),
+            )
 
-            # 1. plusfriend_user_key 기준 업데이트
-            cursor.execute('''
-                UPDATE users SET
-                    marked_bus = ?,
-                    last_message_at = ?
-                WHERE plusfriend_user_key = ?
-            ''', (
-                marked_bus,
-                datetime.now(),
-                user_id
-            ))
-
-            # 2. 업데이트 안 됐으면 bot_user_key로 fallback
-            if cursor.rowcount == 0:
-                cursor.execute('''
-                    UPDATE users SET
-                        marked_bus = ?,
-                        last_message_at = ?
-                    WHERE bot_user_key = ?
-                ''', (
-                    marked_bus,
-                    datetime.now(),
-                    user_id
-                ))
-
-            if cursor.rowcount == 0:
+            if updated_count == 0:
                 logger.warning(f"marked_bus 업데이트 대상 사용자를 찾을 수 없음: {user_id}")
                 return {"success": False, "error": "사용자를 찾을 수 없습니다"}
 
@@ -424,8 +353,6 @@ class UserService:
             db: 데이터베이스 연결
         """
         try:
-            cursor = db.cursor()
-
             # 1. 지오코딩 (경로 정보가 있는 경우)
             dep_info = None
             arr_info = None
@@ -440,37 +367,22 @@ class UserService:
                 if not arr_info:
                     return {"success": False, "error": "도착지를 찾을 수 없습니다"}
 
-            # 2. 전체 필드 업데이트 쿼리 구성
+            # 2. 전체 필드 업데이트
             # 주의: 값이 없는 필드는 NULL로 하거나, 기존 값을 유지해야 하는데
             # Initial Setup의 목적상 입력된 값으로 덮어쓰는 것이 일반적임.
             # 하지만 여기선 입력된 값만 업데이트하도록 동적 쿼리 사용 권장, 
             # 단순화를 위해 모두 업데이트 (None이면 NULL 처리될 수 있음에 유의)
+            updated_count = UserProfileRepository.update_profile(
+                db,
+                plusfriend_user_key=user_setup.bot_user_key,
+                departure_info=dep_info,
+                arrival_info=arr_info,
+                marked_bus=user_setup.marked_bus,
+                language=user_setup.language,
+                now=datetime.now(),
+            )
             
-            update_query = "UPDATE users SET route_updated_at = ?"
-            params = [datetime.now()]
-            
-            if dep_info:
-                update_query += ", departure_name=?, departure_address=?, departure_x=?, departure_y=?"
-                params.extend([dep_info["name"], dep_info["address"], dep_info["x"], dep_info["y"]])
-                
-            if arr_info:
-                update_query += ", arrival_name=?, arrival_address=?, arrival_x=?, arrival_y=?"
-                params.extend([arr_info["name"], arr_info["address"], arr_info["x"], arr_info["y"]])
-                
-            if user_setup.marked_bus:
-                update_query += ", marked_bus=?"
-                params.append(user_setup.marked_bus)
-                
-            if user_setup.language:
-                update_query += ", language=?"
-                params.append(user_setup.language)
-                
-            update_query += " WHERE plusfriend_user_key = ?"
-            params.append(user_setup.bot_user_key)
-            
-            cursor.execute(update_query, params)
-            
-            if cursor.rowcount == 0:
+            if updated_count == 0:
                 logger.warning(f"프로필 업데이트 대상 사용자를 찾을 수 없음: {user_setup.bot_user_key}")
                 return {"success": False, "error": "사용자를 찾을 수 없습니다"}
 
@@ -504,31 +416,18 @@ class UserService:
             Dict: 처리 결과
         """
         try:
-            cursor = db.cursor()
-            
             # 기존 사용자 확인
-            cursor.execute("SELECT id FROM users WHERE bot_user_key = ?", (user_id,))
-            user = cursor.fetchone()
-            
-            if not user:
+            if not UserPreferenceRepository.exists_by_bot_user_key(db, user_id):
                 return {"success": False, "error": "사용자를 찾을 수 없습니다"}
             
             # 설정 업데이트
-            update_fields = []
-            update_values = []
-            
-            if preferences.marked_bus:
-                update_fields.append("marked_bus = ?")
-                update_values.append(preferences.marked_bus)
-            
-            if preferences.language:
-                update_fields.append("language = ?") 
-                update_values.append(preferences.language)
-            
-            if update_fields:
-                update_values.append(user_id)
-                query = f"UPDATE users SET {', '.join(update_fields)} WHERE bot_user_key = ?"
-                cursor.execute(query, update_values)
+            updated_count = UserPreferenceRepository.update_preferences(
+                db,
+                user_id=user_id,
+                marked_bus=preferences.marked_bus,
+                language=preferences.language,
+            )
+            if updated_count:
                 db.commit()
             
             logger.info(f"사용자 설정 업데이트 완료: {user_id}")
@@ -551,15 +450,7 @@ class UserService:
             Optional[Dict]: 사용자 경로 정보 또는 None
         """
         try:
-            cursor = db.cursor()
-            cursor.execute('''
-                SELECT departure_name, departure_address, departure_x, departure_y,
-                       arrival_name, arrival_address, arrival_x, arrival_y,
-                       route_updated_at
-                FROM users WHERE bot_user_key = ?
-            ''', (user_id,))
-            
-            user_data = cursor.fetchone()
+            user_data = UserReadRepository.get_route_info_by_bot_user_key(db, user_id)
             if not user_data:
                 return None
                 
@@ -605,24 +496,7 @@ class UserService:
             Optional[Dict]: 사용자 정보 또는 None
         """
         try:
-            cursor = db.cursor()
-            
-            SELECT_FIELDS = '''
-                SELECT 
-                    is_alarm_on, favorite_zone, marked_bus, 
-                    departure_name, arrival_name,
-                    plusfriend_user_key, bot_user_key
-                FROM users 
-            '''
-
-            # 1단계: plusfriend_user_key로 조회 (우선)
-            cursor.execute(SELECT_FIELDS + 'WHERE plusfriend_user_key = ? LIMIT 1', (user_id,))
-            row = cursor.fetchone()
-
-            # 2단계: 없으면 bot_user_key로 조회 (fallback)
-            if not row:
-                cursor.execute(SELECT_FIELDS + 'WHERE bot_user_key = ? LIMIT 1', (user_id,))
-                row = cursor.fetchone()
+            row = UserReadRepository.get_user_info(db, user_id)
             if not row:
                 return None
                 

--- a/app/services/zone_alarm_service.py
+++ b/app/services/zone_alarm_service.py
@@ -3,6 +3,7 @@ import logging
 from typing import Dict, Any
 
 from app.database.connection import get_db_connection
+from app.repositories.zone_alarm_read_repository import ZoneAlarmReadRepository
 from app.utils.geo_utils import haversine_distance, FAVORITE_ZONES
 from app.services.notification_service import NotificationService
 from app.services.alarm_status_service import AlarmStatusService
@@ -29,32 +30,12 @@ class ZoneAlarmService:
             AlarmStatusService.update_alarm_task_status(task_id, "processing")
 
             with get_db_connection() as db:
-                cursor = db.cursor()
-
                 # 1. favorite_zone이 설정된 활성 사용자 조회
-                cursor.execute('''
-                    SELECT plusfriend_user_key, favorite_zone
-                    FROM users
-                    WHERE active = 1
-                      AND is_alarm_on = 1
-                      AND favorite_zone IS NOT NULL
-                      AND plusfriend_user_key IS NOT NULL
-                ''')
-                users = cursor.fetchall()
+                users = ZoneAlarmReadRepository.list_zone_users(db)
                 logger.info(f"구역 설정된 사용자 {len(users)}명 확인 중...")
 
                 # 2. 활성 집회 전체 조회
-                cursor.execute('''
-                    SELECT id, title, location_name, location_address,
-                           latitude, longitude, start_date, category, severity_level
-                    FROM events
-                    WHERE status = 'active'
-                      AND latitude IS NOT NULL
-                      AND longitude IS NOT NULL
-                      AND start_date > datetime('now', '+9 hours')
-                    ORDER BY start_date
-                ''')
-                events = cursor.fetchall()
+                events = ZoneAlarmReadRepository.list_active_future_events(db)
 
                 if not events:
                     logger.info("활성 집회 없음 — 구역 알람 발송 생략")

--- a/docs/repository-boundary-inventory-issue-99.txt
+++ b/docs/repository-boundary-inventory-issue-99.txt
@@ -1,0 +1,247 @@
+# Issue #99 Repository Boundary Inventory and Roadmap
+
+## 1. Decision
+
+Issue #99 / PR 0 is an impact-assessment and roadmap artifact only.
+
+It does **not** introduce `app/repositories`, move SQL, change service behavior, change API contracts, change DB schema, add an ORM, or change tests to force a pass.
+
+## 2. Source of truth
+
+| Artifact | Path |
+|---|---|
+| Deep-interview spec | `.omx/specs/deep-interview-issue-99-repository-pr-units.md` |
+| Consensus PRD | `.omx/plans/prd-issue-99-repository-boundary.md` |
+| Test spec | `.omx/plans/test-spec-issue-99-repository-boundary.md` |
+| Ralph context | `.omx/context/issue-99-ralph-pr0-20260505T095536Z.md` |
+
+## 3. Scan command
+
+Broad first-pass command used for this inventory:
+
+```bash
+rg -n "execute\(|executemany\(|sqlite3\.connect|get_db_connection|Depends\(get_db\)" app tests --glob '*.py'
+```
+
+Classification rule:
+
+- Production persistence hits are assigned to a domain/boundary and a future PR bucket.
+- Test hits are classified as setup/assertion coverage, not production repository candidates.
+- Import/dependency hits are retained when they explain connection ownership.
+
+## 4. Current architecture mismatch
+
+| Claim / fact | Evidence | Assessment |
+|---|---|---|
+| App description claims Router-Service-Repository | `main.py:5`, `main.py:86` | Documentation/API description implies a repository layer. |
+| No repository package exists | current tree has no `app/repositories` path | Actual persistence code is not separated into repositories. |
+| DB connection boundary is centralized | `app/database/connection.py:16-23`, `app/database/connection.py:27-34` | `get_db()` and `get_db_connection()` create/close SQLite connections but do not own domain SQL. |
+| Schema/bootstrap is centralized | `app/database/connection.py:39-70` | Keep schema creation/migration-like compatibility in DB module, not a domain repository. |
+
+## 5. Inventory taxonomy
+
+| Field | Values used |
+|---|---|
+| Layer | `database`, `service`, `router`, `test` |
+| Domain | `users`, `events`, `alarm_tasks`, `zone_alarm`, `crawling`, `admin_dashboard`, `cross_domain`, `database_schema` |
+| Operation | `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `DDL/PRAGMA`, `connection`, `test_setup`, `test_assertion` |
+| Transaction owner | `request-scoped Depends(get_db)`, `service-owned get_db_connection`, `router-owned get_db_connection`, `background task`, `test fixture`, `schema init` |
+| Risk | `low`, `medium`, `high` |
+| Proposed PR bucket | `PR 0`, `PR 1`, `PR 2a`, `PR 2b`, `PR 3`, `PR 4a`, `PR 4b`, `PR 4c`, `PR 5`, `Admin/read-model`, `Crawling`, `Keep database module`, `Test coverage` |
+
+## 6. Production inventory
+
+### 6.1 Database boundary
+
+| ID | File / lines | Layer | Domain | Operation | Current transaction owner | Candidate boundary | Risk | Existing tests | PR bucket |
+|---|---|---|---|---|---|---|---|---|---|
+| DB-1 | `app/database/connection.py:16-23`, `:27-34` | database | cross_domain | connection | FastAPI dependency / context manager | Keep in DB connection module | low | `tests/test_database_connection_settings.py:26-48`, `tests/test_database.py:79-81` | Keep database module |
+| DB-2 | `app/database/connection.py:39-70` | database | database_schema | DDL/PRAGMA/schema compatibility | schema init | Keep in DB connection module; do not move to domain repository | medium | `tests/test_database.py:9-71`, `tests/test_admin_dashboard_schema_compat.py:10-89` | Keep database module |
+
+### 6.2 Alarm task persistence
+
+| ID | File / lines | Layer | Domain | Operation | Current transaction owner | Candidate boundary | Risk | Existing tests | PR bucket |
+|---|---|---|---|---|---|---|---|---|---|
+| ALARM-TASK-1 | `app/services/alarm_status_service.py:38-57` | service | alarm_tasks | INSERT | service-owned `get_db_connection`; service commits at `:56` | `AlarmTaskRepository.create_task(conn, ...)` accepting connection | low | `tests/test_alarm_status_service.py:8-24` | PR 1 |
+| ALARM-TASK-2 | `app/services/alarm_status_service.py:84-129` | service | alarm_tasks | dynamic UPDATE | service-owned `get_db_connection`; service commits at `:118`; boolean error contract at `:120-129` | `AlarmTaskRepository.update_status(conn, ...)` preserving rowcount semantics | low-medium | `tests/test_alarm_status_service.py:47-76` | PR 1 |
+| ALARM-TASK-3 | `app/services/alarm_status_service.py:143-153`, `:206-214` | service | alarm_tasks | SELECT | service-owned `get_db_connection` | `AlarmTaskRepository.get_status/list_recent(conn, ...)` | low | `tests/test_alarm_status_service.py:78-126` | PR 1 |
+| ALARM-TASK-4 | `app/services/alarm_status_service.py:260-270` | service | alarm_tasks | DELETE | service-owned `get_db_connection`; service commits | `AlarmTaskRepository.cleanup_old(conn, ...)` | low | `tests/test_alarm_status_service.py:128-182` | PR 1 |
+
+Verdict: `alarm_tasks` remains the safest first implementation candidate after PR 0 because the persistence surface is concentrated in one service and already has SQLite-backed tests.
+
+### 6.3 Event persistence and event reads
+
+| ID | File / lines | Layer | Domain | Operation | Current transaction owner | Candidate boundary | Risk | Existing tests | PR bucket |
+|---|---|---|---|---|---|---|---|---|---|
+| EVENT-1 | `app/services/event_service.py:32-52` | service | events | INSERT | request-scoped connection passed into service; service commits at `:52` | `EventRepository.create(conn, ...)`; preserve service commit timing | medium | `tests/test_api_basic.py:47`, `tests/test_database.py:44-54` | PR 2a |
+| EVENT-2 | `app/services/event_service.py:97-107` | service | events | SELECT list with dynamic WHERE | request-scoped connection passed into service | `EventRepository.list(conn, filters, limit)` | medium | `tests/test_api_basic.py:47` | PR 2a |
+| EVENT-3 | `app/services/event_service.py:155-177` | service | events + users | SELECT user route + active events | request-scoped connection passed into service | Split: `UserRouteReadRepository` + `EventRepository.list_active_future`; keep orchestration in service | high | `tests/test_route_setting.py`, route/event integration coverage should be added before extraction | PR 2b |
+| EVENT-4 | `app/services/event_service.py:274-285` | service | users | SELECT active route users for scheduled checks | background/service-owned `get_db_connection` | User-route read boundary before event scheduled extraction | high | scheduler/API smoke in `tests/test_api_basic.py:48`; add targeted route-check tests before extraction | PR 2b |
+| EVENT-5 | `app/services/event_service.py:408-415`, `:464-470` | service | events | SELECT upcoming/today events | request-scoped connection passed into service | `EventRepository.list_upcoming/list_today_jongno(conn, ...)` | medium | `tests/test_api_basic.py:47`, future event repository tests | PR 2a |
+| EVENT-6 | `app/routers/events.py:20-30` | router | events | SELECT created event after service create | request-scoped `Depends(get_db)` | Remove with PR 2a only after create returns enough data or repository/service contract is planned | medium | API event creation coverage should be added/confirmed | PR 2a router decision |
+| EVENT-7 | `app/routers/events.py:132-146` | router | users | SELECT route-check users | request-scoped `Depends(get_db)` | User-route read boundary; not event write repository | high | route-check/admin manual trigger coverage should be added/confirmed | PR 2b / PR 4c dependency |
+
+Verdict: split `events` into CRUD/list (`PR 2a`) and route-check/scheduled orchestration (`PR 2b`). `PR 2b` depends on a clear user-route read boundary.
+
+### 6.4 User persistence
+
+| ID | File / lines | Layer | Domain | Operation | Current transaction owner | Candidate boundary | Risk | Existing tests | PR bucket |
+|---|---|---|---|---|---|---|---|---|---|
+| USER-1 | `app/services/user_service.py:38-57` | service | users | SELECT / UPDATE / INSERT | request-scoped connection passed into service; service commits at `:57`; raises at `:59-61` | `UserIdentityRepository.save_or_update(conn, ...)` | high | `tests/test_user_service.py:6-31` | PR 4a |
+| USER-2 | `app/services/user_service.py:86-162` | service | users | SELECT / UPDATE / INSERT identity sync | request-scoped connection; service commits at `:162` | `UserIdentityRepository.sync_kakao(conn, ...)` or smaller query methods | high | `tests/test_user_service.py:34-94` | PR 4a |
+| USER-3 | `app/services/user_service.py:175-179`, `:203-213`, `:245-255` | service | users | UPDATE active/alarm/favorite-zone | request-scoped connection; service commits after branch checks | `UserSettingsRepository` | medium-high | `tests/test_alarm_setting.py`, `tests/test_favorite_zone.py` | PR 4b |
+| USER-4 | `app/services/user_service.py:296-305`, `:351-355` | service | users | UPDATE route / clear route | request-scoped connection; external geocoding before route persistence; service commits or returns error dict | `UserRouteRepository` | high | `tests/test_route_setting.py`; add repository persistence tests before extraction | PR 4c |
+| USER-5 | `app/services/user_service.py:471` | service | users | dynamic UPDATE profile setup route/profile fields | request-scoped connection; external geocoding precedes dynamic update; service commits or returns error dict | `UserProfileRepository` with explicit route/profile field mapping | high | `tests/test_user_initial_setup.py` plus new repository tests | PR 4c |
+| USER-6 | `app/services/user_service.py:555`, `:619-624` | service | users | SELECT route/info by plusfriend/bot key | request-scoped connection | `UserReadRepository`; prerequisite for event route-check | high | `tests/test_user_service.py`, route tests | PR 4c / PR 2b prerequisite |
+| USER-7 | `app/routers/users.py:18-30` | router | users | SELECT users list | request-scoped `Depends(get_db)` | User read repository or admin/read query depending endpoint purpose | medium-high | user/admin API tests should be confirmed/added | PR 4c / PR 5 router cleanup |
+| USER-8 | `app/routers/users.py:120-124`, `:354-358` | router/background | users | connection acquisition for service call | router-owned/background `get_db_connection` but SQL in service | Preserve call shape; repository should accept existing connection inside service | medium | route-setting tests | PR 4c / PR 5 transaction cleanup |
+| USER-9 | `app/routers/kakao.py:28-68`, `:118-157` | router | users | SELECT / UPDATE / INSERT identity and active state | router-owned `get_db_connection`; commits inside router | Move to `UserService`/identity repository after service contract is explicit | high | Kakao/webhook tests should be added or confirmed before extraction | PR 4a / PR 5 router cleanup |
+| USER-10 | `app/routers/alarms.py:97-108`, `:165-196` | router | users | SELECT alarm recipients / filtered recipients | request-scoped `Depends(get_db)` | `AlarmRecipientReadRepository` or `UserNotificationPreferenceRepository` | medium-high | `tests/test_api_alarms.py:7-69` | PR 3 or PR 4b |
+| USER-11 | `app/routers/kakao_skills.py:19`, `:76`, `:131`, `:260`, `:516`, `:685`, `:770` | router | users/events | DB dependency injection into service-heavy skills | request-scoped `Depends(get_db)` | Preserve until matching service repositories exist; classify endpoint by service call | medium | Kakao skill tests should be confirmed before cleanup | PR 5 domain-specific cleanup |
+| USER-12 | `app/routers/kakao_skills.py:346-359` | router | users | service-call connection for identity sync + route update | router-owned `get_db_connection`; `UserService.sync_kakao_user` and `UserService.update_user_route` perform persistence | Preserve endpoint response; later route/profile extraction must account for this connection owner | high | route-setting and Kakao skill route-save tests should be confirmed/added | PR 4a / PR 4c / PR 5 router cleanup |
+| USER-13 | `app/routers/kakao_skills.py:637-648` | router/background | users | service-call connection for identity sync + marked bus update | router-owned `get_db_connection` for sync and background-owned `get_db_connection` for `update_marked_bus` | Preserve background-task behavior; repository should accept provided connection through service | high | marked bus/Kakao skill tests should be confirmed/added | PR 4b / PR 5 router cleanup |
+| USER-14 | `app/services/user_service.py:380-393`, `:510`, `:531` | service | users | UPDATE marked bus / SELECT user / dynamic UPDATE preferences | request-scoped connection; service commits or returns error dict | `UserPreferenceRepository` / `UserSettingsRepository` | high | `tests/test_alarm_setting.py`, `tests/test_favorite_zone.py`, `tests/test_user_initial_setup.py`; add real SQLite preference tests before extraction | PR 4b |
+
+Verdict: `users` is high-value but too broad for first extraction. Split identity sync, settings/preferences, route/profile, and read/recipient queries.
+
+### 6.5 Zone alarm and notification-recipient reads
+
+| ID | File / lines | Layer | Domain | Operation | Current transaction owner | Candidate boundary | Risk | Existing tests | PR bucket |
+|---|---|---|---|---|---|---|---|---|---|
+| ZONE-1 | `app/services/zone_alarm_service.py:31-55` | service | zone_alarm + users + events | SELECT users by favorite zone; SELECT active events | service-owned `get_db_connection` | `ZoneAlarmReadRepository` or query service after alarm recipient/user read rules | medium | add targeted zone alarm tests if missing | PR 3 |
+| ALARM-RECIPIENT-1 | `app/routers/alarms.py:104-108`, `:173-196` | router | users | SELECT recipients | request-scoped `Depends(get_db)` | `AlarmRecipientReadRepository` | medium-high | `tests/test_api_alarms.py:7-69` | PR 3 |
+
+Verdict: place after `alarm_tasks` because it shares alarm workflows but reads `users` and may need a recipient read boundary.
+
+### 6.6 Crawling persistence
+
+| ID | File / lines | Layer | Domain | Operation | Current transaction owner | Candidate boundary | Risk | Existing tests | PR bucket |
+|---|---|---|---|---|---|---|---|---|---|
+| CRAWL-1 | `app/services/crawling_service.py:857-878` | service | crawling + events | CREATE UNIQUE INDEX / INSERT OR IGNORE events | service-owned `get_db_connection` inside crawler sync | Keep specialized until `EventRepository` conventions are stable; then consider bulk event import repository | medium-high | `tests/test_crawling_service.py`; `tests/test_database_connection_settings.py:26-48` | Crawling |
+
+Verdict: do not use crawling as first repository extraction. It has specialized idempotent import and index behavior.
+
+### 6.7 Admin dashboard read model
+
+| ID | File / lines | Layer | Domain | Operation | Current transaction owner | Candidate boundary | Risk | Existing tests | PR bucket |
+|---|---|---|---|---|---|---|---|---|---|
+| ADMIN-1 | `app/routers/admin.py:126-135` | router | admin_dashboard + events | SELECT recent events | router-owned `get_db_connection` | `AdminDashboardQueryService` / read repository | medium | `tests/test_api_admin.py`, `tests/test_admin_dashboard_schema_compat.py:10-89` | Admin/read-model |
+| ADMIN-2 | `app/routers/admin.py:139-148` | router | admin_dashboard + alarm_tasks | SELECT recent alarms | router-owned `get_db_connection` | `AdminDashboardQueryService` / read repository | medium | `tests/test_api_admin.py`, `tests/test_admin_dashboard_schema_compat.py:10-89` | Admin/read-model |
+| ADMIN-3 | `app/routers/admin.py:158-210` | router | admin_dashboard + users | SELECT count, PRAGMA columns, paginated users | router-owned `get_db_connection`; legacy optional-column compatibility | `AdminDashboardQueryService`; preserve optional column behavior | high | `tests/test_admin_dashboard_schema_compat.py:10-89` | Admin/read-model |
+| ADMIN-4 | `app/routers/admin.py:368-370` | router/background | admin_dashboard + events | connection for manual route check service call | background task `get_db_connection`; service owns SQL | Keep as orchestration until route-check repositories exist | medium | admin API tests | PR 2b / Admin/read-model |
+
+Verdict: admin dashboard is a read-model/query boundary, not a domain write repository.
+
+## 7. Test inventory
+
+| ID | File / lines | Layer | Domain | Operation | Purpose | Repository relevance |
+|---|---|---|---|---|---|---|
+| TEST-1 | `tests/conftest.py:37-43` | test | cross_domain | sqlite connect + DELETE setup | cleans `users`, `events`, `alarm_tasks` | Keep as fixture setup; not repository candidate |
+| TEST-2 | `tests/test_database.py:9-107` | test | database_schema | schema and FK insert/select checks | verifies DB init and table compatibility | Keep as schema/DB baseline |
+| TEST-3 | `tests/test_database_connection_settings.py:9-48` | test | database_schema | sqlite connect / get_db_connection / get_db | verifies settings-driven DB path | Protect connection boundary |
+| TEST-4 | `tests/test_alarm_status_service.py:8-182` | test | alarm_tasks | real SQLite persistence via service | validates create/update/list/cleanup success paths | Baseline for PR 1 |
+| TEST-5 | `tests/test_user_service.py:7-92` | test | users | real SQLite seed/assert | validates Kakao identity sync conflict behavior | Baseline for PR 4a |
+| TEST-6 | `tests/test_api_alarms.py:7-69` | test | users / alarm recipients | SQLite seed users for API | validates recipient ID separation and filtering | Baseline for PR 3 / PR 4b |
+| TEST-7 | `tests/test_admin_dashboard_schema_compat.py:18-150` | test | admin_dashboard | legacy SQLite schema/data setup and assertions | validates optional/legacy admin columns | Required for admin read-model track |
+| TEST-8 | `tests/test_api_admin.py` | test | admin_dashboard / external effects | API + mocked trigger side effects | verifies auth/admin flows; external calls may be mocked | Keep external-effect mocks separate from persistence assertions |
+| TEST-9 | `tests/test_alarm_setting.py:94-128`, `tests/test_favorite_zone.py`, `tests/test_route_setting.py`, `tests/test_user_initial_setup.py` | test | users | router response/service-interaction tests | validates response text and service invocation, but may mock persistence-facing `UserService` methods | Do not count as repository persistence coverage; pair with real SQLite tests such as `tests/test_user_service.py` for PR 4 |
+| TEST-10 | `tests/test_crawling_service.py`, `tests/test_database_connection_settings.py:26-48` | test | crawling/events | crawler normalization and DB path behavior | protects crawler import assumptions | Baseline for crawling track |
+
+## 8. Transaction-owner matrix
+
+| Caller | Evidence | Connection source | Commit owner | Rollback/error behavior | Repository method rule |
+|---|---|---|---|---|---|
+| Request-scoped router/service | `app/database/connection.py:16-23`, `app/routers/events.py:20`, `app/routers/alarms.py:97`, `app/routers/users.py:18` | `Depends(get_db)` yields one request connection | Existing router/service path may commit; dependency closes connection after yield | Errors propagate through endpoint/service contracts; no repository-level swallowing | Repository methods must accept the provided connection and must not open a global connection. |
+| Service-owned context manager | `app/services/alarm_status_service.py:38-57`, `:84-129`, `:143-153`, `:206-214`, `:260-270`; `app/database/connection.py:27-34` | `get_db_connection()` context manager | Service method commits inside the context manager when current behavior does | Preserve current boolean/None/dict error returns and logged exceptions such as `app/services/alarm_status_service.py:127-129` | Extract SQL and row mapping first; keep service-level success/error and commit timing stable. |
+| Background task/service call | `app/services/event_service.py:274-285`, `app/routers/admin.py:368-370`, `app/routers/users.py:354-358`, `app/routers/kakao_skills.py:644-648` | Background task opens `get_db_connection()` or receives service-call connection | Background function/service owns commit timing through invoked service | Preserve task failure logging/return behavior; do not hide background exceptions in repositories | Repository must be synchronous DB boundary only; it must not start background tasks or own scheduling. |
+| Router-owned persistence | `app/routers/kakao.py:28-68`, `:118-157`; `app/routers/alarms.py:104-108`, `:196`; `app/routers/users.py:24` | Router uses request DB or explicit `get_db_connection()` | Router/request path currently executes SQL and may commit | Preserve endpoint response and auth/error semantics before moving SQL | Move only after matching domain service/repository boundary exists; verify endpoint compatibility per domain. |
+| Schema initialization | `app/database/connection.py:39-70` | Connection module opens schema/compatibility connection | Init function owns DDL transaction behavior | Preserve migration/compatibility error visibility | Keep schema DDL outside domain repositories. |
+| Test fixture/setup/assertions | `tests/conftest.py:37-43`, `tests/test_database.py:9-107` | Direct test `sqlite3.connect` or test fixture DB path | Test fixture/setup owns cleanup and assertions | Test failures must remain visible; do not replace persistence assertions with mocks | Keep as real SQLite integration coverage, not production repository candidates. |
+
+## 9. Repository responsibility rules
+
+| Layer | Responsibility |
+|---|---|
+| Router | Request parsing, response shaping, dependency injection, endpoint compatibility. No direct SQL after matching service/repository boundary exists unless explicitly justified. |
+| Service | Business orchestration, validation, external API/notification/geocoding/crawling coordination, and current transaction/commit timing. |
+| Repository | SQL statements, parameter binding, row mapping, and focused query/update methods. Accept existing `sqlite3.Connection`. |
+| DB connection module | Connection creation, row factory, schema initialization, compatibility DDL. |
+| Read/query service | Cross-domain read models such as admin dashboard or recipient lists when domain repositories would be polluted. |
+| Tests | Real SQLite-backed persistence verification; external effects may be mocked only outside persistence assertions. |
+
+## 10. PR sequence
+
+| PR | Scope | Evidence / rationale | Required verification |
+|---:|---|---|---|
+| 0 | This artifact: inventory, taxonomy, responsibility rules, PR sequence, test matrix | All production and test scan rows above | `git diff --check`; changed-files audit; `uv run python -m pytest tests/ -v` |
+| 1 | `alarm_tasks` repository extraction | `app/services/alarm_status_service.py:38-270`; tests `tests/test_alarm_status_service.py:8-182` | `uv run python -m pytest tests/test_alarm_status_service.py tests/test_api_basic.py -v`; full tests |
+| 2a | `events` CRUD/list/upcoming/today repository | `app/services/event_service.py:32-52`, `:97-107`, `:408-415`, `:464-470` | event API/basic/database tests plus new repository tests; full tests |
+| 2b | route-check/scheduled event orchestration | `app/services/event_service.py:155-177`, `:274-285`; `app/routers/events.py:142-146` | route-setting/route-event integration tests; full tests |
+| 3 | alarm recipient / zone alarm read boundary | `app/routers/alarms.py:104-108`, `:173-196`; `app/services/zone_alarm_service.py:31-55` | `tests/test_api_alarms.py`; new zone alarm tests if needed; full tests |
+| 4a | user identity sync | `app/services/user_service.py:38-162`; `app/routers/kakao.py:28-68`, `:118-157` | `tests/test_user_service.py`; Kakao webhook tests if added; full tests |
+| 4b | user settings/preferences | `app/services/user_service.py:175-255`, `:380-393`, `:510-531`; inventory `USER-3`, `USER-13`, `USER-14` | alarm/favorite/preference tests plus real SQLite preference tests; full tests |
+| 4c | user route/profile/read boundary | `app/services/user_service.py:296-355`, `:471`, `:555`, `:619-624`; inventory `USER-4`, `USER-5`, `USER-6`, `USER-12` | route/profile tests plus real SQLite route/profile tests; full tests |
+| 5 | domain-by-domain router SQL/service-call cleanup | `app/routers/events.py:29`, `:142-146`; `app/routers/alarms.py:104-108`, `:196`; `app/routers/users.py:24`; `app/routers/kakao.py:28-68`, `:118-157`; `app/routers/kakao_skills.py:346-359`, `:637-648` | endpoint/API compatibility checks for each affected domain; full tests |
+| Admin/read-model | admin dashboard query service/read repository | `app/routers/admin.py:126-210`; legacy tests `tests/test_admin_dashboard_schema_compat.py:18-150` | `tests/test_admin_dashboard_schema_compat.py tests/test_api_admin.py -v`; full tests |
+| Crawling | event bulk import/idempotent sync boundary | `app/services/crawling_service.py:857-878` | crawler tests + DB settings tests; full tests |
+
+## 11. First implementation candidate
+
+Recommended first implementation after PR 0: `alarm_tasks`.
+
+| Candidate | Verdict | Reason |
+|---|---|---|
+| `alarm_tasks` | Recommended | SQL is concentrated in `app/services/alarm_status_service.py:38-270`; test coverage exists in `tests/test_alarm_status_service.py:8-182`. |
+| `events` | Second, split-aware | Event CRUD/list is reasonable, but route-check reads users at `app/services/event_service.py:155-177`. |
+| `users` | Defer and split | Largest SQL and identity/settings/route/profile surface: `app/services/user_service.py:38-624` plus router SQL in `app/routers/kakao.py`, `app/routers/alarms.py`, `app/routers/users.py`. |
+
+## 12. Future file layout proposal
+
+No files are created in PR 0. For later PRs:
+
+```text
+app/repositories/
+  __init__.py
+  alarm_task_repository.py
+  event_repository.py
+  user_identity_repository.py
+  user_settings_repository.py
+  user_route_repository.py
+  alarm_recipient_repository.py
+  zone_alarm_read_repository.py
+  admin_dashboard_query_service.py  # or read_repository naming, decided in admin track
+```
+
+Naming rule:
+
+- Use domain-specific repositories for write/query methods tied to one table/domain.
+- Use query service/read repository naming for cross-domain reads.
+- Keep transaction ownership in service/router orchestration until a later approved plan changes it.
+
+## 13. Verification contract
+
+PR 0 must pass:
+
+```bash
+git diff --check
+uv run python -m pytest tests/ -v
+```
+
+Changed-files gate:
+
+- Allowed: `.omx/context/*`, `.omx/plans/*`, `.omx/state/*` lifecycle files.
+- Not allowed for PR 0 without separate explicit scope: production `.py`, schema definitions, dependency files, API contract files, test weakening.
+
+Mock policy correction:
+
+- Tests that mock persistence-facing service methods, for example `tests/test_alarm_setting.py:94-128`, are router response/service-interaction checks, not repository persistence checks.
+- Repository persistence coverage must come from real SQLite tests such as `tests/test_user_service.py`, `tests/test_alarm_status_service.py`, and `tests/test_database.py`.
+
+## 14. Follow-up execution note
+
+If execution continues after this PR 0 artifact:
+
+1. Start with `alarm_tasks` repository extraction.
+2. Preserve current `AlarmStatusService` public behavior and error/boolean contracts.
+3. Add repository integration tests before moving SQL.
+4. Run targeted alarm task tests and the full test suite.

--- a/tests/test_admin_dashboard_read_repository.py
+++ b/tests/test_admin_dashboard_read_repository.py
@@ -1,0 +1,213 @@
+"""관리자 대시보드 read-model 저장소 통합 테스트."""
+import os
+import sqlite3
+import tempfile
+from typing import Iterator
+
+import pytest
+
+from app.database.models import ALARM_TASKS_TABLE_SCHEMA, EVENTS_TABLE_SCHEMA, USERS_TABLE_SCHEMA
+from app.repositories.admin_dashboard_read_repository import AdminDashboardReadRepository
+
+
+@pytest.fixture
+def admin_dashboard_db() -> Iterator[sqlite3.Connection]:
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(USERS_TABLE_SCHEMA)
+    conn.execute(EVENTS_TABLE_SCHEMA)
+    conn.execute(ALARM_TASKS_TABLE_SCHEMA)
+    conn.commit()
+
+    try:
+        yield conn
+    finally:
+        conn.close()
+        try:
+            os.remove(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def test_admin_dashboard_repository_lists_recent_events_and_alarms(admin_dashboard_db):
+    admin_dashboard_db.execute(
+        """
+        INSERT INTO events (
+            title, location_name, latitude, longitude,
+            start_date, severity_level, status, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("집회 A", "광화문", 37.57, 126.98, "2026-05-12T09:00:00", 2, "active", "2026-05-12T08:00:00"),
+    )
+    admin_dashboard_db.execute(
+        """
+        INSERT INTO alarm_tasks (
+            task_id, alarm_type, status, total_recipients,
+            successful_sends, failed_sends, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("task-1", "bulk", "completed", 3, 2, 1, "2026-05-12T08:30:00"),
+    )
+    admin_dashboard_db.commit()
+
+    events = AdminDashboardReadRepository.list_recent_events(admin_dashboard_db)
+    alarms = AdminDashboardReadRepository.list_recent_alarms(admin_dashboard_db)
+
+    assert events == [
+        {
+            "id": 1,
+            "title": "집회 A",
+            "location_name": "광화문",
+            "severity_level": 2,
+            "start_date": "2026-05-12T09:00:00",
+            "created_at": "2026-05-12T08:00:00",
+            "status": "active",
+        }
+    ]
+    assert alarms == [
+        {
+            "task_id": "task-1",
+            "alarm_type": "bulk",
+            "status": "completed",
+            "total_recipients": 3,
+            "successful_sends": 2,
+            "failed_sends": 1,
+            "created_at": "2026-05-12T08:30:00",
+        }
+    ]
+
+
+def test_admin_dashboard_repository_preserves_optional_user_columns(admin_dashboard_db):
+    admin_dashboard_db.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, plusfriend_user_key, open_id,
+            first_message_at, last_message_at, message_count,
+            active, departure_name, arrival_name, marked_bus,
+            is_alarm_on, favorite_zone
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "bot-modern",
+            "pf-modern",
+            "open-modern",
+            "2026-05-12T08:00:00",
+            "2026-05-12T09:00:00",
+            5,
+            1,
+            "출발",
+            "도착",
+            "7016",
+            0,
+            None,
+        ),
+    )
+    admin_dashboard_db.commit()
+
+    assert AdminDashboardReadRepository.count_users(admin_dashboard_db) == 1
+
+    users = AdminDashboardReadRepository.list_paginated_users(
+        admin_dashboard_db,
+        limit=10,
+        offset=0,
+    )
+
+    assert users == [
+        {
+            "id": 1,
+            "bot_user_key": "bot-modern",
+            "active": 1,
+            "departure_name": "출발",
+            "arrival_name": "도착",
+            "marked_bus": "7016",
+            "created_at": "2026-05-12T08:00:00",
+            "message_count": 5,
+            "plusfriend_user_key": "pf-modern",
+            "open_id": "open-modern",
+            "is_alarm_on": 0,
+            "favorite_zone": 0,
+        }
+    ]
+
+
+def test_admin_dashboard_repository_supports_legacy_user_schema():
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                bot_user_key TEXT UNIQUE NOT NULL,
+                first_message_at DATETIME,
+                last_message_at DATETIME,
+                message_count INTEGER DEFAULT 1,
+                location TEXT,
+                active BOOLEAN DEFAULT TRUE,
+                departure_name TEXT,
+                arrival_name TEXT,
+                marked_bus TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO users (
+                bot_user_key, first_message_at, last_message_at,
+                message_count, active, departure_name, arrival_name, marked_bus
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-user",
+                "2026-05-12T07:00:00",
+                "2026-05-12T08:00:00",
+                3,
+                1,
+                "영통역",
+                "광화문역",
+                "470",
+            ),
+        )
+        conn.commit()
+
+        users = AdminDashboardReadRepository.list_paginated_users(conn, limit=10, offset=0)
+
+        assert users == [
+            {
+                "id": 1,
+                "bot_user_key": "legacy-user",
+                "active": 1,
+                "departure_name": "영통역",
+                "arrival_name": "광화문역",
+                "marked_bus": "470",
+                "created_at": "2026-05-12T07:00:00",
+                "message_count": 3,
+                "plusfriend_user_key": None,
+                "open_id": None,
+                "is_alarm_on": None,
+                "favorite_zone": 0,
+            }
+        ]
+    finally:
+        conn.close()
+        os.remove(db_path)
+
+
+def test_admin_dashboard_repository_returns_empty_read_model_for_uninitialized_db():
+    conn = sqlite3.connect(":memory:")
+
+    try:
+        assert AdminDashboardReadRepository.list_recent_events(conn) == []
+        assert AdminDashboardReadRepository.list_recent_alarms(conn) == []
+        assert AdminDashboardReadRepository.count_users(conn) == 0
+        assert AdminDashboardReadRepository.list_paginated_users(conn, limit=10, offset=0) == []
+    finally:
+        conn.close()

--- a/tests/test_alarm_recipient_read_repository.py
+++ b/tests/test_alarm_recipient_read_repository.py
@@ -1,0 +1,126 @@
+"""Alarm recipient read repository integration tests."""
+import os
+import sqlite3
+import tempfile
+from typing import Iterator
+
+import pytest
+
+from app.database.models import USERS_TABLE_SCHEMA
+from app.repositories.alarm_recipient_read_repository import AlarmRecipientReadRepository
+
+
+@pytest.fixture
+def recipient_db() -> Iterator[sqlite3.Connection]:
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(USERS_TABLE_SCHEMA)
+    conn.commit()
+
+    try:
+        yield conn
+    finally:
+        conn.close()
+        try:
+            os.remove(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def _insert_user(
+    db: sqlite3.Connection,
+    *,
+    bot_user_key: str | None,
+    plusfriend_user_key: str | None,
+    active: int = 1,
+    is_alarm_on: int = 1,
+    marked_bus: str | None = None,
+    location: str | None = None,
+    has_route: bool = False,
+) -> None:
+    route_values = (127.0, 37.5, 126.9, 37.4) if has_route else (None, None, None, None)
+    db.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, plusfriend_user_key, first_message_at, last_message_at,
+            message_count, active, is_alarm_on, marked_bus, location,
+            departure_x, departure_y, arrival_x, arrival_y
+        )
+        VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            bot_user_key,
+            plusfriend_user_key,
+            active,
+            is_alarm_on,
+            marked_bus,
+            location,
+            *route_values,
+        ),
+    )
+
+
+def test_list_active_recipients_preserves_plusfriend_and_bot_separation(recipient_db):
+    _insert_user(recipient_db, bot_user_key="bot-with-pf", plusfriend_user_key="pf-1")
+    _insert_user(recipient_db, bot_user_key="bot-only", plusfriend_user_key=None)
+    _insert_user(recipient_db, bot_user_key="inactive", plusfriend_user_key="pf-inactive", active=0)
+    _insert_user(recipient_db, bot_user_key="off", plusfriend_user_key="pf-off", is_alarm_on=0)
+    recipient_db.commit()
+
+    recipients = AlarmRecipientReadRepository.list_active_recipients(recipient_db)
+
+    assert recipients == {
+        "plusfriend_user_keys": ["pf-1"],
+        "bot_user_keys": ["bot-only"],
+    }
+
+
+def test_list_filtered_recipients_applies_marked_bus_location_and_route_filters(recipient_db):
+    _insert_user(
+        recipient_db,
+        bot_user_key="bot-with-pf",
+        plusfriend_user_key="pf-1",
+        marked_bus="470",
+        location="서울 종로",
+        has_route=True,
+    )
+    _insert_user(
+        recipient_db,
+        bot_user_key="bot-only",
+        plusfriend_user_key=None,
+        marked_bus="470",
+        location="서울 종로",
+        has_route=True,
+    )
+    _insert_user(
+        recipient_db,
+        bot_user_key="wrong-bus",
+        plusfriend_user_key="pf-wrong-bus",
+        marked_bus="7016",
+        location="서울 종로",
+        has_route=True,
+    )
+    _insert_user(
+        recipient_db,
+        bot_user_key="no-route",
+        plusfriend_user_key="pf-no-route",
+        marked_bus="470",
+        location="서울 종로",
+        has_route=False,
+    )
+    recipient_db.commit()
+
+    recipients = AlarmRecipientReadRepository.list_filtered_recipients(
+        recipient_db,
+        filter_location="종로",
+        filter_marked_bus="470",
+        filter_has_route=True,
+    )
+
+    assert recipients == {
+        "plusfriend_user_keys": ["pf-1"],
+        "bot_user_keys": ["bot-only"],
+    }

--- a/tests/test_alarm_task_repository.py
+++ b/tests/test_alarm_task_repository.py
@@ -1,0 +1,160 @@
+"""Alarm task repository integration tests."""
+import json
+import os
+import sqlite3
+import tempfile
+from typing import Iterator
+
+import pytest
+
+from app.database.models import ALARM_TASKS_TABLE_SCHEMA, EVENTS_TABLE_SCHEMA
+from app.repositories.alarm_task_repository import AlarmTaskRepository
+
+
+@pytest.fixture
+def alarm_task_db_pair() -> Iterator[tuple[sqlite3.Connection, sqlite3.Connection]]:
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    writer = sqlite3.connect(db_path)
+    reader = sqlite3.connect(db_path)
+    writer.execute("PRAGMA foreign_keys = ON")
+    reader.execute("PRAGMA foreign_keys = ON")
+    writer.execute(EVENTS_TABLE_SCHEMA)
+    writer.execute(ALARM_TASKS_TABLE_SCHEMA)
+    writer.commit()
+
+    try:
+        yield writer, reader
+    finally:
+        writer.close()
+        reader.close()
+        try:
+            os.remove(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def _task_count(db: sqlite3.Connection) -> int:
+    cursor = db.execute("SELECT COUNT(*) FROM alarm_tasks")
+    return int(cursor.fetchone()[0])
+
+
+def test_create_task_uses_caller_transaction(alarm_task_db_pair):
+    writer, reader = alarm_task_db_pair
+    request_data = {"user_id": "test-user", "nested": {"route": "A"}}
+    event_id = writer.execute(
+        """
+        INSERT INTO events (title, location_name, latitude, longitude, start_date)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        ("test-event", "test-location", 37.5, 127.0, "2026-05-12T09:00:00"),
+    ).lastrowid
+    writer.commit()
+
+    rowcount = AlarmTaskRepository.create_task(
+        writer,
+        task_id="task-create",
+        alarm_type="individual",
+        total_recipients=2,
+        event_id=event_id,
+        request_data=json.dumps(request_data),
+        created_at="2026-05-12T09:00:00",
+    )
+
+    assert rowcount == 1
+    assert _task_count(writer) == 1
+    assert _task_count(reader) == 0
+
+    writer.commit()
+
+    saved = AlarmTaskRepository.get_status(reader, "task-create")
+    assert saved is not None
+    assert saved["status"] == "pending"
+    assert saved["request_data"] == json.dumps(request_data)
+
+
+def test_update_status_returns_rowcount_without_committing(alarm_task_db_pair):
+    writer, reader = alarm_task_db_pair
+    AlarmTaskRepository.create_task(
+        writer,
+        task_id="task-update",
+        alarm_type="bulk",
+        total_recipients=5,
+        event_id=None,
+        request_data=None,
+        created_at="2026-05-12T09:00:00",
+    )
+    writer.commit()
+
+    rowcount = AlarmTaskRepository.update_status(
+        writer,
+        task_id="task-update",
+        status="completed",
+        updated_at="2026-05-12T09:01:00",
+        successful_sends=4,
+        failed_sends=1,
+        error_messages=json.dumps(["timeout"]),
+        total_recipients=5,
+        completed_at="2026-05-12T09:02:00",
+    )
+
+    assert rowcount == 1
+    before_commit = AlarmTaskRepository.get_status(reader, "task-update")
+    assert before_commit is not None
+    assert before_commit["status"] == "pending"
+
+    writer.commit()
+
+    after_commit = AlarmTaskRepository.get_status(reader, "task-update")
+    assert after_commit is not None
+    assert after_commit["status"] == "completed"
+    assert after_commit["successful_sends"] == 4
+    assert after_commit["failed_sends"] == 1
+    assert after_commit["error_messages"] == json.dumps(["timeout"])
+    assert after_commit["completed_at"] == "2026-05-12T09:02:00"
+
+    assert (
+        AlarmTaskRepository.update_status(
+            writer,
+            task_id="missing-task",
+            status="completed",
+            updated_at="2026-05-12T09:03:00",
+        )
+        == 0
+    )
+
+
+def test_list_recent_and_delete_older_than(alarm_task_db_pair):
+    writer, reader = alarm_task_db_pair
+    for task_id, created_at in [
+        ("old-task", "2026-04-01T00:00:00"),
+        ("middle-task", "2026-05-01T00:00:00"),
+        ("new-task", "2026-05-12T00:00:00"),
+    ]:
+        AlarmTaskRepository.create_task(
+            writer,
+            task_id=task_id,
+            alarm_type="bulk",
+            total_recipients=1,
+            event_id=None,
+            request_data=None,
+            created_at=created_at,
+        )
+    writer.commit()
+
+    recent = AlarmTaskRepository.list_recent(reader, limit=2)
+    assert [task["task_id"] for task in recent] == ["new-task", "middle-task"]
+
+    deleted_count = AlarmTaskRepository.delete_older_than(
+        writer,
+        cutoff_date="2026-05-01T00:00:00",
+    )
+
+    assert deleted_count == 1
+    assert _task_count(reader) == 3
+
+    writer.commit()
+
+    remaining = AlarmTaskRepository.list_recent(reader, limit=10)
+    assert [task["task_id"] for task in remaining] == ["new-task", "middle-task"]

--- a/tests/test_crawling_service.py
+++ b/tests/test_crawling_service.py
@@ -137,5 +137,36 @@ class TestCrawlSpaticEvents:
             assert len(result) == 1
 
 
+def test_sync_to_database_preserves_bulk_import_idempotency(clean_test_db):
+    event_row = {
+        "년": "2026",
+        "월": "05",
+        "일": "12",
+        "start_time": "10:00",
+        "end_time": "12:00",
+        "장소": "광화문",
+        "인원": "1200",
+        "위도": 37.571,
+        "경도": 126.976,
+        "지번주소": "서울 종로구 세종대로",
+        "title": "광화문 집회",
+        "description": "집회 설명",
+    }
+
+    first_count = CrawlingService._sync_to_database([event_row, {**event_row, "title": "중복 집회"}])
+    second_count = CrawlingService._sync_to_database([{**event_row, "title": "중복 재시도"}])
+
+    from app.database.connection import get_db_connection
+
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT title, location_name, start_date, severity_level FROM events")
+        rows = [tuple(row) for row in cursor.fetchall()]
+
+    assert first_count == 1
+    assert second_count == 0
+    assert rows == [("광화문 집회", "광화문", "2026-05-12 10:00:00", 3)]
+
+
 # Note: _fetch_list_playwright logic was merged into CrawlingService._scrape_spatic.
 # Specific playwright parsing tests should be updated to test _scrape_spatic if needed.

--- a/tests/test_event_bulk_import_repository.py
+++ b/tests/test_event_bulk_import_repository.py
@@ -1,0 +1,70 @@
+"""크롤링 이벤트 bulk import 저장소 통합 테스트."""
+
+from app.database.connection import get_db_connection
+from app.repositories.event_bulk_import_repository import EventBulkImportRepository
+
+
+def _bulk_row(
+    *,
+    title: str = "광화문 집회",
+    location_name: str = "광화문",
+    start_date: str = "2026-05-12 10:00:00",
+):
+    return (
+        title,
+        "집회 설명",
+        location_name,
+        "서울 종로구 세종대로",
+        37.571,
+        126.976,
+        start_date,
+        "2026-05-12 12:00:00",
+        "집회",
+        3,
+        "active",
+    )
+
+
+def test_event_bulk_import_repository_preserves_insert_or_ignore_idempotency(clean_test_db):
+    with get_db_connection() as conn:
+        EventBulkImportRepository.ensure_location_date_unique_index(conn)
+
+        first_count = EventBulkImportRepository.insert_or_ignore_events(
+            conn,
+            [_bulk_row(), _bulk_row(title="중복 집회")],
+        )
+        second_count = EventBulkImportRepository.insert_or_ignore_events(
+            conn,
+            [_bulk_row(title="중복 재시도")],
+        )
+        conn.commit()
+
+        cursor = conn.cursor()
+        cursor.execute("SELECT title, location_name, start_date FROM events")
+        rows = [tuple(row) for row in cursor.fetchall()]
+
+    assert first_count == 1
+    assert second_count == 0
+    assert rows == [("광화문 집회", "광화문", "2026-05-12 10:00:00")]
+
+
+def test_event_bulk_import_repository_allows_different_location_or_date(clean_test_db):
+    with get_db_connection() as conn:
+        EventBulkImportRepository.ensure_location_date_unique_index(conn)
+
+        inserted_count = EventBulkImportRepository.insert_or_ignore_events(
+            conn,
+            [
+                _bulk_row(location_name="광화문", start_date="2026-05-12 10:00:00"),
+                _bulk_row(location_name="시청", start_date="2026-05-12 10:00:00"),
+                _bulk_row(location_name="광화문", start_date="2026-05-12 13:00:00"),
+            ],
+        )
+        conn.commit()
+
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM events")
+        total_count = cursor.fetchone()[0]
+
+    assert inserted_count == 3
+    assert total_count == 3

--- a/tests/test_event_repository.py
+++ b/tests/test_event_repository.py
@@ -1,0 +1,159 @@
+"""Event repository integration tests."""
+import os
+import sqlite3
+import tempfile
+from typing import Iterator
+
+import pytest
+
+from app.database.models import EVENTS_TABLE_SCHEMA
+from app.repositories.event_repository import EventRepository
+
+
+@pytest.fixture
+def event_db_pair() -> Iterator[tuple[sqlite3.Connection, sqlite3.Connection]]:
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    writer = sqlite3.connect(db_path)
+    reader = sqlite3.connect(db_path)
+    writer.row_factory = sqlite3.Row
+    reader.row_factory = sqlite3.Row
+    writer.execute(EVENTS_TABLE_SCHEMA)
+    writer.commit()
+
+    try:
+        yield writer, reader
+    finally:
+        writer.close()
+        reader.close()
+        try:
+            os.remove(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def _event_count(db: sqlite3.Connection) -> int:
+    cursor = db.execute("SELECT COUNT(*) FROM events")
+    return int(cursor.fetchone()[0])
+
+
+def test_create_event_uses_caller_transaction(event_db_pair):
+    writer, reader = event_db_pair
+
+    event_id = EventRepository.create_event(
+        writer,
+        title="종로 집회",
+        description="테스트 설명",
+        location_name="종로구청",
+        location_address="서울 종로구",
+        latitude=37.5729,
+        longitude=126.9794,
+        start_date="2026-05-12T10:00:00",
+        end_date="2026-05-12T12:00:00",
+        category="protest",
+        severity_level=2,
+        status="active",
+    )
+
+    assert event_id == 1
+    assert _event_count(writer) == 1
+    assert _event_count(reader) == 0
+
+    writer.commit()
+
+    saved = EventRepository.get_by_id(reader, event_id)
+    assert saved is not None
+    assert saved["title"] == "종로 집회"
+    assert saved["status"] == "active"
+    assert saved["severity_level"] == 2
+
+
+def test_list_events_filters_orders_and_limits(event_db_pair):
+    writer, reader = event_db_pair
+    EventRepository.create_event(
+        writer,
+        title="old-active",
+        description=None,
+        location_name="서울광장",
+        location_address=None,
+        latitude=37.5,
+        longitude=127.0,
+        start_date="2026-05-01T09:00:00",
+        end_date=None,
+        category="notice",
+        severity_level=1,
+        status="active",
+    )
+    EventRepository.create_event(
+        writer,
+        title="new-active",
+        description=None,
+        location_name="광화문",
+        location_address=None,
+        latitude=37.5,
+        longitude=127.0,
+        start_date="2026-05-12T09:00:00",
+        end_date=None,
+        category="notice",
+        severity_level=3,
+        status="active",
+    )
+    EventRepository.create_event(
+        writer,
+        title="inactive",
+        description=None,
+        location_name="청계천",
+        location_address=None,
+        latitude=37.5,
+        longitude=127.0,
+        start_date="2026-05-13T09:00:00",
+        end_date=None,
+        category="notice",
+        severity_level=2,
+        status="ended",
+    )
+    writer.commit()
+
+    rows = EventRepository.list_events(reader, category="notice", status="active", limit=1)
+
+    assert [row["title"] for row in rows] == ["new-active"]
+
+
+def test_list_upcoming_and_today_events(event_db_pair):
+    writer, reader = event_db_pair
+    for title, location_name, location_address, start_date, status in [
+        ("past", "종로", "서울 종로구", "2026-05-11T09:00:00", "active"),
+        ("future", "광화문", "서울 종로구", "2026-05-12T11:00:00", "active"),
+        ("later", "시청", "서울 중구", "2026-05-13T11:00:00", "active"),
+        ("inactive", "종로", "서울 종로구", "2026-05-12T12:00:00", "cancelled"),
+    ]:
+        EventRepository.create_event(
+            writer,
+            title=title,
+            description=None,
+            location_name=location_name,
+            location_address=location_address,
+            latitude=37.5,
+            longitude=127.0,
+            start_date=start_date,
+            end_date=None,
+            category="notice",
+            severity_level=1,
+            status=status,
+        )
+    writer.commit()
+
+    upcoming = EventRepository.list_upcoming(
+        reader,
+        now="2026-05-12T10:00:00",
+        limit=2,
+    )
+    assert [row["title"] for row in upcoming] == ["future", "later"]
+
+    today = EventRepository.list_today_by_location_pattern(
+        reader,
+        today="2026-05-12",
+        location_pattern="%종로%",
+    )
+    assert [row["title"] for row in today] == ["future"]

--- a/tests/test_route_event_integration.py
+++ b/tests/test_route_event_integration.py
@@ -1,0 +1,126 @@
+"""Route/event orchestration integration tests."""
+import os
+import sqlite3
+import tempfile
+from typing import Iterator
+
+import pytest
+
+from app.config.settings import settings
+from app.database.models import EVENTS_TABLE_SCHEMA, USERS_TABLE_SCHEMA
+from app.services.event_service import EventService
+
+
+@pytest.fixture
+def route_event_integration_db() -> Iterator[sqlite3.Connection]:
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(USERS_TABLE_SCHEMA)
+    conn.execute(EVENTS_TABLE_SCHEMA)
+    conn.commit()
+
+    try:
+        yield conn
+    finally:
+        conn.close()
+        try:
+            os.remove(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def _insert_route_user(db: sqlite3.Connection) -> None:
+    db.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, plusfriend_user_key, first_message_at, last_message_at,
+            message_count, active, is_alarm_on,
+            departure_name, departure_address, departure_x, departure_y,
+            arrival_name, arrival_address, arrival_x, arrival_y
+        )
+        VALUES (
+            'bot-route', 'pf-route', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+            1, 1, 1,
+            '출발', '출발 주소', 127.0, 37.0,
+            '도착', '도착 주소', 127.1, 37.1
+        )
+        """
+    )
+
+
+def _insert_route_event(
+    db: sqlite3.Connection,
+    *,
+    title: str,
+    latitude: float,
+    longitude: float,
+    status: str = "active",
+    start_modifier: str = "+10 hours",
+) -> None:
+    db.execute(
+        """
+        INSERT INTO events (
+            title, description, location_name, location_address,
+            latitude, longitude, start_date, end_date, category,
+            severity_level, status
+        )
+        VALUES (?, ?, ?, ?, ?, ?, datetime('now', ?), datetime('now', '+11 hours'), ?, ?, ?)
+        """,
+        (
+            title,
+            f"{title} 설명",
+            "광화문",
+            "서울 종로구",
+            latitude,
+            longitude,
+            start_modifier,
+            "집회",
+            3,
+            status,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_route_events_combines_route_read_and_active_event_query(
+    route_event_integration_db,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "TMAP_APP_KEY", None)
+    monkeypatch.setattr(settings, "KAKAO_LOCATION_API_KEY", None)
+    _insert_route_user(route_event_integration_db)
+    _insert_route_event(
+        route_event_integration_db,
+        title="경로 인근 예정 집회",
+        latitude=37.05,
+        longitude=127.05,
+    )
+    _insert_route_event(
+        route_event_integration_db,
+        title="지난 집회",
+        latitude=37.05,
+        longitude=127.05,
+        start_modifier="+8 hours",
+    )
+    _insert_route_event(
+        route_event_integration_db,
+        title="취소 집회",
+        latitude=37.05,
+        longitude=127.05,
+        status="cancelled",
+    )
+    route_event_integration_db.commit()
+
+    result = await EventService.check_route_events(
+        "pf-route",
+        auto_notify=False,
+        db=route_event_integration_db,
+    )
+
+    assert result.user_id == "pf-route"
+    assert [event.title for event in result.events_found] == ["경로 인근 예정 집회"]
+    assert result.total_events == 1
+    assert result.route_info["departure"]["name"] == "출발"

--- a/tests/test_route_event_query_repository.py
+++ b/tests/test_route_event_query_repository.py
@@ -1,0 +1,74 @@
+"""Route event query repository integration tests."""
+import os
+import sqlite3
+import tempfile
+from typing import Iterator
+
+import pytest
+
+from app.database.models import EVENTS_TABLE_SCHEMA
+from app.repositories.route_event_query_repository import RouteEventQueryRepository
+
+
+@pytest.fixture
+def route_event_db() -> Iterator[sqlite3.Connection]:
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(EVENTS_TABLE_SCHEMA)
+    conn.commit()
+
+    try:
+        yield conn
+    finally:
+        conn.close()
+        try:
+            os.remove(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def _insert_event(
+    db: sqlite3.Connection,
+    *,
+    title: str,
+    status: str = "active",
+    start_modifier: str = "+10 hours",
+) -> None:
+    db.execute(
+        """
+        INSERT INTO events (
+            title, description, location_name, location_address,
+            latitude, longitude, start_date, end_date, category,
+            severity_level, status
+        )
+        VALUES (?, ?, ?, ?, ?, ?, datetime('now', ?), datetime('now', '+11 hours'), ?, ?, ?)
+        """,
+        (
+            title,
+            f"{title} 설명",
+            "광화문",
+            "서울 종로구",
+            37.572,
+            126.9769,
+            start_modifier,
+            "집회",
+            2,
+            status,
+        ),
+    )
+
+
+def test_list_active_future_events_filters_status_time_and_orders(route_event_db):
+    _insert_event(route_event_db, title="future-2", start_modifier="+12 hours")
+    _insert_event(route_event_db, title="past", start_modifier="+8 hours")
+    _insert_event(route_event_db, title="inactive", status="cancelled", start_modifier="+10 hours")
+    _insert_event(route_event_db, title="future-1", start_modifier="+10 hours")
+    route_event_db.commit()
+
+    rows = RouteEventQueryRepository.list_active_future_events(route_event_db)
+
+    assert [row["title"] for row in rows] == ["future-1", "future-2"]
+    assert all(row["status"] == "active" for row in rows)

--- a/tests/test_router_sql_cleanup_boundaries.py
+++ b/tests/test_router_sql_cleanup_boundaries.py
@@ -1,0 +1,170 @@
+"""라우터 SQL cleanup 후 endpoint 계약 통합 테스트."""
+import sqlite3
+
+
+API_HEADERS = {"x-api-key": "test-api-key"}
+
+
+def test_users_list_endpoint_preserves_route_info_contract(test_client, clean_test_db):
+    conn = sqlite3.connect(clean_test_db)
+    conn.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, first_message_at, last_message_at, message_count,
+            location, active, departure_name, departure_address,
+            departure_x, departure_y, arrival_name, arrival_address,
+            arrival_x, arrival_y, route_updated_at, marked_bus, language
+        )
+        VALUES (?, ?, ?, 3, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "bot-with-route",
+            "2026-05-12T08:00:00",
+            "2026-05-12T09:00:00",
+            "종로",
+            "출발지",
+            "서울 출발 주소",
+            127.01,
+            37.51,
+            "도착지",
+            "서울 도착 주소",
+            126.98,
+            37.56,
+            "2026-05-12T09:05:00",
+            "7016",
+            "ko",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, first_message_at, last_message_at, message_count,
+            location, active, marked_bus, language
+        )
+        VALUES (?, ?, ?, 1, ?, 0, ?, ?)
+        """,
+        (
+            "bot-no-route",
+            "2026-05-12T07:00:00",
+            "2026-05-12T10:00:00",
+            "광화문",
+            "162",
+            "en",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    response = test_client.get("/users", headers=API_HEADERS)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert body["users"][0]["bot_user_key"] == "bot-no-route"
+    assert body["users"][0]["route_info"] is None
+    assert body["users"][1]["bot_user_key"] == "bot-with-route"
+    assert body["users"][1]["route_info"] == {
+        "departure": {
+            "name": "출발지",
+            "address": "서울 출발 주소",
+            "x": 127.01,
+            "y": 37.51,
+        },
+        "arrival": {
+            "name": "도착지",
+            "address": "서울 도착 주소",
+            "x": 126.98,
+            "y": 37.56,
+        },
+        "updated_at": "2026-05-12T09:05:00",
+    }
+
+
+def test_kakao_chat_uses_identity_boundary_for_plusfriend_user(test_client, clean_test_db):
+    conn = sqlite3.connect(clean_test_db)
+    conn.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, plusfriend_user_key, first_message_at,
+            last_message_at, message_count, active
+        )
+        VALUES (?, ?, ?, ?, 1, 1)
+        """,
+        ("old-bot", "pf-chat", "2026-05-12T08:00:00", "2026-05-12T08:00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    response = test_client.post(
+        "/kakao/chat",
+        json={
+            "userRequest": {
+                "utterance": "안녕",
+                "user": {
+                    "id": "new-bot",
+                    "type": "botUserKey",
+                    "properties": {"plusfriendUserKey": "pf-chat"},
+                },
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["version"] == "2.0"
+    assert body["template"]["quickReplies"][0]["messageText"] == "이동 경로를 등록하고 싶어요"
+
+    conn = sqlite3.connect(clean_test_db)
+    row = conn.execute(
+        """
+        SELECT bot_user_key, plusfriend_user_key, message_count, active
+        FROM users
+        WHERE plusfriend_user_key = ?
+        """,
+        ("pf-chat",),
+    ).fetchone()
+    conn.close()
+
+    assert row == ("new-bot", "pf-chat", 2, 1)
+
+
+def test_kakao_channel_webhook_uses_identity_boundary_for_open_id(test_client, clean_test_db):
+    response = test_client.post(
+        "/kakao/webhook/channel",
+        json={"event": "added", "id": "open-webhook"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "processed_event": "added",
+        "open_id": "open-webhook",
+    }
+
+    conn = sqlite3.connect(clean_test_db)
+    active_row = conn.execute(
+        "SELECT open_id, active FROM users WHERE open_id = ?",
+        ("open-webhook",),
+    ).fetchone()
+    conn.close()
+    assert active_row == ("open-webhook", 1)
+
+    response = test_client.post(
+        "/kakao/webhook/channel",
+        json={"event": "blocked", "id": "open-webhook"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "processed_event": "blocked",
+        "open_id": "open-webhook",
+    }
+
+    conn = sqlite3.connect(clean_test_db)
+    inactive_row = conn.execute(
+        "SELECT open_id, active FROM users WHERE open_id = ?",
+        ("open-webhook",),
+    ).fetchone()
+    conn.close()
+    assert inactive_row == ("open-webhook", 0)

--- a/tests/test_user_identity_repository.py
+++ b/tests/test_user_identity_repository.py
@@ -1,0 +1,171 @@
+"""User identity repository integration tests."""
+import os
+import sqlite3
+import tempfile
+from datetime import datetime
+from typing import Iterator
+
+import pytest
+
+from app.database.models import USERS_TABLE_SCHEMA
+from app.repositories.user_identity_repository import UserIdentityRepository
+
+
+@pytest.fixture
+def user_identity_db_pair() -> Iterator[tuple[sqlite3.Connection, sqlite3.Connection]]:
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    writer = sqlite3.connect(db_path)
+    reader = sqlite3.connect(db_path)
+    writer.row_factory = sqlite3.Row
+    reader.row_factory = sqlite3.Row
+    writer.execute(USERS_TABLE_SCHEMA)
+    writer.commit()
+
+    try:
+        yield writer, reader
+    finally:
+        writer.close()
+        reader.close()
+        try:
+            os.remove(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def test_insert_bot_user_uses_caller_transaction(user_identity_db_pair):
+    writer, reader = user_identity_db_pair
+    now = datetime(2026, 5, 12, 9, 0, 0)
+
+    UserIdentityRepository.insert_bot_user(writer, bot_user_key="bot-1", now=now)
+
+    assert UserIdentityRepository.find_by_bot_user_key(writer, "bot-1") is not None
+    assert UserIdentityRepository.find_by_bot_user_key(reader, "bot-1") is None
+
+    writer.commit()
+
+    saved = UserIdentityRepository.find_by_bot_user_key(reader, "bot-1")
+    assert saved is not None
+    assert saved["bot_user_key"] == "bot-1"
+    assert saved["plusfriend_user_key"] is None
+
+
+def test_identity_link_methods_return_rowcounts_without_committing(user_identity_db_pair):
+    writer, reader = user_identity_db_pair
+    now = datetime(2026, 5, 12, 9, 0, 0)
+    UserIdentityRepository.insert_bot_user(writer, bot_user_key="bot-1", now=now)
+    writer.commit()
+
+    rowcount = UserIdentityRepository.link_plusfriend_to_bot(
+        writer,
+        bot_user_key="bot-1",
+        plusfriend_key="pf-1",
+        now=datetime(2026, 5, 12, 9, 1, 0),
+    )
+
+    assert rowcount == 1
+    before_commit = UserIdentityRepository.find_by_bot_user_key(reader, "bot-1")
+    assert before_commit is not None
+    assert before_commit["plusfriend_user_key"] is None
+
+    writer.commit()
+
+    after_commit = UserIdentityRepository.find_by_plusfriend_key(reader, "pf-1")
+    assert after_commit is not None
+    assert after_commit["bot_user_key"] == "bot-1"
+    assert after_commit["plusfriend_user_key"] == "pf-1"
+    assert after_commit["message_count"] == 2
+
+
+def test_orphan_lookup_and_link_uses_oldest_unlinked_user(user_identity_db_pair):
+    writer, reader = user_identity_db_pair
+    writer.execute(
+        """
+        INSERT INTO users (open_id, first_message_at, last_message_at, message_count, active)
+        VALUES (?, ?, ?, 1, 1)
+        """,
+        ("old-open", "2026-05-12T08:00:00", "2026-05-12T08:00:00"),
+    )
+    writer.execute(
+        """
+        INSERT INTO users (open_id, first_message_at, last_message_at, message_count, active)
+        VALUES (?, ?, ?, 1, 1)
+        """,
+        ("new-open", "2026-05-12T09:00:00", "2026-05-12T09:00:00"),
+    )
+    writer.commit()
+
+    orphan = UserIdentityRepository.find_oldest_unlinked_user(writer)
+    assert orphan is not None
+    assert orphan["open_id"] == "old-open"
+
+    UserIdentityRepository.link_orphan_identity(
+        writer,
+        user_id=orphan["id"],
+        bot_user_key="bot-1",
+        plusfriend_key="pf-1",
+        now=datetime(2026, 5, 12, 10, 0, 0),
+    )
+    assert UserIdentityRepository.find_by_plusfriend_key(reader, "pf-1") is None
+
+    writer.commit()
+
+    linked = UserIdentityRepository.find_by_plusfriend_key(reader, "pf-1")
+    assert linked is not None
+    assert linked["open_id"] == "old-open"
+
+
+def test_chat_identity_methods_preserve_router_transactions(user_identity_db_pair):
+    writer, reader = user_identity_db_pair
+    now = datetime(2026, 5, 12, 12, 0, 0)
+    writer.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, plusfriend_user_key, first_message_at,
+            last_message_at, message_count, active
+        )
+        VALUES (?, ?, ?, ?, 1, 1)
+        """,
+        ("old-bot", "pf-chat", now, now),
+    )
+    writer.commit()
+
+    rowcount = UserIdentityRepository.touch_chat_plusfriend_user(
+        writer,
+        plusfriend_key="pf-chat",
+        bot_user_key="new-bot",
+        now=datetime(2026, 5, 12, 12, 1, 0),
+    )
+
+    assert rowcount == 1
+    assert UserIdentityRepository.find_by_plusfriend_key(reader, "pf-chat")["bot_user_key"] == "old-bot"
+
+    writer.commit()
+
+    saved = UserIdentityRepository.find_by_plusfriend_key(reader, "pf-chat")
+    assert saved is not None
+    assert saved["bot_user_key"] == "new-bot"
+    assert saved["message_count"] == 2
+
+
+def test_open_id_identity_methods_support_webhook_flow(user_identity_db_pair):
+    writer, reader = user_identity_db_pair
+    now = datetime(2026, 5, 12, 13, 0, 0)
+
+    UserIdentityRepository.insert_open_id_user(writer, open_id="open-1", now=now)
+    assert UserIdentityRepository.find_by_open_id(reader, "open-1") is None
+
+    writer.commit()
+
+    saved = UserIdentityRepository.find_by_open_id(reader, "open-1")
+    assert saved is not None
+    assert saved["open_id"] == "open-1"
+    assert saved["active"] == 1
+
+    UserIdentityRepository.set_active_by_open_id(writer, open_id="open-1", active=False)
+    writer.commit()
+
+    inactive = UserIdentityRepository.find_by_open_id(reader, "open-1")
+    assert inactive is not None
+    assert inactive["active"] == 0

--- a/tests/test_user_route_profile_read_repositories.py
+++ b/tests/test_user_route_profile_read_repositories.py
@@ -1,0 +1,194 @@
+"""사용자 route/profile/read 저장소 통합 테스트."""
+import os
+import sqlite3
+import tempfile
+from datetime import datetime
+from typing import Iterator
+
+import pytest
+
+from app.database.models import USERS_TABLE_SCHEMA
+from app.repositories.user_profile_repository import UserProfileRepository
+from app.repositories.user_read_repository import UserReadRepository
+from app.repositories.user_route_repository import UserRouteRepository
+
+
+ROUTE_NOW = datetime(2026, 5, 12, 10, 30, 0)
+PROFILE_NOW = datetime(2026, 5, 12, 11, 30, 0)
+
+DEPARTURE_INFO = {
+    "name": "출발지",
+    "address": "서울 출발 주소",
+    "x": 127.01,
+    "y": 37.51,
+}
+
+ARRIVAL_INFO = {
+    "name": "도착지",
+    "address": "서울 도착 주소",
+    "x": 126.98,
+    "y": 37.56,
+}
+
+
+@pytest.fixture
+def user_repo_db() -> Iterator[sqlite3.Connection]:
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(USERS_TABLE_SCHEMA)
+    conn.commit()
+
+    try:
+        yield conn
+    finally:
+        conn.close()
+        try:
+            os.remove(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def _insert_user(
+    db: sqlite3.Connection,
+    *,
+    bot_user_key: str,
+    plusfriend_user_key: str | None,
+) -> None:
+    db.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, plusfriend_user_key, first_message_at, last_message_at,
+            message_count, active, is_alarm_on
+        )
+        VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, 1, 1)
+        """,
+        (bot_user_key, plusfriend_user_key),
+    )
+    db.commit()
+
+
+def test_route_repository_updates_plusfriend_route(user_repo_db):
+    _insert_user(user_repo_db, bot_user_key="bot-route", plusfriend_user_key="pf-route")
+
+    updated_count = UserRouteRepository.update_route(
+        user_repo_db,
+        user_id="pf-route",
+        departure_info=DEPARTURE_INFO,
+        arrival_info=ARRIVAL_INFO,
+        now=ROUTE_NOW,
+    )
+
+    assert updated_count == 1
+
+    route = UserReadRepository.get_route_info_by_bot_user_key(user_repo_db, "bot-route")
+
+    assert route is not None
+    assert route["departure_name"] == "출발지"
+    assert route["departure_address"] == "서울 출발 주소"
+    assert route["departure_x"] == 127.01
+    assert route["arrival_name"] == "도착지"
+    assert route["arrival_address"] == "서울 도착 주소"
+    assert route["arrival_y"] == 37.56
+    assert route["route_updated_at"] == str(ROUTE_NOW)
+
+
+def test_route_repository_clear_route_falls_back_to_bot_user_key(user_repo_db):
+    _insert_user(user_repo_db, bot_user_key="bot-only", plusfriend_user_key=None)
+    UserRouteRepository.update_route(
+        user_repo_db,
+        user_id="missing-plusfriend",
+        departure_info=DEPARTURE_INFO,
+        arrival_info=ARRIVAL_INFO,
+        now=ROUTE_NOW,
+    )
+    user_repo_db.execute(
+        """
+        UPDATE users
+        SET departure_name = ?, departure_address = ?, departure_x = ?, departure_y = ?,
+            arrival_name = ?, arrival_address = ?, arrival_x = ?, arrival_y = ?,
+            route_updated_at = ?
+        WHERE bot_user_key = ?
+        """,
+        (
+            DEPARTURE_INFO["name"],
+            DEPARTURE_INFO["address"],
+            DEPARTURE_INFO["x"],
+            DEPARTURE_INFO["y"],
+            ARRIVAL_INFO["name"],
+            ARRIVAL_INFO["address"],
+            ARRIVAL_INFO["x"],
+            ARRIVAL_INFO["y"],
+            ROUTE_NOW,
+            "bot-only",
+        ),
+    )
+    user_repo_db.commit()
+
+    updated_count = UserRouteRepository.clear_route(
+        user_repo_db,
+        user_id="bot-only",
+        now=PROFILE_NOW,
+    )
+
+    assert updated_count == 1
+
+    route = UserReadRepository.get_route_info_by_bot_user_key(user_repo_db, "bot-only")
+
+    assert route is not None
+    assert route["departure_name"] is None
+    assert route["departure_x"] is None
+    assert route["arrival_name"] is None
+    assert route["arrival_y"] is None
+    assert route["route_updated_at"] == str(PROFILE_NOW)
+
+
+def test_profile_repository_updates_route_and_preferences(user_repo_db):
+    _insert_user(user_repo_db, bot_user_key="bot-profile", plusfriend_user_key="pf-profile")
+
+    updated_count = UserProfileRepository.update_profile(
+        user_repo_db,
+        plusfriend_user_key="pf-profile",
+        departure_info=DEPARTURE_INFO,
+        arrival_info=ARRIVAL_INFO,
+        marked_bus="7016",
+        language="ko",
+        now=PROFILE_NOW,
+    )
+
+    assert updated_count == 1
+
+    user_info = UserReadRepository.get_user_info(user_repo_db, "pf-profile")
+
+    assert user_info is not None
+    assert user_info["marked_bus"] == "7016"
+    assert user_info["departure_name"] == "출발지"
+    assert user_info["arrival_name"] == "도착지"
+    assert user_info["plusfriend_user_key"] == "pf-profile"
+    assert user_info["bot_user_key"] == "bot-profile"
+
+
+def test_read_repository_preserves_plusfriend_priority_and_bot_fallback(user_repo_db):
+    _insert_user(user_repo_db, bot_user_key="shared-id", plusfriend_user_key="pf-first")
+    _insert_user(user_repo_db, bot_user_key="bot-fallback", plusfriend_user_key=None)
+    user_repo_db.execute(
+        "UPDATE users SET marked_bus = ?, departure_name = ? WHERE plusfriend_user_key = ?",
+        ("plus-bus", "plus-departure", "pf-first"),
+    )
+    user_repo_db.execute(
+        "UPDATE users SET marked_bus = ?, departure_name = ? WHERE bot_user_key = ?",
+        ("bot-bus", "bot-departure", "bot-fallback"),
+    )
+    user_repo_db.commit()
+
+    plusfriend_info = UserReadRepository.get_user_info(user_repo_db, "pf-first")
+    bot_info = UserReadRepository.get_user_info(user_repo_db, "bot-fallback")
+
+    assert plusfriend_info is not None
+    assert plusfriend_info["marked_bus"] == "plus-bus"
+    assert plusfriend_info["departure_name"] == "plus-departure"
+    assert bot_info is not None
+    assert bot_info["marked_bus"] == "bot-bus"
+    assert bot_info["departure_name"] == "bot-departure"

--- a/tests/test_user_route_read_repository.py
+++ b/tests/test_user_route_read_repository.py
@@ -1,0 +1,106 @@
+"""User route read repository integration tests."""
+import os
+import sqlite3
+import tempfile
+from typing import Iterator
+
+import pytest
+
+from app.database.models import USERS_TABLE_SCHEMA
+from app.repositories.user_route_read_repository import UserRouteReadRepository
+
+
+@pytest.fixture
+def route_read_db() -> Iterator[sqlite3.Connection]:
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(USERS_TABLE_SCHEMA)
+    conn.commit()
+
+    try:
+        yield conn
+    finally:
+        conn.close()
+        try:
+            os.remove(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def _insert_route_user(
+    db: sqlite3.Connection,
+    *,
+    bot_user_key: str | None,
+    plusfriend_user_key: str | None,
+    active: int = 1,
+    is_alarm_on: int = 1,
+    has_route: bool = True,
+) -> None:
+    route_values = (
+        "출발",
+        "출발 주소",
+        127.0,
+        37.5,
+        "도착",
+        "도착 주소",
+        126.9,
+        37.4,
+    ) if has_route else (None, None, None, None, None, None, None, None)
+    db.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, plusfriend_user_key, first_message_at, last_message_at,
+            message_count, active, is_alarm_on,
+            departure_name, departure_address, departure_x, departure_y,
+            arrival_name, arrival_address, arrival_x, arrival_y
+        )
+        VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (bot_user_key, plusfriend_user_key, active, is_alarm_on, *route_values),
+    )
+
+
+def test_get_route_for_user_supports_plusfriend_and_bot_lookup(route_read_db):
+    _insert_route_user(route_read_db, bot_user_key="bot-1", plusfriend_user_key="pf-1")
+    _insert_route_user(route_read_db, bot_user_key="bot-only", plusfriend_user_key=None)
+    route_read_db.commit()
+
+    plusfriend_route = UserRouteReadRepository.get_route_for_user(route_read_db, "pf-1")
+    bot_route = UserRouteReadRepository.get_route_for_user(route_read_db, "bot-only")
+
+    assert plusfriend_route is not None
+    assert plusfriend_route["departure_name"] == "출발"
+    assert bot_route is not None
+    assert bot_route["arrival_name"] == "도착"
+
+
+def test_list_scheduled_route_users_requires_plusfriend_and_route(route_read_db):
+    _insert_route_user(route_read_db, bot_user_key="bot-1", plusfriend_user_key="pf-1")
+    _insert_route_user(route_read_db, bot_user_key="bot-only", plusfriend_user_key=None)
+    _insert_route_user(route_read_db, bot_user_key="off", plusfriend_user_key="pf-off", is_alarm_on=0)
+    _insert_route_user(route_read_db, bot_user_key="no-route", plusfriend_user_key="pf-no-route", has_route=False)
+    route_read_db.commit()
+
+    users = UserRouteReadRepository.list_scheduled_route_users(route_read_db)
+
+    assert users == [
+        {
+            "plusfriend_user_key": "pf-1",
+            "departure_name": "출발",
+            "arrival_name": "도착",
+        }
+    ]
+
+
+def test_list_auto_check_route_user_ids_uses_coalesced_plusfriend_then_bot(route_read_db):
+    _insert_route_user(route_read_db, bot_user_key="bot-1", plusfriend_user_key="pf-1")
+    _insert_route_user(route_read_db, bot_user_key="bot-only", plusfriend_user_key=None)
+    _insert_route_user(route_read_db, bot_user_key="inactive", plusfriend_user_key="pf-inactive", active=0)
+    route_read_db.commit()
+
+    users = UserRouteReadRepository.list_auto_check_route_user_ids(route_read_db)
+
+    assert users == [{"user_id": "pf-1"}, {"user_id": "bot-only"}]

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -92,3 +92,38 @@ def test_sync_kakao_user_does_not_merge_conflicting_rows(clean_test_db):
     cursor.execute("SELECT COUNT(*) FROM users")
     assert cursor.fetchone()[0] == 2
     conn.close()
+
+
+def test_sync_kakao_user_links_oldest_orphan_user(clean_test_db):
+    conn = sqlite3.connect(clean_test_db)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO users (open_id, first_message_at, last_message_at, message_count, active)
+        VALUES (?, ?, ?, 1, 1)
+        """,
+        ("old-open", "2026-05-12T08:00:00", "2026-05-12T08:00:00"),
+    )
+    cursor.execute(
+        """
+        INSERT INTO users (open_id, first_message_at, last_message_at, message_count, active)
+        VALUES (?, ?, ?, 1, 1)
+        """,
+        ("new-open", "2026-05-12T09:00:00", "2026-05-12T09:00:00"),
+    )
+    conn.commit()
+
+    UserService.sync_kakao_user("bot_user_key_123", "pf_123", conn)
+
+    cursor.execute(
+        """
+        SELECT open_id, bot_user_key, plusfriend_user_key, active
+        FROM users
+        ORDER BY first_message_at ASC, id ASC
+        """
+    )
+    rows = cursor.fetchall()
+
+    assert rows[0] == ("old-open", "bot_user_key_123", "pf_123", 1)
+    assert rows[1] == ("new-open", None, None, 1)
+    conn.close()

--- a/tests/test_user_settings_repository.py
+++ b/tests/test_user_settings_repository.py
@@ -1,0 +1,141 @@
+"""User settings/preference repository integration tests."""
+import os
+import sqlite3
+import tempfile
+from datetime import datetime
+from typing import Iterator
+
+import pytest
+
+from app.database.models import USERS_TABLE_SCHEMA
+from app.repositories.user_preference_repository import UserPreferenceRepository
+from app.repositories.user_settings_repository import UserSettingsRepository
+
+
+@pytest.fixture
+def user_settings_db_pair() -> Iterator[tuple[sqlite3.Connection, sqlite3.Connection]]:
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    writer = sqlite3.connect(db_path)
+    reader = sqlite3.connect(db_path)
+    writer.row_factory = sqlite3.Row
+    reader.row_factory = sqlite3.Row
+    writer.execute(USERS_TABLE_SCHEMA)
+    writer.commit()
+
+    try:
+        yield writer, reader
+    finally:
+        writer.close()
+        reader.close()
+        try:
+            os.remove(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def _insert_user(
+    db: sqlite3.Connection,
+    *,
+    bot_user_key: str,
+    plusfriend_user_key: str | None = None,
+) -> None:
+    db.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, plusfriend_user_key, first_message_at, last_message_at,
+            message_count, active, is_alarm_on
+        )
+        VALUES (?, ?, ?, ?, 1, 1, 1)
+        """,
+        (bot_user_key, plusfriend_user_key, "2026-05-12T09:00:00", "2026-05-12T09:00:00"),
+    )
+
+
+def _user_row(db: sqlite3.Connection, bot_user_key: str) -> sqlite3.Row:
+    row = db.execute(
+        "SELECT * FROM users WHERE bot_user_key = ?",
+        (bot_user_key,),
+    ).fetchone()
+    assert row is not None
+    return row
+
+
+def test_alarm_and_favorite_updates_prefer_plusfriend_before_bot(user_settings_db_pair):
+    writer, reader = user_settings_db_pair
+    _insert_user(writer, bot_user_key="bot-owner", plusfriend_user_key="shared-id")
+    _insert_user(writer, bot_user_key="shared-id")
+    writer.commit()
+
+    alarm_count = UserSettingsRepository.update_alarm_setting(
+        writer,
+        user_id="shared-id",
+        is_alarm_on=False,
+    )
+    zone_count = UserSettingsRepository.update_favorite_zone(
+        writer,
+        user_id="shared-id",
+        zone=2,
+    )
+
+    assert alarm_count == 1
+    assert zone_count == 1
+    assert _user_row(reader, "bot-owner")["is_alarm_on"] == 1
+    assert _user_row(reader, "shared-id")["is_alarm_on"] == 1
+
+    writer.commit()
+
+    plusfriend_row = _user_row(reader, "bot-owner")
+    bot_row = _user_row(reader, "shared-id")
+    assert plusfriend_row["is_alarm_on"] == 0
+    assert plusfriend_row["favorite_zone"] == 2
+    assert bot_row["is_alarm_on"] == 1
+    assert bot_row["favorite_zone"] is None
+
+
+def test_marked_bus_falls_back_to_bot_user_key(user_settings_db_pair):
+    writer, reader = user_settings_db_pair
+    _insert_user(writer, bot_user_key="bot-only")
+    writer.commit()
+
+    rowcount = UserSettingsRepository.update_marked_bus(
+        writer,
+        user_id="bot-only",
+        marked_bus="470",
+        now=datetime(2026, 5, 12, 10, 0, 0),
+    )
+
+    assert rowcount == 1
+    assert _user_row(reader, "bot-only")["marked_bus"] is None
+
+    writer.commit()
+
+    saved = _user_row(reader, "bot-only")
+    assert saved["marked_bus"] == "470"
+    assert saved["last_message_at"] == "2026-05-12 10:00:00"
+
+
+def test_preferences_keep_bot_user_key_only_lookup(user_settings_db_pair):
+    writer, reader = user_settings_db_pair
+    _insert_user(writer, bot_user_key="bot-owner", plusfriend_user_key="shared-id")
+    _insert_user(writer, bot_user_key="shared-id")
+    writer.commit()
+
+    assert UserPreferenceRepository.exists_by_bot_user_key(writer, "shared-id") is True
+    rowcount = UserPreferenceRepository.update_preferences(
+        writer,
+        user_id="shared-id",
+        marked_bus="7016",
+        language="ko",
+    )
+
+    assert rowcount == 1
+    writer.commit()
+
+    plusfriend_row = _user_row(reader, "bot-owner")
+    bot_row = _user_row(reader, "shared-id")
+    assert plusfriend_row["marked_bus"] is None
+    assert plusfriend_row["language"] is None
+    assert bot_row["marked_bus"] == "7016"
+    assert bot_row["language"] == "ko"

--- a/tests/test_zone_alarm_read_repository.py
+++ b/tests/test_zone_alarm_read_repository.py
@@ -1,0 +1,79 @@
+"""Zone alarm read repository integration tests."""
+import os
+import sqlite3
+import tempfile
+from typing import Iterator
+
+import pytest
+
+from app.database.models import EVENTS_TABLE_SCHEMA, USERS_TABLE_SCHEMA
+from app.repositories.zone_alarm_read_repository import ZoneAlarmReadRepository
+
+
+@pytest.fixture
+def zone_alarm_db() -> Iterator[sqlite3.Connection]:
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(USERS_TABLE_SCHEMA)
+    conn.execute(EVENTS_TABLE_SCHEMA)
+    conn.commit()
+
+    try:
+        yield conn
+    finally:
+        conn.close()
+        try:
+            os.remove(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def test_list_zone_users_requires_active_alarm_on_favorite_zone_and_plusfriend(zone_alarm_db):
+    rows = [
+        ("pf-1", 1, 1, 1),
+        ("pf-off", 1, 0, 1),
+        ("pf-inactive", 0, 1, 1),
+        ("pf-no-zone", 1, 1, None),
+        (None, 1, 1, 1),
+    ]
+    for plusfriend_key, active, is_alarm_on, favorite_zone in rows:
+        zone_alarm_db.execute(
+            """
+            INSERT INTO users (
+                plusfriend_user_key, first_message_at, last_message_at,
+                message_count, active, is_alarm_on, favorite_zone
+            )
+            VALUES (?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, ?, ?, ?)
+            """,
+            (plusfriend_key, active, is_alarm_on, favorite_zone),
+        )
+    zone_alarm_db.commit()
+
+    users = ZoneAlarmReadRepository.list_zone_users(zone_alarm_db)
+
+    assert users == [{"plusfriend_user_key": "pf-1", "favorite_zone": 1}]
+
+
+def test_list_active_future_events_requires_active_coordinates_and_future_start(zone_alarm_db):
+    for title, status, latitude, longitude, start_date in [
+        ("future", "active", 37.5, 127.0, "2099-05-12T09:00:00"),
+        ("inactive", "ended", 37.5, 127.0, "2099-05-12T09:00:00"),
+        ("past", "active", 37.5, 127.0, "2000-05-12T09:00:00"),
+    ]:
+        zone_alarm_db.execute(
+            """
+            INSERT INTO events (
+                title, location_name, latitude, longitude, start_date, status, category, severity_level
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (title, title, latitude, longitude, start_date, status, "notice", 1),
+        )
+    zone_alarm_db.commit()
+
+    events = ZoneAlarmReadRepository.list_active_future_events(zone_alarm_db)
+
+    assert [event["title"] for event in events] == ["future"]


### PR DESCRIPTION
## Summary

Refs #99

Draft PR for the Issue #99 repository-boundary roadmap implementation.

- Add `app/repositories/` and move SQL access behind repository classes by domain.
- Keep router/service API contracts and service-owned transaction timing intact.
- Remove direct SQL execution from routers covered by this roadmap.
- Add real SQLite repository and integration coverage for alarm tasks, events, users, admin read models, route checks, zone alarms, and crawling bulk import.
- Add the Issue #99 repository boundary inventory document.

## Change scope

| Area | Files | Lines |
|---|---:|---:|
| Total | 41 | +3,935 / -753 |
| `app/repositories/` | 15 new | +1,522 |
| `app/routers/` | 5 modified | +92 / -209 |
| `app/services/` | 5 modified | +219 / -544 |
| `tests/` | 15 added/modified | +1,855 |
| `docs/` | 1 new | +247 |

## Verification

- [x] `git diff --check`
- [x] `.venv/bin/python -m compileall -q app`
- [x] `.venv/bin/python -m pytest -q` — `149 passed, 29 warnings`
- [x] Router SQL execution scan — no `execute` / `executemany` calls left in `app/routers`
- [x] Repository connection ownership scan — repositories do not open connections or commit/rollback
- [x] No dependency/schema/config drift detected for `pyproject.toml`, `uv.lock`, `app/database`, migrations, Docker/GitHub workflow files

## Deployment smoke checklist before marking ready

- [ ] Admin dashboard renders normally after deploy.
- [ ] Manual crawling trigger completes and writes/ignores events as expected.
- [ ] Event list/today/upcoming endpoints return existing response shapes.
- [ ] User alarm/favorite/route setting flows still persist changes.
- [ ] Manual test alarm or route-check trigger creates expected alarm task records.
- [ ] App logs stay clear of SQLite `OperationalError`, row mapping `KeyError`, and unexpected `NoneType` errors for 10–30 minutes.

## Notes

This is intentionally opened as a Draft because the code path is broad and should receive review plus staging smoke checks before merge.
