### PR TITLE
Reduce admin dashboard scroll density with disclosure panels

### DIFF
--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -616,8 +616,8 @@
                     <div class="kv-row" style="margin-top: 16px;">
                         <span>Showing page {{ pagination.page }} of {{ pagination.total_pages }}</span>
                         <span>
-                            {% if pagination.has_previous %}<a class="link" href="?page={{ pagination.previous_page }}&page_size={{ pagination.page_size }}">Previous</a>{% endif %}
-                            {% if pagination.has_next %}<a class="link" href="?page={{ pagination.next_page }}&page_size={{ pagination.page_size }}">Next</a>{% endif %}
+                            {% if pagination.has_previous %}<a class="link" data-dashboard-pagination-link href="?page={{ pagination.previous_page }}&page_size={{ pagination.page_size }}">Previous</a>{% endif %}
+                            {% if pagination.has_next %}<a class="link" data-dashboard-pagination-link href="?page={{ pagination.next_page }}&page_size={{ pagination.page_size }}">Next</a>{% endif %}
                         </span>
                     </div>
                     {% endif %}
@@ -790,6 +790,16 @@
                     return;
                 }
                 setDashboardPanelVisibility(panelId, true);
+            });
+        });
+        document.querySelectorAll('[data-dashboard-pagination-link]').forEach((link) => {
+            link.addEventListener('click', (event) => {
+                const href = link.getAttribute('href');
+                if (!href || !window.location.hash) return;
+                event.preventDefault();
+                const targetUrl = new URL(href, window.location.href);
+                targetUrl.hash = window.location.hash;
+                window.location.href = targetUrl.toString();
             });
         });
         restoreDashboardPanelFromHash();

--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -67,6 +67,7 @@
             box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
             overflow: hidden;
         }
+        [hidden] { display: none !important; }
         .section-header {
             display: flex;
             justify-content: space-between;
@@ -168,6 +169,49 @@
             cursor: pointer;
         }
         .action-card button:disabled { opacity: 0.55; cursor: not-allowed; }
+        .task-nav {
+            margin-top: 24px;
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 16px;
+            box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+            padding: 18px 20px;
+        }
+        .task-nav-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 16px;
+            align-items: flex-start;
+            margin-bottom: 14px;
+        }
+        .task-nav h2 {
+            margin: 0;
+        }
+        .task-nav p {
+            margin: 6px 0 0;
+            color: var(--muted);
+            font-size: 14px;
+        }
+        .task-button-grid {
+            display: grid;
+            grid-template-columns: repeat(5, minmax(0, 1fr));
+            gap: 10px;
+        }
+        .task-button {
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 12px;
+            background: #f8fafc;
+            color: var(--text);
+            cursor: pointer;
+            font-weight: 700;
+            text-align: left;
+        }
+        .task-button[aria-expanded="true"] {
+            border-color: var(--primary);
+            background: #eef2ff;
+            color: #3730a3;
+        }
         .kv-list { display: grid; gap: 10px; }
         .kv-row {
             display: flex;
@@ -199,12 +243,14 @@
         @media (max-width: 1100px) {
             .grid-4, .action-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
             .grid-3 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+            .task-button-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
             .grid-2 { grid-template-columns: 1fr; }
         }
         @media (max-width: 640px) {
             main, .header-inner { width: min(100% - 20px, 100%); }
-            .grid-4, .grid-3, .action-grid { grid-template-columns: 1fr; }
+            .grid-4, .grid-3, .action-grid, .task-button-grid { grid-template-columns: 1fr; }
             .header-inner { align-items: flex-start; flex-direction: column; }
+            .task-nav-header { flex-direction: column; }
         }
     </style>
 </head>
@@ -225,7 +271,7 @@
             <div class="section-header">
                 <div>
                     <h2>Overview</h2>
-                    <p>운영 판단에 필요한 수집 최신성, 발송 실패, 사용자 readiness, 버스 캐시 상태를 한 화면에 모읍니다.</p>
+                    <p>운영 판단에 필요한 수집 최신성, 발송 실패, 버스 캐시, 스케줄러 상태를 한 화면에 모읍니다.</p>
                 </div>
                 {% if scheduler_status and scheduler_status.status == 'running' %}
                     <span class="badge badge-success">Scheduler running</span>
@@ -241,19 +287,22 @@
                         <div class="subtext">Active: {{ stats.active_events }}</div>
                     </div>
                     <div class="metric">
+                        <span>Collection Recency</span>
+                        <strong style="font-size: 18px;">Latest collected: {{ stats.latest_collected_at_display or 'not recorded' }}</strong>
+                        <div class="subtext">Latest event update: {{ stats.latest_event_updated_at_display or 'not recorded' }}</div>
+                    </div>
+                    <div class="metric">
                         <span>Notification Tasks</span>
                         <strong>{{ stats.total_alarms }}</strong>
-                        <div class="subtext">Failed/partial tasks: {{ stats.failed_alarm_tasks }}</div>
+                        <div class="subtext">Sent: {{ stats.total_alarms_sent }} · Failed/partial tasks: {{ stats.failed_alarm_tasks }} · Success rate: {{ stats.success_rate }}% · Failures: {{ stats.failed_sends }}</div>
                     </div>
                     <div class="metric">
-                        <span>Alarms Sent</span>
-                        <strong>{{ stats.total_alarms_sent }}</strong>
-                        <div class="subtext">Success rate: {{ stats.success_rate }}% · Failures: {{ stats.failed_sends }}</div>
-                    </div>
-                    <div class="metric">
-                        <span>User Readiness</span>
-                        <strong>{{ stats.route_ready_users }}/{{ stats.total_users }}</strong>
-                        <div class="subtext">{{ stats.readiness_rate }}% route-ready · {{ stats.subscribed_users }} subscribed</div>
+                        <span>Bus cache</span>
+                        <strong style="font-size: 18px;">cached_count: {{ bus_notice_status.cached_count }}</strong>
+                        <div class="subtext">
+                            {% if bus_notice_status.crawler_initialized %}Crawler initialized{% else %}Crawler not initialized{% endif %}
+                            · Last update: {{ bus_notice_status.last_update_display or 'not recorded' }}
+                        </div>
                     </div>
                 </div>
                 <div style="margin-top: 16px;">
@@ -274,8 +323,65 @@
             </div>
         </section>
 
-        <div class="grid grid-2">
-            <section class="section" data-testid="collection-section">
+        <nav class="task-nav" aria-label="업무 상세 보기">
+            <div class="task-nav-header">
+                <div>
+                    <h2>업무 상세 보기</h2>
+                    <p>긴 상세 표는 기본으로 숨기고, 필요한 업무 버튼을 선택할 때 하나씩 펼칩니다.</p>
+                </div>
+                <span class="badge badge-muted">Details hidden by default</span>
+            </div>
+            <div class="task-button-grid">
+                <button
+                    type="button"
+                    class="task-button"
+                    data-testid="dashboard-task-button-collection"
+                    data-dashboard-panel-button
+                    data-panel-hash="collection"
+                    aria-expanded="false"
+                    aria-controls="collection-panel"
+                >데이터 수집 상태</button>
+                <button
+                    type="button"
+                    class="task-button"
+                    data-testid="dashboard-task-button-bus"
+                    data-dashboard-panel-button
+                    data-panel-hash="bus"
+                    aria-expanded="false"
+                    aria-controls="bus-panel"
+                >버스 공지 운영</button>
+                <button
+                    type="button"
+                    class="task-button"
+                    data-testid="dashboard-task-button-alarms"
+                    data-dashboard-panel-button
+                    data-panel-hash="alarms"
+                    aria-expanded="false"
+                    aria-controls="alarm-panel"
+                >알림 발송 운영</button>
+                <button
+                    type="button"
+                    class="task-button"
+                    data-testid="dashboard-task-button-readiness"
+                    data-dashboard-panel-button
+                    data-panel-hash="readiness"
+                    aria-expanded="false"
+                    aria-controls="readiness-panel"
+                >사용자 readiness</button>
+                <button
+                    type="button"
+                    class="task-button"
+                    data-testid="dashboard-task-button-events"
+                    data-dashboard-panel-button
+                    data-panel-hash="events"
+                    aria-expanded="false"
+                    aria-controls="events-panel"
+                >이벤트/집회 탐색</button>
+            </div>
+        </nav>
+
+        <div class="dashboard-panels" data-dashboard-panels>
+            <section id="collection-panel" class="section" data-testid="collection-section" data-dashboard-panel hidden>
                 <div class="section-header">
                     <div>
                         <h2>데이터 수집 상태</h2>
@@ -326,7 +432,7 @@
                 </div>
             </section>
 
-            <section class="section" data-testid="bus-section">
+            <section id="bus-panel" class="section" data-testid="bus-section" data-dashboard-panel hidden>
                 <div class="section-header">
                     <div>
                         <h2>버스 공지 운영</h2>
@@ -353,154 +459,234 @@
                     </div>
                 </div>
             </section>
+
+            <section id="alarm-panel" class="section" data-testid="alarm-section" data-dashboard-panel hidden>
+                <div class="section-header">
+                    <div>
+                        <h2>알림 발송 운영</h2>
+                        <p>event_id, request_data, error_messages, completed_at, updated_at를 포함해 실패 진단을 노출합니다.</p>
+                    </div>
+                    <span class="badge {% if stats.failed_sends > 0 %}badge-danger{% else %}badge-success{% endif %}">{{ stats.failed_sends }} failed sends</span>
+                </div>
+                <div class="section-body">
+                    {% if alarms %}
+                    <div class="table-wrap">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Task / Time (KST)</th>
+                                    <th>Status</th>
+                                    <th>Delivery</th>
+                                    <th>Diagnostics</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            {% for alarm in alarms %}
+                                <tr>
+                                    <td>
+                                        <div class="mono">{{ alarm.task_id_display }}</div>
+                                        <div class="muted">Created: {{ alarm.created_at_display or 'not recorded' }}</div>
+                                        <div class="muted">Updated: {{ alarm.updated_at_display or 'not recorded' }}</div>
+                                        <div class="muted">Completed: {{ alarm.completed_at_display or 'not recorded' }}</div>
+                                    </td>
+                                    <td>
+                                        {% if alarm.status == 'completed' %}
+                                            <span class="badge badge-success">Completed</span>
+                                        {% elif alarm.status == 'failed' %}
+                                            <span class="badge badge-danger">Failed</span>
+                                        {% elif alarm.status == 'partial' %}
+                                            <span class="badge badge-warning">Partial</span>
+                                        {% else %}
+                                            <span class="badge">{{ alarm.status }}</span>
+                                        {% endif %}
+                                        <div class="muted">Type: {{ alarm.alarm_type }}</div>
+                                        <div class="muted">event_id: {{ alarm.event_id or 'none' }}</div>
+                                    </td>
+                                    <td>
+                                        <strong>{{ alarm.successful_sends }}</strong> success /
+                                        <strong>{{ alarm.failed_sends }}</strong> failed of
+                                        <strong>{{ alarm.total_recipients }}</strong>
+                                    </td>
+                                    <td>
+                                        <div><strong>Request:</strong> {{ alarm.request_summary or 'not recorded' }}</div>
+                                        <div><strong>Errors:</strong> {{ alarm.error_summary or 'not recorded' }}</div>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% else %}
+                    <div class="empty">No recent alarms found — notification diagnostics are empty.</div>
+                    {% endif %}
+                </div>
+            </section>
+
+            <section id="readiness-panel" class="section" data-testid="user-readiness-section" data-dashboard-panel hidden>
+                <div class="section-header">
+                    <div>
+                        <h2>사용자 readiness</h2>
+                        <p>active/alarm 상태, route 좌표 완성도, favorite_zone, marked_bus, language, last activity를 확인합니다.</p>
+                    </div>
+                    <span class="badge badge-muted">{{ pagination.total_users }} total users</span>
+                </div>
+                <div class="section-body">
+                    <div class="grid grid-3" style="margin-bottom: 16px;">
+                        <div class="metric">
+                            <span>Route ready</span>
+                            <strong>{{ stats.route_ready_users }}/{{ stats.total_users }}</strong>
+                            <div class="subtext">{{ stats.readiness_rate }}% route-ready</div>
+                        </div>
+                        <div class="metric">
+                            <span>Subscribed users</span>
+                            <strong>{{ stats.subscribed_users }}</strong>
+                            <div class="subtext">Alarm opt-in users</div>
+                        </div>
+                        <div class="metric">
+                            <span>Total users</span>
+                            <strong>{{ stats.total_users }}</strong>
+                            <div class="subtext">Current filtered page: {{ users|length }}</div>
+                        </div>
+                    </div>
+                    {% if users %}
+                    <div class="table-wrap">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>User Key / ID</th>
+                                    <th>Status</th>
+                                    <th>Route Info</th>
+                                    <th>Preferences</th>
+                                    <th>Activity</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            {% for user in users %}
+                                <tr>
+                                    <td>
+                                        <div class="mono">{{ user.display_identifier }}</div>
+                                        <div class="muted">ID: {{ user.id }}</div>
+                                    </td>
+                                    <td>
+                                        {% if user.active %}
+                                            <span class="badge badge-success">Active</span>
+                                        {% else %}
+                                            <span class="badge badge-muted">Inactive</span>
+                                        {% endif %}
+                                        {% if user.is_alarm_on %}
+                                            <span class="badge">Subscribed</span>
+                                        {% else %}
+                                            <span class="badge badge-danger">Unsubscribed</span>
+                                        {% endif %}
+                                        {% if user.route_ready %}
+                                            <span class="badge badge-success">{{ user.readiness_label }}</span>
+                                        {% else %}
+                                            <span class="badge badge-warning">{{ user.readiness_label }}</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if user.departure_name and user.arrival_name %}
+                                            <div><strong>From:</strong> {{ user.departure_name }}</div>
+                                            <div><strong>To:</strong> {{ user.arrival_name }}</div>
+                                        {% else %}
+                                            <span class="muted">Route not set</span>
+                                        {% endif %}
+                                        <div class="muted">route_updated_at: {{ user.route_updated_at_display or 'not recorded' }}</div>
+                                    </td>
+                                    <td>
+                                        <div>Bus: <strong>{{ user.marked_bus or 'not set' }}</strong></div>
+                                        <div>Zone: <strong>{{ user.favorite_zone or 'not set' }}</strong></div>
+                                        <div>Language: <strong>{{ user.language_display }}</strong></div>
+                                    </td>
+                                    <td>
+                                        <div>Msgs: <strong>{{ user.message_count }}</strong></div>
+                                        <div>Created: {{ user.created_at_display }}</div>
+                                        <div>Last: {{ user.last_message_at_display or 'not recorded' }}</div>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% else %}
+                    <div class="empty">No users found — readiness cannot be evaluated until users are registered.</div>
+                    {% endif %}
+
+                    {% if pagination.total_pages > 1 %}
+                    <div class="kv-row" style="margin-top: 16px;">
+                        <span>Showing page {{ pagination.page }} of {{ pagination.total_pages }}</span>
+                        <span>
+                            {% if pagination.has_previous %}<a class="link" href="?page={{ pagination.previous_page }}&page_size={{ pagination.page_size }}">Previous</a>{% endif %}
+                            {% if pagination.has_next %}<a class="link" href="?page={{ pagination.next_page }}&page_size={{ pagination.page_size }}">Next</a>{% endif %}
+                        </span>
+                    </div>
+                    {% endif %}
+                </div>
+            </section>
+
+            <section id="events-panel" class="section" data-testid="event-explorer-section" data-dashboard-panel hidden>
+                <div class="section-header">
+                    <div>
+                        <h2>이벤트/집회 탐색</h2>
+                        <p>source, 기간, 장소, 참석자, 관할서, severity/status, 원문 링크, 수집/갱신 이력을 탐색합니다.</p>
+                    </div>
+                    <span class="badge badge-muted">{{ events|length }} recent rows</span>
+                </div>
+                <div class="section-body">
+                    {% if events %}
+                    <div class="table-wrap">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Event Details</th>
+                                    <th>Period / Place</th>
+                                    <th>People / Police</th>
+                                    <th>Severity / Status</th>
+                                    <th>Source History</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            {% for event in events %}
+                                <tr>
+                                    <td>
+                                        <strong>{{ event.title }}</strong>
+                                        <div class="muted mono">#{{ event.id }}</div>
+                                    </td>
+                                    <td>
+                                        <div>{{ event.location_name }} • {{ event.start_date_display }}</div>
+                                        {% if event.end_date_display %}<div class="muted">Ends: {{ event.end_date_display }}</div>{% endif %}
+                                        {% if event.location_address %}<div class="muted">{{ event.location_address }}</div>{% endif %}
+                                    </td>
+                                    <td>
+                                        <div>Attendees: {{ event.attendees or '미상' }}</div>
+                                        <div>Police: {{ event.police_station or 'not recorded' }}</div>
+                                    </td>
+                                    <td>
+                                        {% if event.severity_level|int == 3 %}
+                                            <span class="badge badge-danger">High</span>
+                                        {% elif event.severity_level|int == 2 %}
+                                            <span class="badge badge-warning">Medium</span>
+                                        {% else %}
+                                            <span class="badge badge-success">Low</span>
+                                        {% endif %}
+                                        <span class="badge badge-muted">{{ event.status }}</span>
+                                    </td>
+                                    <td>
+                                        <div>Source: {{ event.source_label }}</div>
+                                        <div>Created: {{ event.created_at_display or 'not recorded' }}</div>
+                                        <div>Updated: {{ event.updated_at_display or 'not recorded' }}</div>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% else %}
+                    <div class="empty">No recent events found — event exploration has no source records yet.</div>
+                    {% endif %}
+                </div>
+            </section>
         </div>
-
-        <section class="section" data-testid="alarm-section">
-            <div class="section-header">
-                <div>
-                    <h2>알림 발송 운영</h2>
-                    <p>event_id, request_data, error_messages, completed_at, updated_at를 포함해 실패 진단을 노출합니다.</p>
-                </div>
-                <span class="badge {% if stats.failed_sends > 0 %}badge-danger{% else %}badge-success{% endif %}">{{ stats.failed_sends }} failed sends</span>
-            </div>
-            <div class="section-body">
-                {% if alarms %}
-                <div class="table-wrap">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Task / Time (KST)</th>
-                                <th>Status</th>
-                                <th>Delivery</th>
-                                <th>Diagnostics</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for alarm in alarms %}
-                            <tr>
-                                <td>
-                                    <div class="mono">{{ alarm.task_id_display }}</div>
-                                    <div class="muted">Created: {{ alarm.created_at_display or 'not recorded' }}</div>
-                                    <div class="muted">Updated: {{ alarm.updated_at_display or 'not recorded' }}</div>
-                                    <div class="muted">Completed: {{ alarm.completed_at_display or 'not recorded' }}</div>
-                                </td>
-                                <td>
-                                    {% if alarm.status == 'completed' %}
-                                        <span class="badge badge-success">Completed</span>
-                                    {% elif alarm.status == 'failed' %}
-                                        <span class="badge badge-danger">Failed</span>
-                                    {% elif alarm.status == 'partial' %}
-                                        <span class="badge badge-warning">Partial</span>
-                                    {% else %}
-                                        <span class="badge">{{ alarm.status }}</span>
-                                    {% endif %}
-                                    <div class="muted">Type: {{ alarm.alarm_type }}</div>
-                                    <div class="muted">event_id: {{ alarm.event_id or 'none' }}</div>
-                                </td>
-                                <td>
-                                    <strong>{{ alarm.successful_sends }}</strong> success /
-                                    <strong>{{ alarm.failed_sends }}</strong> failed of
-                                    <strong>{{ alarm.total_recipients }}</strong>
-                                </td>
-                                <td>
-                                    <div><strong>Request:</strong> {{ alarm.request_summary or 'not recorded' }}</div>
-                                    <div><strong>Errors:</strong> {{ alarm.error_summary or 'not recorded' }}</div>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                {% else %}
-                <div class="empty">No recent alarms found — notification diagnostics are empty.</div>
-                {% endif %}
-            </div>
-        </section>
-
-        <section class="section" data-testid="user-readiness-section">
-            <div class="section-header">
-                <div>
-                    <h2>사용자 readiness</h2>
-                    <p>active/alarm 상태, route 좌표 완성도, favorite_zone, marked_bus, language, last activity를 확인합니다.</p>
-                </div>
-                <span class="badge badge-muted">{{ pagination.total_users }} total users</span>
-            </div>
-            <div class="section-body">
-                {% if users %}
-                <div class="table-wrap">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>User Key / ID</th>
-                                <th>Status</th>
-                                <th>Route Info</th>
-                                <th>Preferences</th>
-                                <th>Activity</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for user in users %}
-                            <tr>
-                                <td>
-                                    <div class="mono">{{ user.display_identifier }}</div>
-                                    <div class="muted">ID: {{ user.id }}</div>
-                                </td>
-                                <td>
-                                    {% if user.active %}
-                                        <span class="badge badge-success">Active</span>
-                                    {% else %}
-                                        <span class="badge badge-muted">Inactive</span>
-                                    {% endif %}
-                                    {% if user.is_alarm_on %}
-                                        <span class="badge">Subscribed</span>
-                                    {% else %}
-                                        <span class="badge badge-danger">Unsubscribed</span>
-                                    {% endif %}
-                                    {% if user.route_ready %}
-                                        <span class="badge badge-success">{{ user.readiness_label }}</span>
-                                    {% else %}
-                                        <span class="badge badge-warning">{{ user.readiness_label }}</span>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if user.departure_name and user.arrival_name %}
-                                        <div><strong>From:</strong> {{ user.departure_name }}</div>
-                                        <div><strong>To:</strong> {{ user.arrival_name }}</div>
-                                    {% else %}
-                                        <span class="muted">Route not set</span>
-                                    {% endif %}
-                                    <div class="muted">route_updated_at: {{ user.route_updated_at_display or 'not recorded' }}</div>
-                                </td>
-                                <td>
-                                    <div>Bus: <strong>{{ user.marked_bus or 'not set' }}</strong></div>
-                                    <div>Zone: <strong>{{ user.favorite_zone or 'not set' }}</strong></div>
-                                    <div>Language: <strong>{{ user.language_display }}</strong></div>
-                                </td>
-                                <td>
-                                    <div>Msgs: <strong>{{ user.message_count }}</strong></div>
-                                    <div>Created: {{ user.created_at_display }}</div>
-                                    <div>Last: {{ user.last_message_at_display or 'not recorded' }}</div>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                {% else %}
-                <div class="empty">No users found — readiness cannot be evaluated until users are registered.</div>
-                {% endif %}
-
-                {% if pagination.total_pages > 1 %}
-                <div class="kv-row" style="margin-top: 16px;">
-                    <span>Showing page {{ pagination.page }} of {{ pagination.total_pages }}</span>
-                    <span>
-                        {% if pagination.has_previous %}<a class="link" href="?page={{ pagination.previous_page }}&page_size={{ pagination.page_size }}">Previous</a>{% endif %}
-                        {% if pagination.has_next %}<a class="link" href="?page={{ pagination.next_page }}&page_size={{ pagination.page_size }}">Next</a>{% endif %}
-                    </span>
-                </div>
-                {% endif %}
-            </div>
-        </section>
 
         <section class="section" data-testid="action-section">
             <div class="section-header">
@@ -532,69 +718,6 @@
             </div>
         </section>
 
-        <section class="section" data-testid="event-explorer-section">
-            <div class="section-header">
-                <div>
-                    <h2>이벤트/집회 탐색</h2>
-                    <p>source, 기간, 장소, 참석자, 관할서, severity/status, 원문 링크, 수집/갱신 이력을 탐색합니다.</p>
-                </div>
-                <span class="badge badge-muted">{{ events|length }} recent rows</span>
-            </div>
-            <div class="section-body">
-                {% if events %}
-                <div class="table-wrap">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Event Details</th>
-                                <th>Period / Place</th>
-                                <th>People / Police</th>
-                                <th>Severity / Status</th>
-                                <th>Source History</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for event in events %}
-                            <tr>
-                                <td>
-                                    <strong>{{ event.title }}</strong>
-                                    <div class="muted mono">#{{ event.id }}</div>
-                                </td>
-                                <td>
-                                    <div>{{ event.location_name }} • {{ event.start_date_display }}</div>
-                                    {% if event.end_date_display %}<div class="muted">Ends: {{ event.end_date_display }}</div>{% endif %}
-                                    {% if event.location_address %}<div class="muted">{{ event.location_address }}</div>{% endif %}
-                                </td>
-                                <td>
-                                    <div>Attendees: {{ event.attendees or '미상' }}</div>
-                                    <div>Police: {{ event.police_station or 'not recorded' }}</div>
-                                </td>
-                                <td>
-                                    {% if event.severity_level|int == 3 %}
-                                        <span class="badge badge-danger">High</span>
-                                    {% elif event.severity_level|int == 2 %}
-                                        <span class="badge badge-warning">Medium</span>
-                                    {% else %}
-                                        <span class="badge badge-success">Low</span>
-                                    {% endif %}
-                                    <span class="badge badge-muted">{{ event.status }}</span>
-                                </td>
-                                <td>
-                                    <div>Source: {{ event.source_label }}</div>
-                                    <div>Created: {{ event.created_at_display or 'not recorded' }}</div>
-                                    <div>Updated: {{ event.updated_at_display or 'not recorded' }}</div>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                {% else %}
-                <div class="empty">No recent events found — event exploration has no source records yet.</div>
-                {% endif %}
-            </div>
-        </section>
-
     </main>
 </div>
 
@@ -602,6 +725,57 @@
 
 <script>
     const ACTION_COOLDOWN_MS = 1000;
+
+    function getDashboardPanelButtons() {
+        return Array.from(document.querySelectorAll('[data-dashboard-panel-button]'));
+    }
+
+    function getDashboardPanels() {
+        return Array.from(document.querySelectorAll('[data-dashboard-panel]'));
+    }
+
+    function setDashboardPanelVisibility(panelId, updateHash) {
+        const selectedPanel = document.getElementById(panelId);
+        if (!selectedPanel) return;
+
+        getDashboardPanels().forEach((panel) => {
+            panel.hidden = panel.id !== panelId;
+        });
+        getDashboardPanelButtons().forEach((button) => {
+            const isSelected = button.getAttribute('aria-controls') === panelId;
+            button.setAttribute('aria-expanded', isSelected ? 'true' : 'false');
+            if (isSelected && updateHash) {
+                const panelHash = button.dataset.panelHash;
+                if (panelHash) history.replaceState(null, '', `#${panelHash}`);
+            }
+        });
+    }
+
+    function findDashboardPanelIdForHash(hashKey) {
+        const targetButton = getDashboardPanelButtons().find(
+            (button) => button.dataset.panelHash === hashKey
+        );
+        return targetButton ? targetButton.getAttribute('aria-controls') : null;
+    }
+
+    function restoreDashboardPanelFromHash() {
+        const hashKey = window.location.hash.replace('#', '');
+        const panelId = findDashboardPanelIdForHash(hashKey);
+        if (panelId) setDashboardPanelVisibility(panelId, false);
+    }
+
+    function initializeDashboardPanels() {
+        getDashboardPanelButtons().forEach((button) => {
+            button.addEventListener('click', () => {
+                const panelId = button.getAttribute('aria-controls');
+                if (panelId) setDashboardPanelVisibility(panelId, true);
+            });
+        });
+        restoreDashboardPanelFromHash();
+        window.addEventListener('hashchange', restoreDashboardPanelFromHash);
+    }
+
+    document.addEventListener('DOMContentLoaded', initializeDashboardPanels);
 
     async function triggerAction(endpoint, buttonElement) {
         if (buttonElement.disabled || buttonElement.dataset.cooldown === 'true') return;

--- a/app/templates/admin_dashboard.html
+++ b/app/templates/admin_dashboard.html
@@ -67,7 +67,7 @@
             box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
             overflow: hidden;
         }
-        [hidden] { display: none !important; }
+        [data-dashboard-panel][hidden] { display: none !important; }
         .section-header {
             display: flex;
             justify-content: space-between;
@@ -734,6 +734,18 @@
         return Array.from(document.querySelectorAll('[data-dashboard-panel]'));
     }
 
+    function clearDashboardPanelVisibility(updateHash) {
+        getDashboardPanels().forEach((panel) => {
+            panel.hidden = true;
+        });
+        getDashboardPanelButtons().forEach((button) => {
+            button.setAttribute('aria-expanded', 'false');
+        });
+        if (updateHash) {
+            history.replaceState(null, '', window.location.href.replace(/#.*$/, ''));
+        }
+    }
+
     function setDashboardPanelVisibility(panelId, updateHash) {
         const selectedPanel = document.getElementById(panelId);
         if (!selectedPanel) return;
@@ -761,14 +773,23 @@
     function restoreDashboardPanelFromHash() {
         const hashKey = window.location.hash.replace('#', '');
         const panelId = findDashboardPanelIdForHash(hashKey);
-        if (panelId) setDashboardPanelVisibility(panelId, false);
+        if (panelId) {
+            setDashboardPanelVisibility(panelId, false);
+            return;
+        }
+        clearDashboardPanelVisibility(false);
     }
 
     function initializeDashboardPanels() {
         getDashboardPanelButtons().forEach((button) => {
             button.addEventListener('click', () => {
                 const panelId = button.getAttribute('aria-controls');
-                if (panelId) setDashboardPanelVisibility(panelId, true);
+                if (!panelId) return;
+                if (button.getAttribute('aria-expanded') === 'true') {
+                    clearDashboardPanelVisibility(true);
+                    return;
+                }
+                setDashboardPanelVisibility(panelId, true);
             });
         });
         restoreDashboardPanelFromHash();

--- a/tests/test_admin_dashboard_playwright.py
+++ b/tests/test_admin_dashboard_playwright.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlsplit
+
 import pytest
 from playwright.sync_api import expect, sync_playwright
 
@@ -7,6 +9,7 @@ from app.config.settings import settings
 ADMIN_USER = "admin"
 ADMIN_PASS = f"{ADMIN_USER}-playwright-auth"
 ADMIN_AUTH = (ADMIN_USER, ADMIN_PASS)
+ADMIN_DASHBOARD_PATH = "/admin/dashboard"
 
 ADMIN_SECTION_TEST_IDS = [
     "overview-section",
@@ -43,7 +46,7 @@ def test_admin_dashboard_playwright_smoke_blocks_non_local_requests(test_client,
     monkeypatch.setattr(settings, "ADMIN_USER", ADMIN_USER)
     monkeypatch.setattr(settings, "ADMIN_PASS", ADMIN_PASS)
 
-    response = test_client.get("/admin/dashboard", auth=ADMIN_AUTH)
+    response = test_client.get(ADMIN_DASHBOARD_PATH, auth=ADMIN_AUTH)
     assert response.status_code == 200
 
     console_errors = []
@@ -55,7 +58,13 @@ def test_admin_dashboard_playwright_smoke_blocks_non_local_requests(test_client,
 
         def route_dashboard_and_block_non_local_requests(route):
             request_url = route.request.url
-            if request_url.startswith("http://testserver/admin/dashboard"):
+            parsed_url = urlsplit(request_url)
+            is_dashboard_request = (
+                parsed_url.scheme == "http"
+                and parsed_url.netloc == "testserver"
+                and parsed_url.path == ADMIN_DASHBOARD_PATH
+            )
+            if is_dashboard_request:
                 route.fulfill(status=200, content_type="text/html; charset=utf-8", body=response.text)
                 return
             if request_url.startswith(("http://testserver", "data:", "blob:", "about:")):
@@ -100,8 +109,12 @@ def test_admin_dashboard_playwright_smoke_blocks_non_local_requests(test_client,
                     "aria-expanded",
                     "false",
                 )
+            button.click()
+            expect(button).to_have_attribute("aria-expanded", "false")
+            for test_id in ADMIN_DETAIL_SECTION_TEST_IDS:
+                expect(page.get_by_test_id(test_id)).to_be_hidden()
 
-        page.goto("http://testserver/admin/dashboard#readiness", wait_until="domcontentloaded")
+        page.goto(f"http://testserver{ADMIN_DASHBOARD_PATH}#readiness", wait_until="domcontentloaded")
         expect(page.get_by_test_id("user-readiness-section")).to_be_visible()
         expect(page.get_by_test_id("dashboard-task-button-readiness")).to_have_attribute(
             "aria-expanded",
@@ -113,6 +126,16 @@ def test_admin_dashboard_playwright_smoke_blocks_non_local_requests(test_client,
             "alarm-section",
             "event-explorer-section",
         ):
+            expect(page.get_by_test_id(test_id)).to_be_hidden()
+        page.evaluate("window.location.hash = ''")
+        for test_id in ADMIN_DETAIL_SECTION_TEST_IDS:
+            expect(page.get_by_test_id(test_id)).to_be_hidden()
+        expect(page.get_by_test_id("dashboard-task-button-readiness")).to_have_attribute(
+            "aria-expanded",
+            "false",
+        )
+        page.evaluate("window.location.hash = '#not-a-dashboard-panel'")
+        for test_id in ADMIN_DETAIL_SECTION_TEST_IDS:
             expect(page.get_by_test_id(test_id)).to_be_hidden()
 
         browser.close()

--- a/tests/test_admin_dashboard_playwright.py
+++ b/tests/test_admin_dashboard_playwright.py
@@ -11,12 +11,22 @@ ADMIN_AUTH = (ADMIN_USER, ADMIN_PASS)
 ADMIN_SECTION_TEST_IDS = [
     "overview-section",
     "collection-section",
+    "bus-section",
     "alarm-section",
     "user-readiness-section",
     "action-section",
     "event-explorer-section",
-    "bus-section",
 ]
+
+ADMIN_DETAIL_BUTTONS = {
+    "collection": "collection-section",
+    "bus": "bus-section",
+    "alarms": "alarm-section",
+    "readiness": "user-readiness-section",
+    "events": "event-explorer-section",
+}
+
+ADMIN_DETAIL_SECTION_TEST_IDS = list(ADMIN_DETAIL_BUTTONS.values())
 
 ADMIN_ACTION_ENDPOINTS = [
     "/admin/trigger-crawling",
@@ -29,7 +39,7 @@ ADMIN_ACTION_ENDPOINTS = [
 
 @pytest.mark.usefixtures("clean_test_db")
 def test_admin_dashboard_playwright_smoke_blocks_non_local_requests(test_client, monkeypatch):
-    """Playwright smoke: 주요 섹션은 보이고 trigger 클릭 없이 endpoint wiring만 확인한다."""
+    """Playwright smoke: 기본 hidden 업무 패널, disclosure 전환, hash 복원을 검증한다."""
     monkeypatch.setattr(settings, "ADMIN_USER", ADMIN_USER)
     monkeypatch.setattr(settings, "ADMIN_PASS", ADMIN_PASS)
 
@@ -43,15 +53,18 @@ def test_admin_dashboard_playwright_smoke_blocks_non_local_requests(test_client,
         browser = playwright.chromium.launch(headless=True, args=["--no-sandbox"])
         page = browser.new_page(base_url="http://testserver")
 
-        def route_non_local_requests(route):
+        def route_dashboard_and_block_non_local_requests(route):
             request_url = route.request.url
+            if request_url.startswith("http://testserver/admin/dashboard"):
+                route.fulfill(status=200, content_type="text/html; charset=utf-8", body=response.text)
+                return
             if request_url.startswith(("http://testserver", "data:", "blob:", "about:")):
-                route.continue_()
+                route.abort()
                 return
             blocked_non_local_requests.append(request_url)
             route.abort()
 
-        page.route("**/*", route_non_local_requests)
+        page.route("**/*", route_dashboard_and_block_non_local_requests)
         page.on(
             "console",
             lambda message: console_errors.append(message.text) if message.type == "error" else None,
@@ -61,11 +74,46 @@ def test_admin_dashboard_playwright_smoke_blocks_non_local_requests(test_client,
 
         expect(page.get_by_role("heading", name="KT Demo Alarm Back-office")).to_be_visible()
         expect(page.locator("section.section")).to_have_count(len(ADMIN_SECTION_TEST_IDS))
-        for test_id in ADMIN_SECTION_TEST_IDS:
-            expect(page.get_by_test_id(test_id)).to_be_visible()
+        expect(page.get_by_test_id("overview-section")).to_be_visible()
+        expect(page.get_by_test_id("action-section")).to_be_visible()
+        for test_id in ADMIN_DETAIL_SECTION_TEST_IDS:
+            expect(page.get_by_test_id(test_id)).to_be_hidden()
         expect(page.get_by_text("Scheduler 상태")).to_be_visible()
         for endpoint in ADMIN_ACTION_ENDPOINTS:
             expect(page.get_by_text(endpoint, exact=True)).to_be_visible()
+
+        for button_key, selected_test_id in ADMIN_DETAIL_BUTTONS.items():
+            button = page.get_by_test_id(f"dashboard-task-button-{button_key}")
+            controls = button.get_attribute("aria-controls")
+            assert controls
+            expect(button).to_have_attribute("aria-expanded", "false")
+            expect(page.locator(f"#{controls}")).to_have_attribute("data-testid", selected_test_id)
+
+            button.click()
+            expect(button).to_have_attribute("aria-expanded", "true")
+            expect(page.locator(f"#{controls}")).to_be_visible()
+            for other_key, other_test_id in ADMIN_DETAIL_BUTTONS.items():
+                if other_key == button_key:
+                    continue
+                expect(page.get_by_test_id(other_test_id)).to_be_hidden()
+                expect(page.get_by_test_id(f"dashboard-task-button-{other_key}")).to_have_attribute(
+                    "aria-expanded",
+                    "false",
+                )
+
+        page.goto("http://testserver/admin/dashboard#readiness", wait_until="domcontentloaded")
+        expect(page.get_by_test_id("user-readiness-section")).to_be_visible()
+        expect(page.get_by_test_id("dashboard-task-button-readiness")).to_have_attribute(
+            "aria-expanded",
+            "true",
+        )
+        for test_id in (
+            "collection-section",
+            "bus-section",
+            "alarm-section",
+            "event-explorer-section",
+        ):
+            expect(page.get_by_test_id(test_id)).to_be_hidden()
 
         browser.close()
 

--- a/tests/test_admin_dashboard_playwright.py
+++ b/tests/test_admin_dashboard_playwright.py
@@ -4,6 +4,7 @@ import pytest
 from playwright.sync_api import expect, sync_playwright
 
 from app.config.settings import settings
+from app.database.connection import get_db_connection
 
 
 ADMIN_USER = "admin"
@@ -46,7 +47,33 @@ def test_admin_dashboard_playwright_smoke_blocks_non_local_requests(test_client,
     monkeypatch.setattr(settings, "ADMIN_USER", ADMIN_USER)
     monkeypatch.setattr(settings, "ADMIN_PASS", ADMIN_PASS)
 
-    response = test_client.get(ADMIN_DASHBOARD_PATH, auth=ADMIN_AUTH)
+    with get_db_connection() as db:
+        db.executemany(
+            """
+            INSERT INTO users (
+                bot_user_key, first_message_at, last_message_at, message_count, active
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "playwright-pagination-1",
+                    "2026-05-20T00:00:00+00:00",
+                    "2026-05-20T00:00:00+00:00",
+                    1,
+                    1,
+                ),
+                (
+                    "playwright-pagination-2",
+                    "2026-05-20T00:01:00+00:00",
+                    "2026-05-20T00:01:00+00:00",
+                    1,
+                    1,
+                ),
+            ],
+        )
+        db.commit()
+
+    response = test_client.get(f"{ADMIN_DASHBOARD_PATH}?page=1&page_size=1", auth=ADMIN_AUTH)
     assert response.status_code == 200
 
     console_errors = []
@@ -115,6 +142,15 @@ def test_admin_dashboard_playwright_smoke_blocks_non_local_requests(test_client,
                 expect(page.get_by_test_id(test_id)).to_be_hidden()
 
         page.goto(f"http://testserver{ADMIN_DASHBOARD_PATH}#readiness", wait_until="domcontentloaded")
+        expect(page.get_by_test_id("user-readiness-section")).to_be_visible()
+        expect(page.get_by_test_id("dashboard-task-button-readiness")).to_have_attribute(
+            "aria-expanded",
+            "true",
+        )
+        page.get_by_role("link", name="Next").click()
+        expect(page).to_have_url(
+            f"http://testserver{ADMIN_DASHBOARD_PATH}?page=2&page_size=1#readiness"
+        )
         expect(page.get_by_test_id("user-readiness-section")).to_be_visible()
         expect(page.get_by_test_id("dashboard-task-button-readiness")).to_have_attribute(
             "aria-expanded",

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
 
 import pytest
+from bs4 import BeautifulSoup
 
 from app.config.settings import settings
 from app.database.connection import get_db_connection
@@ -17,12 +18,21 @@ from app.services.bus_notice_service import BusNoticeService
 
 ADMIN_SECTION_HEADINGS = [
     "Overview",
+    "업무 상세 보기",
     "데이터 수집 상태",
     "알림 발송 운영",
     "사용자 readiness",
     "수동 운영 액션",
     "이벤트/집회 탐색",
     "버스 공지 운영",
+]
+
+ADMIN_DETAIL_SECTION_TEST_IDS = [
+    "collection-section",
+    "bus-section",
+    "alarm-section",
+    "user-readiness-section",
+    "event-explorer-section",
 ]
 
 ADMIN_ACTION_ENDPOINTS = [
@@ -50,6 +60,12 @@ def _restore_bus_notice_state(crawler, cached_notices, last_update) -> None:
     BusNoticeService.crawler = crawler
     BusNoticeService.cached_notices = cached_notices
     BusNoticeService.last_update = last_update
+
+
+def _section_text(soup: BeautifulSoup, test_id: str) -> str:
+    section = soup.find(attrs={"data-testid": test_id})
+    assert section is not None
+    return section.get_text(" ", strip=True)
 
 
 def test_admin_dashboard_no_credentials(test_client, monkeypatch):
@@ -83,7 +99,7 @@ def test_admin_dashboard_valid_credentials(test_client, monkeypatch):
 
 @pytest.mark.usefixtures("clean_test_db")
 def test_admin_dashboard_redesign_sections_and_operational_signals(test_client, monkeypatch):
-    """대시보드는 7개 운영 섹션과 실제 sqlite 기반 운영 신호를 표시해야 함"""
+    """대시보드는 Overview 위험 신호와 기본 hidden 업무 패널을 실제 sqlite 경로로 표시해야 함"""
     monkeypatch.setattr(settings, "ADMIN_USER", ADMIN_USER)
     monkeypatch.setattr(settings, "ADMIN_PASS", ADMIN_PASS)
     monkeypatch.setattr(BusNoticeService, "crawler", object())
@@ -189,6 +205,7 @@ def test_admin_dashboard_redesign_sections_and_operational_signals(test_client, 
 
     response = test_client.get("/admin/dashboard", auth=ADMIN_AUTH)
     rendered = unescape(response.text)
+    soup = BeautifulSoup(response.text, "html.parser")
 
     assert response.status_code == 200
     for heading in ADMIN_SECTION_HEADINGS:
@@ -212,6 +229,38 @@ def test_admin_dashboard_redesign_sections_and_operational_signals(test_client, 
     assert "Crawler initialized" in rendered
     assert "cached_count" in rendered
     assert "2026-05-16 12:00:00 KST" in rendered
+
+    overview_text = _section_text(soup, "overview-section")
+    readiness_text = _section_text(soup, "user-readiness-section")
+    assert "Latest collected: 2026-05-16 10:00:00 KST" in overview_text
+    assert "Latest event update: 2026-05-16 10:10:00 KST" in overview_text
+    assert "Success rate: 60.0%" in overview_text
+    assert "Failures: 2" in overview_text
+    assert "Crawler initialized" in overview_text
+    assert "cached_count: 1" in overview_text
+    assert "User Readiness" not in overview_text
+    assert "Route ready" not in overview_text
+    assert "bot-ready-user" not in overview_text
+    assert "Route ready" in readiness_text
+    assert "Bus: 470" in readiness_text
+    assert "Language: ko" in readiness_text
+
+    for test_id in ("overview-section", "action-section"):
+        section = soup.find(attrs={"data-testid": test_id})
+        assert section is not None
+        assert not section.has_attr("hidden")
+    for test_id in ADMIN_DETAIL_SECTION_TEST_IDS:
+        section = soup.find(attrs={"data-testid": test_id})
+        assert section is not None
+        assert section.has_attr("hidden")
+
+    task_buttons = soup.find_all("button", attrs={"data-dashboard-panel-button": True})
+    assert len(task_buttons) == len(ADMIN_DETAIL_SECTION_TEST_IDS)
+    for button in task_buttons:
+        controls = button.get("aria-controls")
+        assert controls
+        assert button.get("aria-expanded") == "false"
+        assert soup.find(id=controls) is not None
 
 
 @pytest.mark.usefixtures("clean_test_db")


### PR DESCRIPTION
## Summary

- Rework `/admin/dashboard` into a compact Overview plus disclosure-style task navigation.
- Keep five long operational detail panels hidden by default and open one panel at a time via buttons.
- Move user readiness summary out of Overview and keep readiness details in the readiness panel.
- Preserve visible manual action controls and existing admin auth/POST guard boundaries.

Closes #124

## Verification

- `uv run pytest tests/test_api_admin.py tests/test_admin_dashboard_playwright.py -q` → 33 passed, 7 warnings
- `uv run pytest -q` → 163 passed, 2 skipped, 22 warnings

## Notes

- Hidden panels reduce default scroll density only; they are not a security or payload reduction boundary.
- No new dependencies were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin dashboard now has hidden-by-default, individually addressable panels (collection, bus, alarms, readiness, events) with task navigation and responsive styling
  * Overview refreshed with a "Collection Recency" metric and expanded cache/notification details
  * Panel selection persists via URL hash and restores on load

* **Tests**
  * Updated UI tests to assert panel visibility, button ARIA wiring, and hash-based navigation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoonly01/kt-demo-alarm/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->