### PR TITLE
Stabilize SMPA geocoding abbreviation candidates

### DIFF
--- a/app/services/crawling/smpa_coordinates.py
+++ b/app/services/crawling/smpa_coordinates.py
@@ -225,11 +225,8 @@ async def _geocode_first_matching_query(
     client: httpx.AsyncClient | None,
 ) -> GeocodeResult | None:
     if not settings.KAKAO_LOCATION_API_KEY:
-        return await geocode_place_with_kakao(
-            queries[0] if queries else "",
-            client,
-            warn_on_empty_result=False,
-        )
+        logger.warning("KAKAO_LOCATION_API_KEY가 없어 지오코딩을 건너뜁니다.")
+        return None
 
     for query in queries:
         result = await geocode_place_with_kakao(

--- a/app/services/crawling/smpa_coordinates.py
+++ b/app/services/crawling/smpa_coordinates.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
+from functools import lru_cache
+from typing import cast
 
 import httpx
 
 from app.config.settings import settings
+from app.services.crawling.smpa_geocode_rules import (
+    SMPA_GEOCODE_ABBREVIATION_RULES,
+    GeocodeAbbreviationRule,
+)
 from app.services.crawling.smpa_parser import ParsedSmpaEvent
 
 logger = logging.getLogger(__name__)
@@ -20,6 +27,8 @@ JONGNO_BBOX = {
     "min_lon": 126.9400,
     "max_lon": 127.0250,
 }
+LOCATION_CONTEXT_RE = re.compile(r"<(?P<context>[^>]+)>")
+CONTEXT_TRAILING_MARKERS_RE = re.compile(r"\s*(?:등|일대)$")
 
 
 @dataclass(frozen=True)
@@ -90,9 +99,86 @@ def choose_representative_coordinate(
     )
 
 
+def _clean_query_text(value: str) -> str:
+    return " ".join(value.split()).strip()
+
+
+def _dedupe_queries(queries: list[str]) -> tuple[str, ...]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for query in queries:
+        cleaned = _clean_query_text(query)
+        if cleaned and cleaned not in seen:
+            deduped.append(cleaned)
+            seen.add(cleaned)
+    return tuple(deduped)
+
+
+def _extract_location_context(raw_location: str) -> str:
+    match = LOCATION_CONTEXT_RE.search(raw_location)
+    if match is None:
+        return ""
+    context = _clean_query_text(match.group("context"))
+    return CONTEXT_TRAILING_MARKERS_RE.sub("", context).strip()
+
+
+@lru_cache(maxsize=16)
+def _compile_geocode_abbreviation_rules(
+    raw_rules: tuple[GeocodeAbbreviationRule, ...],
+) -> tuple[tuple[re.Pattern[str], str], ...]:
+    return tuple((re.compile(pattern_text), replacement) for pattern_text, replacement in raw_rules)
+
+
+def _active_geocode_abbreviation_rules() -> tuple[tuple[re.Pattern[str], str], ...]:
+    return _compile_geocode_abbreviation_rules(SMPA_GEOCODE_ABBREVIATION_RULES)
+
+
+def _replace_geocode_abbreviations(query: str) -> str:
+    replaced = query
+    for pattern, replacement in _active_geocode_abbreviation_rules():
+        replaced = pattern.sub(replacement, replaced)
+    return _clean_query_text(replaced)
+
+
+def build_geocode_query_candidates(candidate: str, raw_location: str) -> tuple[str, ...]:
+    """SMPA 장소 표기를 Kakao keyword search용 후보 검색어로 확장한다."""
+    cleaned = _clean_query_text(candidate)
+    replaced = _replace_geocode_abbreviations(cleaned)
+    context = _extract_location_context(raw_location)
+
+    queries = [cleaned, replaced]
+    base_for_context = replaced or cleaned
+    if context and base_for_context:
+        queries.extend([f"{context} {base_for_context}", f"{base_for_context} {context}"])
+
+    return _dedupe_queries(queries)
+
+
+def _first_kakao_document(payload: object) -> dict[str, object] | None:
+    if not isinstance(payload, dict):
+        return None
+    payload_mapping = cast(dict[str, object], payload)
+    raw_documents = payload_mapping.get("documents")
+    if not isinstance(raw_documents, list) or not raw_documents:
+        return None
+    documents = cast(list[object], raw_documents)
+    first = documents[0]
+    if not isinstance(first, dict):
+        return None
+    return cast(dict[str, object], first)
+
+
+def _optional_text(value: object, fallback: str = "") -> str:
+    if isinstance(value, str) and value:
+        return value
+    return fallback
+
+
 async def geocode_place_with_kakao(
     query: str,
     client: httpx.AsyncClient | None = None,
+    *,
+    warn_on_empty_result: bool = True,
 ) -> GeocodeResult | None:
     """Kakao keyword search로 장소명 하나를 좌표로 변환한다."""
     if not settings.KAKAO_LOCATION_API_KEY:
@@ -108,20 +194,53 @@ async def geocode_place_with_kakao(
         async with httpx.AsyncClient(timeout=settings.SMPA_HTTP_TIMEOUT_SECONDS) as new_client:
             response = await new_client.get(KAKAO_LOCAL_KEYWORD_URL, headers=headers, params=params)
 
-    response.raise_for_status()
-    documents = response.json().get("documents") or []
-    if not documents:
-        logger.warning("Kakao 지오코딩 결과 없음: %s", query)
+    _ = response.raise_for_status()
+    payload = cast(object, response.json())
+    first = _first_kakao_document(payload)
+    if first is None:
+        if warn_on_empty_result:
+            logger.warning("Kakao 지오코딩 결과 없음: %s", query)
         return None
 
-    first = documents[0]
+    latitude = first.get("y")
+    longitude = first.get("x")
+    if not isinstance(latitude, str) or not isinstance(longitude, str):
+        logger.warning("Kakao 지오코딩 좌표 형식 오류: %s", query)
+        return None
+
     return GeocodeResult(
         query=query,
-        name=first.get("place_name") or query,
-        address=first.get("road_address_name") or first.get("address_name") or "",
-        latitude=float(first["y"]),
-        longitude=float(first["x"]),
+        name=_optional_text(first.get("place_name"), query),
+        address=_optional_text(
+            first.get("road_address_name"),
+            _optional_text(first.get("address_name")),
+        ),
+        latitude=float(latitude),
+        longitude=float(longitude),
     )
+
+
+async def _geocode_first_matching_query(
+    queries: tuple[str, ...],
+    client: httpx.AsyncClient | None,
+) -> GeocodeResult | None:
+    if not settings.KAKAO_LOCATION_API_KEY:
+        return await geocode_place_with_kakao(
+            queries[0] if queries else "",
+            client,
+            warn_on_empty_result=False,
+        )
+
+    for query in queries:
+        result = await geocode_place_with_kakao(
+            query,
+            client,
+            warn_on_empty_result=False,
+        )
+        if result is not None:
+            return result
+    logger.warning("Kakao 지오코딩 결과 없음: %s", " | ".join(queries))
+    return None
 
 
 async def select_coordinate_for_event(
@@ -131,7 +250,8 @@ async def select_coordinate_for_event(
     """파싱된 이벤트의 endpoint 후보를 지오코딩하고 대표 좌표를 선택한다."""
     results: list[GeocodeResult] = []
     for candidate in event.endpoint_candidates:
-        result = await geocode_place_with_kakao(candidate, client)
+        queries = build_geocode_query_candidates(candidate, event.raw_location)
+        result = await _geocode_first_matching_query(queries, client)
         if result is not None:
             results.append(result)
     if not results:

--- a/app/services/crawling/smpa_geocode_rules.py
+++ b/app/services/crawling/smpa_geocode_rules.py
@@ -1,0 +1,17 @@
+"""SMPA Kakao 지오코딩 후보 생성을 위한 버전관리 ruleset."""
+
+from __future__ import annotations
+
+GeocodeAbbreviationRule = tuple[str, str]
+
+# 규칙 추가/수정은 이 ruleset만 변경하고, 대표 케이스를 테스트로 함께 고정한다.
+SMPA_GEOCODE_ABBREVIATION_RULES: tuple[GeocodeAbbreviationRule, ...] = (
+    (r"舊\)", "구)"),
+    (
+        r"(?P<station>.+?역)\s*(?P<exit>\d+)\s*出",
+        r"\g<station> \g<exit>번 출구",
+    ),
+    (r"(?P<exit>\d+)\s*出", r"\g<exit>번 출구"),
+    (r"(?P<place>.+?)PB$", r"\g<place>치안센터"),
+    (r"(?P<place>.+?)R$", r"\g<place>교차로"),
+)

--- a/app/services/crawling/smpa_geocode_rules.py
+++ b/app/services/crawling/smpa_geocode_rules.py
@@ -12,6 +12,6 @@ SMPA_GEOCODE_ABBREVIATION_RULES: tuple[GeocodeAbbreviationRule, ...] = (
         r"\g<station> \g<exit>번 출구",
     ),
     (r"(?P<exit>\d+)\s*出", r"\g<exit>번 출구"),
-    (r"(?P<place>.+?)PB$", r"\g<place>치안센터"),
-    (r"(?P<place>.+?)R$", r"\g<place>교차로"),
+    (r"(?P<place>.*[가-힣])PB$", r"\g<place>치안센터"),
+    (r"(?P<place>.*[가-힣])R$", r"\g<place>교차로"),
 )

--- a/tests/test_smpa_coordinate_selection.py
+++ b/tests/test_smpa_coordinate_selection.py
@@ -141,8 +141,17 @@ def test_build_geocode_query_candidates_adds_context_to_replaced_query():
     )
 
 
+@pytest.mark.parametrize("candidate", ["STAR", "XPB"])
+def test_build_geocode_query_candidates_keeps_latin_suffix_words(candidate: str) -> None:
+    queries = build_geocode_query_candidates(candidate, candidate)
+
+    assert queries == (candidate,)
+
+
 @pytest.mark.asyncio
-async def test_select_coordinate_for_event_uses_replaced_query_in_kakao_path() -> None:
+async def test_select_coordinate_for_event_uses_replaced_query_in_kakao_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     transport = KakaoKeywordTransport(
         {
             "효자치안센터": [
@@ -157,16 +166,12 @@ async def test_select_coordinate_for_event_uses_replaced_query_in_kakao_path() -
         }
     )
 
-    previous_key = settings.KAKAO_LOCATION_API_KEY
-    settings.KAKAO_LOCATION_API_KEY = TEST_KAKAO_API_KEY
-    try:
-        async with httpx.AsyncClient(transport=transport) as client:
-            selected = await select_coordinate_for_event(
-                smpa_event_for_endpoint("효자PB"),
-                client,
-            )
-    finally:
-        settings.KAKAO_LOCATION_API_KEY = previous_key
+    monkeypatch.setattr(settings, "KAKAO_LOCATION_API_KEY", TEST_KAKAO_API_KEY)
+    async with httpx.AsyncClient(transport=transport) as client:
+        selected = await select_coordinate_for_event(
+            smpa_event_for_endpoint("효자PB"),
+            client,
+        )
 
     assert transport.requested_queries == ["효자PB", "효자치안센터"]
     assert selected is not None
@@ -174,19 +179,34 @@ async def test_select_coordinate_for_event_uses_replaced_query_in_kakao_path() -
 
 
 @pytest.mark.asyncio
-async def test_select_coordinate_for_event_keeps_coordinate_failure_visible() -> None:
+async def test_select_coordinate_for_event_keeps_coordinate_failure_visible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     transport = KakaoKeywordTransport({})
 
-    previous_key = settings.KAKAO_LOCATION_API_KEY
-    settings.KAKAO_LOCATION_API_KEY = TEST_KAKAO_API_KEY
-    try:
-        async with httpx.AsyncClient(transport=transport) as client:
-            selected = await select_coordinate_for_event(
-                smpa_event_for_endpoint("신교R"),
-                client,
-            )
-    finally:
-        settings.KAKAO_LOCATION_API_KEY = previous_key
+    monkeypatch.setattr(settings, "KAKAO_LOCATION_API_KEY", TEST_KAKAO_API_KEY)
+    async with httpx.AsyncClient(transport=transport) as client:
+        selected = await select_coordinate_for_event(
+            smpa_event_for_endpoint("신교R"),
+            client,
+        )
 
     assert transport.requested_queries == ["신교R", "신교교차로"]
+    assert selected is None
+
+
+@pytest.mark.asyncio
+async def test_select_coordinate_for_event_returns_without_query_when_kakao_key_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = KakaoKeywordTransport({"효자치안센터": []})
+
+    monkeypatch.setattr(settings, "KAKAO_LOCATION_API_KEY", "")
+    async with httpx.AsyncClient(transport=transport) as client:
+        selected = await select_coordinate_for_event(
+            smpa_event_for_endpoint("효자PB"),
+            client,
+        )
+
+    assert transport.requested_queries == []
     assert selected is None

--- a/tests/test_smpa_coordinate_selection.py
+++ b/tests/test_smpa_coordinate_selection.py
@@ -1,19 +1,65 @@
+from datetime import datetime
+from collections.abc import Mapping
+from typing import override
+
+import httpx
 import pytest
 
+from app.config.settings import settings
 from app.services.crawling.smpa_coordinates import (
     GeocodeResult,
+    build_geocode_query_candidates,
     choose_representative_coordinate,
     is_jongno_result,
+    select_coordinate_for_event,
 )
+from app.services.crawling.smpa_parser import ParsedSmpaEvent
+
+TEST_KAKAO_API_KEY = "test-api-key"
+SMPA_TEST_SOURCE_URL = "https://example.test/smpa"
+SMPA_TEST_START_AT = datetime(2026, 5, 15, 9, 0)
+SMPA_TEST_END_AT = datetime(2026, 5, 15, 10, 0)
 
 
-def result(query, address, latitude, longitude):
+class KakaoKeywordTransport(httpx.AsyncBaseTransport):
+    """실제 httpx.AsyncClient 경로로 Kakao keyword 응답을 재현하는 인프로세스 전송 계층."""
+
+    def __init__(self, documents_by_query: Mapping[str, list[dict[str, str]]]) -> None:
+        self._documents_by_query: Mapping[str, list[dict[str, str]]] = documents_by_query
+        self.requested_queries: list[str] = []
+
+    @override
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        query = request.url.params["query"]
+        self.requested_queries.append(query)
+        return httpx.Response(
+            200,
+            json={"documents": self._documents_by_query.get(query, [])},
+            request=request,
+        )
+
+
+def result(query: str, address: str, latitude: float, longitude: float) -> GeocodeResult:
     return GeocodeResult(
         query=query,
         name=query,
         address=address,
         latitude=latitude,
         longitude=longitude,
+    )
+
+
+def smpa_event_for_endpoint(endpoint: str) -> ParsedSmpaEvent:
+    return ParsedSmpaEvent(
+        title=f"SMPA 집회 - {endpoint}",
+        raw_location=endpoint,
+        endpoint_candidates=(endpoint,),
+        attendees="10명",
+        police_station="종로서",
+        start_date=SMPA_TEST_START_AT,
+        end_date=SMPA_TEST_END_AT,
+        source_id="board-1",
+        source_url=SMPA_TEST_SOURCE_URL,
     )
 
 
@@ -63,4 +109,84 @@ def test_bbox_fallback_is_used_only_when_address_is_missing():
 
 def test_empty_geocode_results_are_rejected():
     with pytest.raises(ValueError):
-        choose_representative_coordinate("원문 경로", [])
+        _ = choose_representative_coordinate("원문 경로", [])
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expected_replaced"),
+    [
+        ("舊)효자PB", "구)효자치안센터"),
+        ("문래역4出", "문래역 4번 출구"),
+        ("신교R", "신교교차로"),
+        ("효자PB", "효자치안센터"),
+    ],
+)
+def test_build_geocode_query_candidates_applies_generic_abbreviation_replacements(
+    candidate: str,
+    expected_replaced: str,
+) -> None:
+    queries = build_geocode_query_candidates(candidate, candidate)
+
+    assert queries == (candidate, expected_replaced)
+
+
+def test_build_geocode_query_candidates_adds_context_to_replaced_query():
+    queries = build_geocode_query_candidates("문래역4出", "문래역4出 -> 당산역10出 <문래동3가 등>")
+
+    assert queries == (
+        "문래역4出",
+        "문래역 4번 출구",
+        "문래동3가 문래역 4번 출구",
+        "문래역 4번 출구 문래동3가",
+    )
+
+
+@pytest.mark.asyncio
+async def test_select_coordinate_for_event_uses_replaced_query_in_kakao_path() -> None:
+    transport = KakaoKeywordTransport(
+        {
+            "효자치안센터": [
+                {
+                    "place_name": "효자치안센터",
+                    "address_name": "서울 종로구 효자동",
+                    "road_address_name": "",
+                    "x": "126.9700",
+                    "y": "37.5800",
+                }
+            ]
+        }
+    )
+
+    previous_key = settings.KAKAO_LOCATION_API_KEY
+    settings.KAKAO_LOCATION_API_KEY = TEST_KAKAO_API_KEY
+    try:
+        async with httpx.AsyncClient(transport=transport) as client:
+            selected = await select_coordinate_for_event(
+                smpa_event_for_endpoint("효자PB"),
+                client,
+            )
+    finally:
+        settings.KAKAO_LOCATION_API_KEY = previous_key
+
+    assert transport.requested_queries == ["효자PB", "효자치안센터"]
+    assert selected is not None
+    assert selected.selected_name == "효자치안센터"
+
+
+@pytest.mark.asyncio
+async def test_select_coordinate_for_event_keeps_coordinate_failure_visible() -> None:
+    transport = KakaoKeywordTransport({})
+
+    previous_key = settings.KAKAO_LOCATION_API_KEY
+    settings.KAKAO_LOCATION_API_KEY = TEST_KAKAO_API_KEY
+    try:
+        async with httpx.AsyncClient(transport=transport) as client:
+            selected = await select_coordinate_for_event(
+                smpa_event_for_endpoint("신교R"),
+                client,
+            )
+    finally:
+        settings.KAKAO_LOCATION_API_KEY = previous_key
+
+    assert transport.requested_queries == ["신교R", "신교교차로"]
+    assert selected is None


### PR DESCRIPTION
## Summary
- Add a version-controlled SMPA geocode abbreviation ruleset for common source abbreviations.
- Generate original/replaced/contextual Kakao keyword candidates in the `select_coordinate_for_event()` path.
- Add regression coverage for default rules, query ordering, and visible coordinate failures.

Closes #117

## Verification
- `uv run pytest tests/test_smpa_coordinate_selection.py tests/test_smpa_parser.py tests/test_smpa_source.py tests/test_smpa_source_upsert.py` → 23 passed
- `uv run pytest` → 155 passed, 2 skipped
- `uv run python -m compileall -q app tests`
- `git diff --check && git diff --cached --check`
- LSP diagnostics on changed files → 0 errors

## Notes
- No place-specific dictionary was added.
- No new geocoder/API/dependency was added.
- Live Kakao/SMPA smoke tests remain guarded by environment variables and were not run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced event location coordinate detection with improved candidate generation from various location formats.
  * Added optional warning control for empty geocoding results.

* **Bug Fixes**
  * Improved location query robustness with stricter response validation.

* **Tests**
  * Expanded test coverage for coordinate selection and location query candidate generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoonly01/kt-demo-alarm/pull/118)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->