### PR TITLE
Fix #109: unify protest notification message templates

### DIFF
--- a/app/routers/events.py
+++ b/app/routers/events.py
@@ -8,10 +8,21 @@ import asyncio
 from app.models.event import EventCreate, EventResponse, RouteEventCheck
 from app.database.connection import get_db
 from app.services.event_service import EventService
+from app.services.notification_service import NotificationService
 from app.services.auth_service import verify_api_key
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/events", tags=["events"])
+
+
+def _to_notification_event_data(event: EventResponse) -> dict:
+    """사용자 출력 템플릿에 필요한 집회 필드만 변환"""
+    return {
+        "description": event.description,
+        "location": event.location_name,
+        "start_date": event.start_date,
+        "end_date": event.end_date,
+    }
 
 
 @router.post("", response_model=EventResponse)
@@ -96,21 +107,9 @@ async def check_user_route_events(
             }
         }
 
-    # 집회 정보 포맷
-    event_messages = []
-    for event in result.events_found:
-        severity_emoji = "🔴" if event.severity_level >= 3 else "🟡" if event.severity_level >= 2 else "🟢"
-        event_messages.append(
-            f"{severity_emoji} {event.title}\n"
-            f"📍 {event.location_name}\n"
-            f"⏰ {event.start_date}\n"
-            f"🏷️ {event.category if event.category else '일반'}"
-        )
-
-    message_text = (
-        f"⚠️ 경로상에 {len(result.events_found)}개의 집회가 감지되었습니다:\n\n"
-        + "\n\n".join(event_messages)
-        + "\n\n우회 경로를 고려해주세요."
+    message_text = NotificationService._format_event_collection_message(
+        "경로상 감지된 집회 안내입니다.",
+        [_to_notification_event_data(event) for event in result.events_found],
     )
 
     return {
@@ -234,18 +233,10 @@ async def get_upcoming_protests(
             }
         }
 
-    # 집회 정보를 텍스트로 포맷
-    event_messages = []
-    for event in events:
-        severity_emoji = "🔴" if event.severity_level >= 3 else "🟡" if event.severity_level >= 2 else "🟢"
-        event_messages.append(
-            f"{severity_emoji} {event.title}\n"
-            f"📍 {event.location_name}\n"
-            f"⏰ {event.start_date}\n"
-            f"🏷️ {event.category if event.category else '일반'}"
-        )
-
-    message_text = f"📅 예정된 집회 {len(events)}건:\n\n" + "\n\n".join(event_messages)
+    message_text = NotificationService._format_event_collection_message(
+        "예정된 집회 안내입니다.",
+        [_to_notification_event_data(event) for event in events],
+    )
 
     return {
         "version": "2.0",
@@ -288,18 +279,10 @@ async def get_today_protests(
             }
         }
 
-    # 집회 정보를 텍스트로 포맷
-    event_messages = []
-    for event in events:
-        severity_emoji = "🔴" if event.severity_level >= 3 else "🟡" if event.severity_level >= 2 else "🟢"
-        event_messages.append(
-            f"{severity_emoji} {event.title}\n"
-            f"📍 {event.location_name}\n"
-            f"⏰ {event.start_date}\n"
-            f"🏷️ {event.category if event.category else '일반'}"
-        )
-
-    message_text = f"📅 오늘 예정된 집회 {len(events)}건:\n\n" + "\n\n".join(event_messages)
+    message_text = NotificationService._format_event_collection_message(
+        "오늘 예정된 집회 안내입니다.",
+        [_to_notification_event_data(event) for event in events],
+    )
 
     return {
         "version": "2.0",

--- a/app/routers/kakao_skills.py
+++ b/app/routers/kakao_skills.py
@@ -6,10 +6,22 @@ import logging
 from app.config.settings import settings
 from app.database.connection import get_db
 from app.services.event_service import EventService
+from app.services.notification_service import NotificationService
 from app.services.user_service import UserService
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["kakao-skills"])
+
+
+def _to_notification_event_data(event: object) -> dict:
+    """사용자 출력 템플릿에 필요한 집회 필드만 변환"""
+    return {
+        "description": getattr(event, "description", None),
+        "location": getattr(event, "location_name"),
+        "start_date": getattr(event, "start_date"),
+        "end_date": getattr(event, "end_date", None),
+    }
+
 
 # ─── 집회 정보 조회 ─────────────────────────────────────────
 
@@ -44,18 +56,10 @@ async def get_upcoming_protests(
             }
         }
 
-    # 집회 정보를 텍스트로 포맷
-    event_messages = []
-    for event in events:
-        severity_emoji = "🔴" if event.severity_level >= 3 else "🟡" if event.severity_level >= 2 else "🟢"
-        event_messages.append(
-            f"{severity_emoji} {event.title}\n"
-            f"📍 {event.location_name}\n"
-            f"⏰ {event.start_date}\n"
-            f"🏷️ {event.category if event.category else '일반'}"
-        )
-
-    message_text = f"📅 예정된 집회 {len(events)}건:\n\n" + "\n\n".join(event_messages)
+    message_text = NotificationService._format_event_collection_message(
+        "예정된 집회 안내입니다.",
+        [_to_notification_event_data(event) for event in events],
+    )
 
     return {
         "version": "2.0",
@@ -97,18 +101,10 @@ async def get_today_protests(
             }
         }
 
-    # 집회 정보를 텍스트로 포맷
-    event_messages = []
-    for event in events:
-        severity_emoji = "🔴" if event.severity_level >= 3 else "🟡" if event.severity_level >= 2 else "🟢"
-        event_messages.append(
-            f"{severity_emoji} {event.title}\n"
-            f"📍 {event.location_name}\n"
-            f"⏰ {event.start_date}\n"
-            f"🏷️ {event.category if event.category else '일반'}"
-        )
-
-    message_text = f"📅 오늘 예정된 집회 {len(events)}건:\n\n" + "\n\n".join(event_messages)
+    message_text = NotificationService._format_event_collection_message(
+        "오늘 예정된 집회 안내입니다.",
+        [_to_notification_event_data(event) for event in events],
+    )
 
     return {
         "version": "2.0",
@@ -168,21 +164,9 @@ async def check_user_route_events(
             }
         }
 
-    # 집회 정보 포맷
-    event_messages = []
-    for event in result.events_found:
-        severity_emoji = "🔴" if event.severity_level >= 3 else "🟡" if event.severity_level >= 2 else "🟢"
-        event_messages.append(
-            f"{severity_emoji} {event.title}\n"
-            f"📍 {event.location_name}\n"
-            f"⏰ {event.start_date}\n"
-            f"🏷️ {event.category if event.category else '일반'}"
-        )
-
-    message_text = (
-        f"⚠️ 경로상에 {len(result.events_found)}개의 집회가 감지되었습니다:\n\n"
-        + "\n\n".join(event_messages)
-        + "\n\n우회 경로를 고려해주세요."
+    message_text = NotificationService._format_event_collection_message(
+        "경로상 감지된 집회 안내입니다.",
+        [_to_notification_event_data(event) for event in result.events_found],
     )
 
     return {

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -225,10 +225,12 @@ class EventService:
                     events_data.append({
                         "id": event.id,
                         "title": event.title,
+                        "description": event.description,
                         "location": event.location_name,
                         "latitude": event.latitude,
                         "longitude": event.longitude,
                         "start_date": event.start_date.isoformat(),
+                        "end_date": event.end_date.isoformat() if event.end_date else None,
                         "category": event.category,
                         "severity_level": event.severity_level
                     })
@@ -311,10 +313,12 @@ class EventService:
                                     {
                                         "id": event.id,
                                         "title": event.title,
+                                        "description": event.description,
                                         "location": event.location_name,
                                         "latitude": event.latitude,
                                         "longitude": event.longitude,
                                         "start_date": event.start_date.isoformat() if hasattr(event.start_date, 'isoformat') else str(event.start_date),
+                                        "end_date": event.end_date.isoformat() if event.end_date and hasattr(event.end_date, 'isoformat') else str(event.end_date) if event.end_date else None,
                                         "category": event.category,
                                         "severity_level": event.severity_level
                                     }

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import httpx
 import json
+from datetime import datetime
 from typing import List, Dict, Any, Optional
 from app.models.alarm import AlarmRequest, FilteredAlarmRequest
 from app.models.kakao import EventAPIRequest, Event, EventUser
@@ -15,16 +16,49 @@ class NotificationService:
     """알림 전송 비즈니스 로직"""
 
     @staticmethod
-    def _format_event_block(event: Dict[str, Any]) -> str:
-        """단일 집회 정보를 이모지 블록으로 포맷팅"""
-        severity_level = event.get("severity_level", 1)
-        severity_emoji = "🔴" if severity_level >= 3 else "🟡" if severity_level >= 2 else "🟢"
+    def _format_event_time(value: Any) -> str:
+        """집회 일시 표시용 HH:MM 포맷 변환"""
+        if value is None:
+            return "미정"
+
+        if isinstance(value, datetime):
+            return value.strftime("%H:%M")
+
+        value_text = str(value).strip()
+        if not value_text:
+            return "미정"
+
+        try:
+            return datetime.fromisoformat(value_text).strftime("%H:%M")
+        except ValueError:
+            return value_text[:5] if len(value_text) >= 5 else value_text
+
+    @staticmethod
+    def _format_event_time_range(event: Dict[str, Any]) -> str:
+        """집회 시작/종료 일시 범위 포맷팅"""
+        start_time = NotificationService._format_event_time(event.get("start_date"))
+        end_time = NotificationService._format_event_time(event.get("end_date"))
+        return f"{start_time} ~ {end_time}"
+
+    @staticmethod
+    def _format_event_block(index: int, event: Dict[str, Any]) -> str:
+        """단일 집회 정보를 사용자 알림용 번호 블록으로 포맷팅"""
+        description = str(event.get("description") or "").strip() or "미상"
         return (
-            f"{severity_emoji} {event['title']}\n"
-            f"📍 {event['location']}\n"
-            f"⏰ {event['start_date']}\n"
-            f"🏷️ {event.get('category', '일반')}"
+            f"{index}.\n"
+            f"집회 일시 : {NotificationService._format_event_time_range(event)}\n"
+            f"집회 장소 : {event['location']}\n"
+            f"신고 인원 : {description}"
         )
+
+    @staticmethod
+    def _format_event_collection_message(header: str, events: List[Dict[str, Any]]) -> str:
+        """여러 집회 정보를 공통 번호형 템플릿으로 포맷팅"""
+        blocks = [
+            NotificationService._format_event_block(index, event)
+            for index, event in enumerate(events, start=1)
+        ]
+        return f"{header}\n\n" + "\n\n".join(blocks)
 
     @staticmethod
     def _format_event_message(events: List[Dict[str, Any]]) -> str:
@@ -37,8 +71,10 @@ class NotificationService:
         Returns:
             str: 포맷팅된 메시지 텍스트
         """
-        blocks = [NotificationService._format_event_block(e) for e in events]
-        return f"⚠️ 경로상에 {len(events)}개의 집회가 감지되었습니다:\n\n" + "\n\n".join(blocks)
+        return NotificationService._format_event_collection_message(
+            "경로상 감지된 집회 안내입니다.",
+            events,
+        )
 
     @staticmethod
     def _format_zone_message(zone_name: str, events: List[Dict[str, Any]]) -> str:
@@ -52,8 +88,10 @@ class NotificationService:
         Returns:
             str: 포맷팅된 메시지 텍스트
         """
-        blocks = [NotificationService._format_event_block(e) for e in events]
-        return f"설정하신 {zone_name}에 집회가 감지되었습니다.\n\n" + "\n\n".join(blocks)
+        return NotificationService._format_event_collection_message(
+            f"설정하신 {zone_name}의 집회 안내입니다.",
+            events,
+        )
 
     @staticmethod
     async def send_individual_alarm(

--- a/app/services/zone_alarm_service.py
+++ b/app/services/zone_alarm_service.py
@@ -45,8 +45,8 @@ class ZoneAlarmService:
 
                 # 2. 활성 집회 전체 조회
                 cursor.execute('''
-                    SELECT id, title, location_name, location_address,
-                           latitude, longitude, start_date, category, severity_level
+                    SELECT id, title, description, location_name, location_address,
+                           latitude, longitude, start_date, end_date, category, severity_level
                     FROM events
                     WHERE status = 'active'
                       AND latitude IS NOT NULL
@@ -96,10 +96,12 @@ class ZoneAlarmService:
                                 {
                                     "id": e["id"],
                                     "title": e["title"],
+                                    "description": e["description"],
                                     "location": e["location_name"],
                                     "latitude": e["latitude"],
                                     "longitude": e["longitude"],
                                     "start_date": e["start_date"],
+                                    "end_date": e["end_date"],
                                     "category": e["category"],
                                     "severity_level": e["severity_level"],
                                 }

--- a/tests/test_notification_templates.py
+++ b/tests/test_notification_templates.py
@@ -1,0 +1,122 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.routers import events as event_router
+from app.routers import kakao_skills
+from app.services.notification_service import NotificationService
+
+
+def test_route_alert_template_uses_numbered_brief_fields():
+    events = [
+        {
+            "location": "산업은행 측면 -> 신교교차로",
+            "start_date": datetime(2026, 5, 14, 11, 30),
+            "end_date": datetime(2026, 5, 14, 13, 0),
+            "description": "70명",
+        },
+        {
+            "location": "광화문 월대 -> 舊)효자치안센터",
+            "start_date": "2026-05-14 14:30:00",
+            "end_date": "2026-05-14 16:00:00",
+            "description": "300명",
+        },
+    ]
+
+    message = NotificationService._format_event_message(events)
+
+    assert message == (
+        "경로상 감지된 집회 안내입니다.\n\n"
+        "1.\n"
+        "집회 일시 : 11:30 ~ 13:00\n"
+        "집회 장소 : 산업은행 측면 -> 신교교차로\n"
+        "신고 인원 : 70명\n\n"
+        "2.\n"
+        "집회 일시 : 14:30 ~ 16:00\n"
+        "집회 장소 : 광화문 월대 -> 舊)효자치안센터\n"
+        "신고 인원 : 300명"
+    )
+
+
+def test_zone_alert_template_uses_zone_header_and_unknown_description_default():
+    events = [
+        {
+            "location": "산업은행 측면 -> 신교교차로",
+            "start_date": "2026-05-14T11:30:00",
+            "end_date": "2026-05-14T13:00:00",
+            "description": "",
+        },
+        {
+            "location": "광화문 월대 -> 舊)효자치안센터",
+            "start_date": "2026-05-14T14:30:00",
+            "end_date": "2026-05-14T16:00:00",
+            "description": None,
+        }
+    ]
+
+    message = NotificationService._format_zone_message("광화문광장", events)
+
+    assert message == (
+        "설정하신 광화문광장의 집회 안내입니다.\n\n"
+        "1.\n"
+        "집회 일시 : 11:30 ~ 13:00\n"
+        "집회 장소 : 산업은행 측면 -> 신교교차로\n"
+        "신고 인원 : 미상\n\n"
+        "2.\n"
+        "집회 일시 : 14:30 ~ 16:00\n"
+        "집회 장소 : 광화문 월대 -> 舊)효자치안센터\n"
+        "신고 인원 : 미상"
+    )
+
+
+@pytest.mark.asyncio
+async def test_events_today_protests_uses_numbered_brief_template(monkeypatch):
+    monkeypatch.setattr(
+        event_router.EventService,
+        "get_today_events",
+        lambda db: [
+            SimpleNamespace(
+                description="70명",
+                location_name="산업은행 측면 -> 신교교차로",
+                start_date="2026-05-14 11:30:00",
+                end_date="2026-05-14 13:00:00",
+            )
+        ],
+    )
+
+    response = await event_router.get_today_protests({}, None)
+
+    assert response["template"]["outputs"][0]["simpleText"]["text"] == (
+        "오늘 예정된 집회 안내입니다.\n\n"
+        "1.\n"
+        "집회 일시 : 11:30 ~ 13:00\n"
+        "집회 장소 : 산업은행 측면 -> 신교교차로\n"
+        "신고 인원 : 70명"
+    )
+
+
+@pytest.mark.asyncio
+async def test_kakao_skills_upcoming_protests_uses_numbered_brief_template(monkeypatch):
+    monkeypatch.setattr(
+        kakao_skills.EventService,
+        "get_upcoming_events",
+        lambda limit, db: [
+            SimpleNamespace(
+                description="300명",
+                location_name="광화문 월대 -> 舊)효자치안센터",
+                start_date="2026-05-14T14:30:00",
+                end_date="2026-05-14T16:00:00",
+            )
+        ],
+    )
+
+    response = await kakao_skills.get_upcoming_protests({"action": {"params": {"limit": 1}}}, None)
+
+    assert response["template"]["outputs"][0]["simpleText"]["text"] == (
+        "예정된 집회 안내입니다.\n\n"
+        "1.\n"
+        "집회 일시 : 14:30 ~ 16:00\n"
+        "집회 장소 : 광화문 월대 -> 舊)효자치안센터\n"
+        "신고 인원 : 300명"
+    )


### PR DESCRIPTION
## 결론

Closes #109.

집회 알림과 카카오 스킬 응답의 사용자 메시지를 공통 번호형 템플릿으로 통일했습니다.
`description`은 저장된 값을 그대로 사용하고, `null`/빈 값일 때만 `미상`으로 표시합니다.

## 변경 범위

| 파일 | 내용 |
|---|---|
| `app/services/notification_service.py` | 공통 번호형 집회 메시지 템플릿 추가, 일시 표시 정리, `description` 기본값 처리 |
| `app/services/event_service.py` | `scheduled_route_check` 알림 데이터에 `description`, `end_date` 전달 |
| `app/services/zone_alarm_service.py` | `scheduled_zone_check` 조회/전달 데이터에 `description`, `end_date` 포함 |
| `app/routers/events.py` | `/today-protests`, `/upcoming-protests`, `/check-route` 응답을 공통 템플릿으로 통일 |
| `app/routers/kakao_skills.py` | prefix 없는 카카오 스킬용 `today/upcoming/check-route` 응답을 공통 템플릿으로 통일 |
| `tests/test_notification_templates.py` | 공통 템플릿과 `description` 기본값 회귀 테스트 추가 |

## 예시 출력

```text
오늘 예정된 집회 안내입니다.

1.
집회 일시 : 11:30 ~ 13:00
집회 장소 : 산업은행 측면 -> 신교교차로
신고 인원 : 70명
```

## 템플릿 규칙

| 입력 | 출력 |
|---|---|
| `description="70명"` | `70명` |
| `description=null` | `미상` |
| `description=""` | `미상` |
| `start_date="2026-05-14 11:30:00"` | `11:30` |
| `end_date="2026-05-14T13:00:00"` | `13:00` |

## 검증

| 명령/도구 | 결과 |
|---|---|
| `uv run pytest` | `115 passed, 6 warnings` |
| `git diff --check` | 통과 |
| `python3 -m compileall -q app tests` | 통과 |
| `lsp_bridge diagnostics app/services/notification_service.py` | 기존 스타일/타입 경고 확인, 변경 범위 테스트 통과 |
