### PR TITLE
관리자 대시보드 시간을 KST 기준으로 표시

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -41,7 +41,7 @@ _task_lock = asyncio.Lock()
 KST_ZONE_NAME = "Asia/Seoul"
 KST = ZoneInfo(KST_ZONE_NAME)
 DASHBOARD_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S KST"
-DASHBOARD_DATE_FORMAT = "%Y-%m-%d"
+DASHBOARD_DATE_FORMAT = "%Y-%m-%d KST"
 
 def verify_admin(credentials: HTTPBasicCredentials | None = admin_credentials):
     # Using environment variables for admin credentials.
@@ -159,7 +159,7 @@ def fetch_recent_alarms() -> List[Dict[str, Any]]:
         """)
         alarms = cursor.fetchall()
         for alarm in alarms:
-            alarm["created_at_display"] = _format_utc_timestamp_as_kst(alarm.get("created_at"))
+            alarm["created_at_display"] = _format_kst_local_datetime(alarm.get("created_at"))
         return alarms
 
 # Helper for sqlite row to dict
@@ -290,7 +290,7 @@ def _format_user_created_at(value: Any) -> str:
     parsed = _parse_datetime_value(value)
     if parsed is not None:
         if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
+            parsed = parsed.replace(tzinfo=KST)
         return parsed.astimezone(KST).strftime(DASHBOARD_DATE_FORMAT)
 
     return "" if value in (None, "") else str(value)[:10]

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -3,8 +3,9 @@ import secrets
 import asyncio
 import logging
 from collections.abc import Callable, Coroutine
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 from typing import Dict, Any, List, Set
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, HTTPException, status, Request, Query
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
@@ -36,6 +37,11 @@ templates = Jinja2Templates(directory=os.path.join(os.path.dirname(os.path.dirna
 # Task registry and lock to prevent duplicate runs and race conditions
 _background_tasks: dict[str, asyncio.Task[Any]] = {}
 _task_lock = asyncio.Lock()
+
+KST_ZONE_NAME = "Asia/Seoul"
+KST = ZoneInfo(KST_ZONE_NAME)
+DASHBOARD_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S KST"
+DASHBOARD_DATE_FORMAT = "%Y-%m-%d"
 
 def verify_admin(credentials: HTTPBasicCredentials | None = admin_credentials):
     # Using environment variables for admin credentials.
@@ -134,7 +140,11 @@ def fetch_recent_events() -> List[Dict[str, Any]]:
             ORDER BY id DESC 
             LIMIT 100
         """)
-        return cursor.fetchall()
+        events = cursor.fetchall()
+        for event in events:
+            event["created_at_display"] = _format_utc_timestamp_as_kst(event.get("created_at"))
+            event["start_date_display"] = _format_kst_local_datetime(event.get("start_date"))
+        return events
 
 def fetch_recent_alarms() -> List[Dict[str, Any]]:
     # Synchronous DB query
@@ -147,7 +157,10 @@ def fetch_recent_alarms() -> List[Dict[str, Any]]:
             ORDER BY created_at DESC 
             LIMIT 100
         """)
-        return cursor.fetchall()
+        alarms = cursor.fetchall()
+        for alarm in alarms:
+            alarm["created_at_display"] = _format_utc_timestamp_as_kst(alarm.get("created_at"))
+        return alarms
 
 # Helper for sqlite row to dict
 def dict_factory(cursor, row):
@@ -211,36 +224,86 @@ def fetch_paginated_users(limit: int, offset: int) -> List[Dict[str, Any]]:
         """, (limit, offset))
         return cursor.fetchall()
 
-def _format_user_created_at(value: Any) -> str:
+def _parse_datetime_value(value: Any) -> datetime | None:
     if value in (None, ""):
-        return ""
+        return None
 
     if isinstance(value, datetime):
-        return value.strftime("%Y-%m-%d")
+        return value
 
     if isinstance(value, (int, float)):
-        timestamp = float(value)
-        if timestamp > 1_000_000_000_000:
-            timestamp /= 1000.0
-        try:
-            return datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime("%Y-%m-%d")
-        except (OverflowError, OSError, ValueError):
-            return str(value)[:10]
+        return _datetime_from_epoch(value)
 
     text = str(value).strip()
     if not text:
-        return ""
+        return None
+
+    if text.isdigit() and len(text) >= 10:
+        parsed_epoch = _datetime_from_epoch(int(text))
+        if parsed_epoch is not None:
+            return parsed_epoch
 
     for parser in (datetime.fromisoformat,):
         try:
-            return parser(text.replace("Z", "+00:00")).strftime("%Y-%m-%d")
+            return parser(text.replace("Z", "+00:00"))
         except ValueError:
             pass
 
-    if text.isdigit():
-        return _format_user_created_at(int(text))
+    return None
 
-    return text[:10]
+
+def _datetime_from_epoch(value: int | float) -> datetime | None:
+    timestamp = float(value)
+    if timestamp > 1_000_000_000_000:
+        timestamp /= 1000.0
+    try:
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _format_datetime_as_kst(
+    value: Any,
+    *,
+    naive_source_tz: tzinfo,
+    output_format: str = DASHBOARD_DATETIME_FORMAT,
+) -> str:
+    parsed = _parse_datetime_value(value)
+    if parsed is None:
+        return "" if value in (None, "") else str(value)
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=naive_source_tz)
+
+    return parsed.astimezone(KST).strftime(output_format)
+
+
+def _format_utc_timestamp_as_kst(value: Any) -> str:
+    return _format_datetime_as_kst(value, naive_source_tz=timezone.utc)
+
+
+def _format_kst_local_datetime(value: Any) -> str:
+    return _format_datetime_as_kst(value, naive_source_tz=KST)
+
+
+def _format_user_created_at(value: Any) -> str:
+    parsed = _parse_datetime_value(value)
+    if parsed is not None:
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(KST).strftime(DASHBOARD_DATE_FORMAT)
+
+    return "" if value in (None, "") else str(value)[:10]
+
+
+def _apply_scheduler_time_displays(scheduler_status: Dict[str, Any]) -> Dict[str, Any]:
+    for job in scheduler_status.get("jobs", []):
+        job["next_run_display"] = _format_datetime_as_kst(
+            job.get("next_run"),
+            naive_source_tz=KST,
+            output_format="%Y-%m-%d %H:%M KST",
+        )
+    return scheduler_status
 
 @router.get("/dashboard")
 async def dashboard(
@@ -265,7 +328,7 @@ async def dashboard(
         total_pages = math.ceil(total_users / page_size) if total_users > 0 else 1
 
         # Get Scheduler Status
-        scheduler_status = get_scheduler_status()
+        scheduler_status = _apply_scheduler_time_displays(get_scheduler_status())
 
         # Calculate some summary statistics
         total_events = len(events)

--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -93,7 +93,7 @@
                             {% for job in scheduler_status.jobs %}
                                 <li class="py-2 flex justify-between items-center">
                                     <div class="text-sm font-medium text-gray-800">{{ job.name }}</div>
-                                    <div class="text-xs text-indigo-600 font-mono">{{ job.next_run[:16] if job.next_run else 'N/A' }}</div>
+                                    <div class="text-xs text-indigo-600 font-mono">{{ job.next_run_display if job.next_run_display else 'N/A' }}</div>
                                 </li>
                             {% endfor %}
                         </ul>
@@ -138,7 +138,7 @@
                     <table class="min-w-full divide-y divide-gray-200">
                         <thead class="bg-gray-50 sticky top-0">
                             <tr>
-                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID / Created</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID / Created (KST)</th>
                                 <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Event Details</th>
                                 <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Severity</th>
                             </tr>
@@ -148,11 +148,11 @@
                             <tr class="hover:bg-gray-50">
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                                     <div class="font-mono">#{{ event.id }}</div>
-                                    <div class="text-xs mt-1 text-gray-400">{{ event.created_at }}</div>
+                                    <div class="text-xs mt-1 text-gray-400">{{ event.created_at_display }}</div>
                                 </td>
                                 <td class="px-6 py-4 text-sm text-gray-900">
                                     <div class="font-bold truncate max-w-xs">{{ event.title }}</div>
-                                    <div class="text-gray-500 text-xs mt-1">{{ event.location_name }} • {{ event.start_date }}</div>
+                                    <div class="text-gray-500 text-xs mt-1">{{ event.location_name }} • {{ event.start_date_display }}</div>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap">
                                     {% if event.severity_level == 3 %}
@@ -187,7 +187,7 @@
                     <table class="min-w-full divide-y divide-gray-200">
                         <thead class="bg-gray-50 sticky top-0">
                             <tr>
-                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Task / Time</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Task / Time (KST)</th>
                                 <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                                 <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Progress</th>
                             </tr>
@@ -197,7 +197,7 @@
                             <tr class="hover:bg-gray-50">
                                 <td class="px-6 py-4 whitespace-nowrap text-sm">
                                     <div class="font-mono text-gray-600">{{ alarm.task_id[:12] }}...</div>
-                                    <div class="text-xs text-gray-400 mt-1">{{ alarm.created_at }}</div>
+                                    <div class="text-xs text-gray-400 mt-1">{{ alarm.created_at_display }}</div>
                                     <span class="inline-block mt-1 px-1.5 py-0.5 text-[10px] font-medium bg-gray-100 text-gray-600 rounded">{{ alarm.alarm_type }}</span>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap">

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock
 from app.config.settings import settings
+from app.database.connection import get_db_connection
 
 # Do not instantiate a global TestClient here.
 # Use the `test_client` fixture to isolate the DB and rely on `clean_test_db`.
@@ -33,6 +34,78 @@ def test_admin_dashboard_valid_credentials(test_client, monkeypatch):
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
     assert "KT Demo Alarm Back-office" in response.text
+
+
+@pytest.mark.usefixtures("clean_test_db")
+def test_admin_dashboard_displays_times_in_kst(test_client, monkeypatch):
+    """관리자 대시보드의 운영 타임스탬프는 KST로 변환해서 표시해야 함"""
+    monkeypatch.setattr(settings, "ADMIN_USER", "admin")
+    monkeypatch.setattr(settings, "ADMIN_PASS", "secret123")
+
+    with get_db_connection() as db:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            INSERT INTO events (
+                title, location_name, latitude, longitude, start_date,
+                severity_level, status, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "KST 표시 검증 집회",
+                "광화문",
+                37.5716,
+                126.9784,
+                "2026-05-15 11:00:00",
+                1,
+                "active",
+                "2026-05-15 00:30:00",
+            ),
+        )
+        cursor.execute(
+            """
+            INSERT INTO alarm_tasks (
+                task_id, alarm_type, status, total_recipients,
+                successful_sends, failed_sends, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "task-kst-display",
+                "bulk",
+                "completed",
+                3,
+                3,
+                0,
+                "2026-05-15T00:40:00",
+            ),
+        )
+        cursor.execute(
+            """
+            INSERT INTO users (
+                bot_user_key, first_message_at, last_message_at,
+                message_count, active
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "kst-user",
+                "2026-05-20 23:30:00",
+                "2026-05-20 23:30:00",
+                1,
+                1,
+            ),
+        )
+        db.commit()
+
+    response = test_client.get("/admin/dashboard", auth=("admin", "secret123"))
+
+    assert response.status_code == 200
+    assert "2026-05-15 09:30:00 KST" in response.text
+    assert "2026-05-15 09:40:00 KST" in response.text
+    assert "광화문 • 2026-05-15 11:00:00 KST" in response.text
+    assert "2026-05-15 20:00:00 KST" not in response.text
+    assert "kst-user" in response.text
+    assert "2026-05-21" in response.text
+    assert "2026-05-20" not in response.text
 
 def test_admin_dashboard_missing_env_vars(test_client, monkeypatch):
     """환경변수가 설정되지 않은 경우 500 에러를 반환해야 함"""

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -76,7 +76,24 @@ def test_admin_dashboard_displays_times_in_kst(test_client, monkeypatch):
                 3,
                 3,
                 0,
-                "2026-05-15T00:40:00",
+                "2026-05-15T09:40:00",
+            ),
+        )
+        cursor.execute(
+            """
+            INSERT INTO alarm_tasks (
+                task_id, alarm_type, status, total_recipients,
+                successful_sends, failed_sends, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "task-utc-offset-display",
+                "bulk",
+                "completed",
+                2,
+                2,
+                0,
+                "2026-05-15T00:50:00+00:00",
             ),
         )
         cursor.execute(
@@ -101,11 +118,12 @@ def test_admin_dashboard_displays_times_in_kst(test_client, monkeypatch):
     assert response.status_code == 200
     assert "2026-05-15 09:30:00 KST" in response.text
     assert "2026-05-15 09:40:00 KST" in response.text
+    assert "2026-05-15 09:50:00 KST" in response.text
     assert "광화문 • 2026-05-15 11:00:00 KST" in response.text
     assert "2026-05-15 20:00:00 KST" not in response.text
     assert "kst-user" in response.text
-    assert "2026-05-21" in response.text
-    assert "2026-05-20" not in response.text
+    assert "2026-05-20 KST" in response.text
+    assert "2026-05-21" not in response.text
 
 def test_admin_dashboard_missing_env_vars(test_client, monkeypatch):
     """환경변수가 설정되지 않은 경우 500 에러를 반환해야 함"""


### PR DESCRIPTION
## Summary
- 관리자 대시보드의 이벤트/알림/스케줄러/사용자 시간 표시를 KST 기준으로 명시합니다.
- SQLite/서버 UTC 타임스탬프는 KST로 변환하고, 이미 한국 현지 일정 시간인 이벤트 `start_date`는 시간 이동 없이 KST 라벨을 붙입니다.
- 대시보드 KST 표시 회귀 테스트를 추가했습니다.

## Status
Ready for review

## Issue
Closes #115

## Verification
- `uv run pytest tests/test_api_admin.py::test_admin_dashboard_displays_times_in_kst`
- `uv run pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin dashboard now displays all timestamps in Korea Standard Time (KST) with consistent formatting.
  * Dashboard headers updated to clarify KST timezone for scheduler jobs, event records, and notification tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoonly01/kt-demo-alarm/pull/116)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->