### PR TITLE
Fix /users alarm off newline typo

### DIFF
--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -301,7 +301,7 @@ async def alarm_setting(request: dict, db: sqlite3.Connection = Depends(get_db))
             msg = "✅ 매일 아침 알림이 켜졌습니다.\n등록하신 이동 경로에 영향을 주는 집회 정보를 안내해 드립니다."
         elif alarm_status_str == 'off':
             is_alarm_on = False
-            msg = "🔕 매일 아침 알림이 꺼졌습니다.\이동 경로 집회 알림이 더 이상 발송되지 않습니다."
+            msg = "🔕 매일 아침 알림이 꺼졌습니다.\n이동 경로 집회 알림이 더 이상 발송되지 않습니다."
         else:
             return {
                 "version": "2.0",

--- a/tests/test_alarm_setting.py
+++ b/tests/test_alarm_setting.py
@@ -254,6 +254,31 @@ class TestAlarmSettingSaveViaClientExtra:
                 assert mock_update.call_args[0][1] is True
 
 
+class TestUsersAlarmSetting:
+    """/users/alarm-setting 라우터 응답 회귀 테스트"""
+
+    def test_users_alarm_setting_off_uses_newline(
+        self,
+        clean_test_db,
+        alarm_save_payload,
+    ):
+        """알림 끄기 응답이 리터럴 역슬래시가 아닌 실제 줄바꿈을 포함한다."""
+        alarm_save_payload["action"]["params"]["alarm_status"] = "off"
+
+        users_response = client.post("/users/alarm-setting", json=alarm_save_payload)
+        save_response = client.post("/alarm-setting/save", json=alarm_save_payload)
+
+        assert users_response.status_code == 200
+        assert save_response.status_code == 200
+
+        users_text = users_response.json()["template"]["outputs"][0]["simpleText"]["text"]
+        save_text = save_response.json()["template"]["outputs"][0]["simpleText"]["text"]
+
+        assert "꺼졌습니다.\n이동 경로" in users_text
+        assert "\\이동" not in users_text
+        assert users_text == save_text
+
+
 class TestFavoriteZoneSaveViaClientExtra:
     """/favorite-zone/save: block+extra 방식(clientExtra) 관심장소 저장 테스트"""
 


### PR DESCRIPTION
## Summary

- Fix `/users/alarm-setting` off response typo from literal `\이동` to actual newline `\n이동`
- Add a real router regression test using `TestClient + clean_test_db` without mocking `UserService`
- Assert `/users/alarm-setting` and `/alarm-setting/save` off response text parity

Fixes #106

## Verification

| Command | Result |
|---|---|
| `uv run python -m py_compile app/routers/users.py tests/test_alarm_setting.py` | Passed |
| `uv run pytest tests/test_alarm_setting.py -q` | 13 passed |
| `uv run pytest -q` | 112 passed |
| `git diff --check` | Passed |

## Code review

| Lane | Result |
|---|---|
| Code quality/security | APPROVE — narrow string fix plus regression coverage; no secret, dependency, or broad behavior changes |
| Architecture | CLEAR — preserves existing endpoint contracts and aligns duplicate response text behavior |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected notification message formatting when disabling alarm alerts to properly display line breaks.
  * Fixed response structure in alarm-related endpoint error handling.

* **Tests**
  * Added regression test to verify alarm notification messages format correctly when disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoonly01/kt-demo-alarm/pull/107)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->