### PR TITLE
Normalize DB timestamp storage boundaries

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,13 +1,12 @@
 """사용자 관련 Pydantic 모델들"""
-from typing import Optional, List
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class User(BaseModel):
     """카카오톡 사용자 모델"""
     id: str  # botUserKey. 카카오 문서에서는 plusfriendUserKey 또는 botUserKey 라고 함
     type: str
-    properties: dict = {}
+    properties: dict[str, object] = Field(default_factory=dict)
 
 
 class UserRequest(BaseModel):
@@ -18,16 +17,18 @@ class UserRequest(BaseModel):
 
 class UserPreferences(BaseModel):
     """사용자 설정 모델"""
-    location: Optional[str] = None
-    categories: Optional[List[str]] = None
-    preferences: Optional[dict] = None
+    location: str | None = None
+    categories: list[str] | None = None
+    preferences: dict[str, object] | None = None
+    marked_bus: str | None = None
+    language: str | None = None
 
 
 class InitialSetupRequest(BaseModel):
     """초기 설정 요청 모델"""
     bot_user_key: str  # 사용자 식별 키 (필수)
-    departure: Optional[str] = None
-    arrival: Optional[str] = None
-    marked_bus: Optional[str] = None
-    language: Optional[str] = None
-    userRequest: Optional[UserRequest] = None  # 카카오톡 요청 시에만 사용
+    departure: str | None = None
+    arrival: str | None = None
+    marked_bus: str | None = None
+    language: str | None = None
+    userRequest: UserRequest | None = None  # 카카오톡 요청 시에만 사용

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -4,9 +4,8 @@ import asyncio
 import logging
 import json
 from collections.abc import Callable, Coroutine
-from datetime import datetime, timezone, tzinfo
+from datetime import timezone, tzinfo
 from typing import Dict, Any, List, Set
-from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, HTTPException, status, Request, Query
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
@@ -21,6 +20,7 @@ from app.services.event_service import EventService
 from app.services.bus_notice_service import BusNoticeService
 from app.services.crawling import crawl_and_sync_smpa_events
 from app.services.zone_alarm_service import ZoneAlarmService
+from app.utils.time_utils import KST, parse_datetime_value
 
 from urllib.parse import urlparse
 
@@ -39,8 +39,6 @@ templates = Jinja2Templates(directory=os.path.join(os.path.dirname(os.path.dirna
 _background_tasks: dict[str, asyncio.Task[Any]] = {}
 _task_lock = asyncio.Lock()
 
-KST_ZONE_NAME = "Asia/Seoul"
-KST = ZoneInfo(KST_ZONE_NAME)
 DASHBOARD_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S KST"
 DASHBOARD_DATE_FORMAT = "%Y-%m-%d KST"
 DASHBOARD_RECENT_LIMIT = 100
@@ -611,51 +609,13 @@ def get_bus_notice_snapshot() -> Dict[str, Any]:
         ),
     }
 
-def _parse_datetime_value(value: Any) -> datetime | None:
-    if value in (None, ""):
-        return None
-
-    if isinstance(value, datetime):
-        return value
-
-    if isinstance(value, (int, float)):
-        return _datetime_from_epoch(value)
-
-    text = str(value).strip()
-    if not text:
-        return None
-
-    if text.isdigit() and len(text) >= 10:
-        parsed_epoch = _datetime_from_epoch(int(text))
-        if parsed_epoch is not None:
-            return parsed_epoch
-
-    for parser in (datetime.fromisoformat,):
-        try:
-            return parser(text.replace("Z", "+00:00"))
-        except ValueError:
-            pass
-
-    return None
-
-
-def _datetime_from_epoch(value: int | float) -> datetime | None:
-    timestamp = float(value)
-    if timestamp > 1_000_000_000_000:
-        timestamp /= 1000.0
-    try:
-        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
-    except (OverflowError, OSError, ValueError):
-        return None
-
-
 def _format_datetime_as_kst(
     value: Any,
     *,
     naive_source_tz: tzinfo,
     output_format: str = DASHBOARD_DATETIME_FORMAT,
 ) -> str:
-    parsed = _parse_datetime_value(value)
+    parsed = parse_datetime_value(value)
     if parsed is None:
         return "" if value in (None, "") else str(value)
 
@@ -674,7 +634,7 @@ def _format_kst_local_datetime(value: Any) -> str:
 
 
 def _format_user_created_at(value: Any) -> str:
-    parsed = _parse_datetime_value(value)
+    parsed = parse_datetime_value(value)
     if parsed is not None:
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=KST)

--- a/app/routers/kakao.py
+++ b/app/routers/kakao.py
@@ -2,9 +2,9 @@
 from fastapi import APIRouter, Request, HTTPException
 import logging
 import json
-from datetime import datetime
 
 from app.models.kakao import KakaoRequest
+from app.utils.time_utils import utc_now_for_db
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/kakao", tags=["kakao"])
@@ -25,11 +25,12 @@ async def kakao_chat_fallback(request: KakaoRequest):
 
     from app.database.connection import get_db_connection
 
-    with get_db_connection() as db:
-        cursor = db.cursor()
+    if plusfriend_key:
+        with get_db_connection() as db:
+            cursor = db.cursor()
+            now = utc_now_for_db()
 
-        # plusfriend_user_key로 기존 사용자 조회 (가장 안정적)
-        if plusfriend_key:
+            # plusfriend_user_key로 기존 사용자 조회 (가장 안정적)
             cursor.execute(
                 "SELECT bot_user_key, open_id FROM users WHERE plusfriend_user_key = ?",
                 (plusfriend_key,)
@@ -40,7 +41,7 @@ async def kakao_chat_fallback(request: KakaoRequest):
                 # 이미 존재 → bot_user_key 업데이트
                 cursor.execute(
                     "UPDATE users SET bot_user_key = ?, last_message_at = ?, message_count = message_count + 1 WHERE plusfriend_user_key = ?",
-                    (bot_user_key, datetime.now(), plusfriend_key)
+                    (bot_user_key, now, plusfriend_key)
                 )
                 db.commit()
                 logger.info(f"사용자 업데이트: plusfriend={plusfriend_key}")
@@ -55,7 +56,7 @@ async def kakao_chat_fallback(request: KakaoRequest):
                     # 웹훅 사용자 연결
                     cursor.execute(
                         "UPDATE users SET bot_user_key = ?, plusfriend_user_key = ?, last_message_at = ? WHERE id = ?",
-                        (bot_user_key, plusfriend_key, datetime.now(), orphan["id"])
+                        (bot_user_key, plusfriend_key, now, orphan["id"])
                     )
                     db.commit()
                     logger.info(f"✅ 웹훅 사용자 연결: botUserKey={bot_user_key}, plusfriend={plusfriend_key}")
@@ -64,7 +65,7 @@ async def kakao_chat_fallback(request: KakaoRequest):
                     cursor.execute('''
                         INSERT INTO users (bot_user_key, plusfriend_user_key, first_message_at, last_message_at, message_count, active)
                         VALUES (?, ?, ?, ?, 1, 1)
-                    ''', (bot_user_key, plusfriend_key, datetime.now(), datetime.now()))
+                    ''', (bot_user_key, plusfriend_key, now, now))
                     db.commit()
                     logger.info(f"새 사용자 등록: botUserKey={bot_user_key}, plusfriend={plusfriend_key}")
 
@@ -117,6 +118,7 @@ async def kakao_channel_webhook(request: Request):
     try:
         with get_db_connection() as db:
             cursor = db.cursor()
+            now = utc_now_for_db()
 
             # open_id로 기존 사용자 조회 (plusfriend_user_key도 확인)
             cursor.execute(
@@ -142,7 +144,7 @@ async def kakao_channel_webhook(request: Request):
                     cursor.execute('''
                         INSERT INTO users (open_id, first_message_at, last_message_at, message_count, active)
                         VALUES (?, ?, ?, 1, 1)
-                    ''', (open_id, datetime.now(), datetime.now()))
+                    ''', (open_id, now, now))
                     db.commit()
                     logger.info(f"신규 사용자 생성 (open_id만): {open_id}")
 

--- a/app/services/alarm_status_service.py
+++ b/app/services/alarm_status_service.py
@@ -6,7 +6,13 @@ from typing import Dict, Any, Optional, List
 import logging
 
 from app.database.connection import get_db_connection
-from app.utils.time_utils import format_utc_datetime_for_db, utc_now, utc_now_for_db
+from app.utils.time_utils import (
+    KST,
+    format_utc_datetime_for_db,
+    parse_db_timestamp,
+    utc_now,
+    utc_now_for_db,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -246,6 +252,9 @@ class AlarmStatusService:
     def cleanup_old_tasks(days: int = 30) -> int:
         """
         오래된 알림 작업 정리
+
+        신규 UTC-aware 저장값과 기존 naive KST 저장값을 모두 실제 시점 기준으로
+        비교한다. 기존 row는 backfill하지 않고 cleanup 경계에서만 해석한다.
         
         Args:
             days: 보관 일수
@@ -255,19 +264,25 @@ class AlarmStatusService:
         """
         try:
             # Python에서 날짜 계산
-            cutoff_date = format_utc_datetime_for_db(utc_now() - timedelta(days=days))
+            cutoff_datetime = (utc_now() - timedelta(days=days)).replace(microsecond=0)
+            cutoff_date = format_utc_datetime_for_db(cutoff_datetime)
             
             with get_db_connection() as db:
                 cursor = db.cursor()
-                cursor.execute(
-                    """
-                    DELETE FROM alarm_tasks 
-                    WHERE datetime(created_at) < datetime(?)
-                    """,
-                    (cutoff_date,)
-                )
+                cursor.execute("SELECT task_id, created_at FROM alarm_tasks")
+                expired_task_ids = []
+                for row in cursor.fetchall():
+                    created_at = parse_db_timestamp(row["created_at"], naive_source_tz=KST)
+                    if created_at is not None and created_at < cutoff_datetime:
+                        expired_task_ids.append(row["task_id"])
+
+                if expired_task_ids:
+                    cursor.executemany(
+                        "DELETE FROM alarm_tasks WHERE task_id = ?",
+                        [(task_id,) for task_id in expired_task_ids],
+                    )
                 db.commit()
-                deleted_count = cursor.rowcount
+                deleted_count = len(expired_task_ids)
                 
                 logger.info(f"오래된 알림 작업 {deleted_count}개 정리 완료 ({days}일 이전, {cutoff_date} 기준)")
                 return deleted_count

--- a/app/services/alarm_status_service.py
+++ b/app/services/alarm_status_service.py
@@ -1,12 +1,12 @@
 """알림 상태 추적 서비스"""
 import json
-import sqlite3
 import uuid
-from datetime import datetime
+from datetime import timedelta
 from typing import Dict, Any, Optional, List
 import logging
 
 from app.database.connection import get_db_connection
+from app.utils.time_utils import format_utc_datetime_for_db, utc_now, utc_now_for_db
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +34,7 @@ class AlarmStatusService:
             str: 생성된 task_id
         """
         task_id = str(uuid.uuid4())
+        created_at = utc_now_for_db()
         
         with get_db_connection() as db:
             cursor = db.cursor()
@@ -50,7 +51,7 @@ class AlarmStatusService:
                     total_recipients,
                     event_id,
                     json.dumps(request_data) if request_data else None,
-                    datetime.now().isoformat()
+                    created_at
                 )
             )
             db.commit()
@@ -83,10 +84,11 @@ class AlarmStatusService:
         try:
             with get_db_connection() as db:
                 cursor = db.cursor()
+                updated_at = utc_now_for_db()
                 
                 # 기본 업데이트 쿼리 구성
                 update_fields = ["status = ?", "updated_at = ?"]
-                update_values = [status, datetime.now().isoformat()]
+                update_values: list[str | int] = [status, updated_at]
                 
                 # 선택적 필드 추가
                 if successful_sends is not None:
@@ -108,7 +110,7 @@ class AlarmStatusService:
                 # 완료 상태인 경우 완료 시간 추가
                 if status in ["completed", "failed", "partial"]:
                     update_fields.append("completed_at = ?")
-                    update_values.append(datetime.now().isoformat())
+                    update_values.append(updated_at)
                 
                 # 쿼리 실행
                 query = f"UPDATE alarm_tasks SET {', '.join(update_fields)} WHERE task_id = ?"
@@ -212,7 +214,7 @@ class AlarmStatusService:
                         successful_sends, failed_sends, event_id,
                         created_at, updated_at, completed_at
                     FROM alarm_tasks 
-                    ORDER BY created_at DESC
+                    ORDER BY created_at DESC, rowid DESC
                     LIMIT ?
                     """,
                     (limit,)
@@ -252,17 +254,15 @@ class AlarmStatusService:
             int: 삭제된 작업 수
         """
         try:
-            from datetime import timedelta
-            
             # Python에서 날짜 계산
-            cutoff_date = (datetime.now() - timedelta(days=days)).isoformat()
+            cutoff_date = format_utc_datetime_for_db(utc_now() - timedelta(days=days))
             
             with get_db_connection() as db:
                 cursor = db.cursor()
                 cursor.execute(
                     """
                     DELETE FROM alarm_tasks 
-                    WHERE created_at < ?
+                    WHERE datetime(created_at) < datetime(?)
                     """,
                     (cutoff_date,)
                 )

--- a/app/services/crawling/smpa_event_sync.py
+++ b/app/services/crawling/smpa_event_sync.py
@@ -6,11 +6,17 @@ import hashlib
 import re
 import sqlite3
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 from app.services.crawling.smpa_coordinates import SelectedCoordinate
 from app.services.crawling.smpa_parser import ParsedSmpaEvent, SMPA_SOURCE_NAME
+from app.utils.time_utils import (
+    format_kst_wall_clock_for_db,
+    format_utc_datetime_for_db,
+    utc_now,
+    utc_now_for_db,
+)
 
 LOW_SEVERITY_MAX_ATTENDEES = 99
 MEDIUM_SEVERITY_MAX_ATTENDEES = 499
@@ -144,21 +150,22 @@ def prepare_event_candidate(
         source_url=event.source_url,
         source_record_hash=source_record_hash,
         source_payload_hash=source_payload_hash,
-        collected_at=collected_at or datetime.now(timezone.utc),
+        collected_at=collected_at or utc_now(),
         parser_version=event.parser_version,
     )
 
 
 def _insert_candidate(cursor: sqlite3.Cursor, candidate: EventCandidate) -> None:
+    write_timestamp = utc_now_for_db()
     cursor.execute(
         """
         INSERT INTO events (
             title, description, attendees, police_station, location_name, location_address,
             latitude, longitude, start_date, end_date, category, severity_level, status,
             source, source_id, source_url, source_record_hash, source_payload_hash,
-            collected_at, parser_version
+            collected_at, parser_version, created_at, updated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             candidate.title,
@@ -169,8 +176,8 @@ def _insert_candidate(cursor: sqlite3.Cursor, candidate: EventCandidate) -> None
             candidate.location_address,
             candidate.latitude,
             candidate.longitude,
-            candidate.start_date,
-            candidate.end_date,
+            format_kst_wall_clock_for_db(candidate.start_date),
+            format_kst_wall_clock_for_db(candidate.end_date),
             candidate.category,
             candidate.severity_level,
             candidate.source,
@@ -178,8 +185,10 @@ def _insert_candidate(cursor: sqlite3.Cursor, candidate: EventCandidate) -> None
             candidate.source_url,
             candidate.source_record_hash,
             candidate.source_payload_hash,
-            candidate.collected_at,
+            format_utc_datetime_for_db(candidate.collected_at),
             candidate.parser_version,
+            write_timestamp,
+            write_timestamp,
         ),
     )
 
@@ -206,7 +215,7 @@ def _update_candidate(cursor: sqlite3.Cursor, candidate: EventCandidate, event_i
                source_payload_hash = ?,
                collected_at = ?,
                parser_version = ?,
-               updated_at = CURRENT_TIMESTAMP
+               updated_at = ?
          WHERE id = ?
         """,
         (
@@ -218,16 +227,17 @@ def _update_candidate(cursor: sqlite3.Cursor, candidate: EventCandidate, event_i
             candidate.location_address,
             candidate.latitude,
             candidate.longitude,
-            candidate.start_date,
-            candidate.end_date,
+            format_kst_wall_clock_for_db(candidate.start_date),
+            format_kst_wall_clock_for_db(candidate.end_date),
             candidate.category,
             candidate.severity_level,
             candidate.source,
             candidate.source_id,
             candidate.source_url,
             candidate.source_payload_hash,
-            candidate.collected_at,
+            format_utc_datetime_for_db(candidate.collected_at),
             candidate.parser_version,
+            utc_now_for_db(),
             event_id,
         ),
     )

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,10 +1,10 @@
 """사용자 관리 서비스"""
 import logging
 import sqlite3
-from datetime import datetime
 from typing import Optional, Dict, Any
 from app.models.user import UserPreferences, InitialSetupRequest
 from app.utils.geo_utils import get_location_info
+from app.utils.time_utils import utc_now_for_db
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class UserService:
         """
         try:
             cursor = db.cursor()
-            now = datetime.now()
+            now = utc_now_for_db()
             
             # 기존 사용자 확인
             cursor.execute('SELECT * FROM users WHERE bot_user_key = ?', (bot_user_key,))
@@ -74,7 +74,7 @@ class UserService:
         """
         try:
             cursor = db.cursor()
-            now = datetime.now()
+            now = utc_now_for_db()
             
             if not plusfriend_key:
                 # plusfriend_key가 없는 경우 기존 레거시 로직(bot_user_key 기준) 사용
@@ -304,7 +304,7 @@ class UserService:
                 departure_info["x"], departure_info["y"],
                 arrival_info["name"], arrival_info["address"],
                 arrival_info["x"], arrival_info["y"],
-                datetime.now(),
+                utc_now_for_db(),
                 user_id
             ))
 
@@ -348,11 +348,12 @@ class UserService:
                 WHERE {} = ?
             '''
             # 1. plusfriend_user_key로 우선 업데이트 시도
-            cursor.execute(clear_sql.format("plusfriend_user_key"), (datetime.now(), user_id))
+            now = utc_now_for_db()
+            cursor.execute(clear_sql.format("plusfriend_user_key"), (now, user_id))
 
             # 2. 업데이트된 레코드가 없으면 bot_user_key로 폴백 시도
             if cursor.rowcount == 0:
-                cursor.execute(clear_sql.format("bot_user_key"), (datetime.now(), user_id))
+                cursor.execute(clear_sql.format("bot_user_key"), (now, user_id))
 
             if cursor.rowcount == 0:
                 logger.warning(f"경로 삭제 대상 사용자를 찾을 수 없음: {user_id}")
@@ -375,6 +376,7 @@ class UserService:
         """
         try:
             cursor = db.cursor()
+            now = utc_now_for_db()
 
             # 1. plusfriend_user_key 기준 업데이트
             cursor.execute('''
@@ -384,7 +386,7 @@ class UserService:
                 WHERE plusfriend_user_key = ?
             ''', (
                 marked_bus,
-                datetime.now(),
+                now,
                 user_id
             ))
 
@@ -397,7 +399,7 @@ class UserService:
                     WHERE bot_user_key = ?
                 ''', (
                     marked_bus,
-                    datetime.now(),
+                    now,
                     user_id
                 ))
 
@@ -447,7 +449,7 @@ class UserService:
             # 단순화를 위해 모두 업데이트 (None이면 NULL 처리될 수 있음에 유의)
             
             update_query = "UPDATE users SET route_updated_at = ?"
-            params = [datetime.now()]
+            params = [utc_now_for_db()]
             
             if dep_info:
                 update_query += ", departure_name=?, departure_address=?, departure_x=?, departure_y=?"
@@ -514,8 +516,8 @@ class UserService:
                 return {"success": False, "error": "사용자를 찾을 수 없습니다"}
             
             # 설정 업데이트
-            update_fields = []
-            update_values = []
+            update_fields: list[str] = []
+            update_values: list[str] = []
             
             if preferences.marked_bus:
                 update_fields.append("marked_bus = ?")

--- a/app/utils/time_utils.py
+++ b/app/utils/time_utils.py
@@ -1,0 +1,97 @@
+"""DB timestamp 저장 계약을 한 곳에서 다루는 유틸리티."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone, tzinfo
+from zoneinfo import ZoneInfo
+
+UTC = timezone.utc
+KST_ZONE_NAME = "Asia/Seoul"
+KST = ZoneInfo(KST_ZONE_NAME)
+DB_TIMESTAMP_TIMESPEC = "seconds"
+EPOCH_MILLISECONDS_THRESHOLD = 1_000_000_000_000
+
+
+def utc_now() -> datetime:
+    """현재 시각을 timezone-aware UTC datetime으로 반환한다."""
+    return datetime.now(UTC)
+
+
+def _is_aware(value: datetime) -> bool:
+    return value.tzinfo is not None and value.utcoffset() is not None
+
+
+def format_utc_datetime_for_db(value: datetime) -> str:
+    """시점 timestamp를 UTC offset 포함 ISO-8601 문자열로 직렬화한다."""
+    if not _is_aware(value):
+        raise ValueError("UTC DB timestamp requires a timezone-aware datetime")
+
+    return (
+        value.astimezone(UTC)
+        .replace(microsecond=0)
+        .isoformat(timespec=DB_TIMESTAMP_TIMESPEC)
+    )
+
+
+def utc_now_for_db() -> str:
+    """신규 DB write path에 사용할 UTC-aware 저장 문자열을 반환한다."""
+    return format_utc_datetime_for_db(utc_now())
+
+
+def format_kst_wall_clock_for_db(value: datetime) -> str:
+    """SMPA 서울 현지 일정 wall-clock 값을 시간 이동 없이 저장 문자열로 만든다."""
+    if _is_aware(value):
+        value = value.astimezone(KST).replace(tzinfo=None)
+
+    return value.replace(microsecond=0).isoformat(
+        sep=" ",
+        timespec=DB_TIMESTAMP_TIMESPEC,
+    )
+
+
+def parse_datetime_value(value: object) -> datetime | None:
+    """DB/API에서 온 timestamp 값을 datetime으로 파싱한다."""
+    if value in (None, ""):
+        return None
+
+    if isinstance(value, datetime):
+        return value
+
+    if isinstance(value, (int, float)):
+        return _datetime_from_epoch(value)
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    if text.isdigit() and len(text) >= 10:
+        parsed_epoch = _datetime_from_epoch(int(text))
+        if parsed_epoch is not None:
+            return parsed_epoch
+
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def parse_db_timestamp(value: object, *, naive_source_tz: tzinfo) -> datetime | None:
+    """legacy naive timestamp에 명시 source timezone 정책을 적용해 파싱한다."""
+    parsed = parse_datetime_value(value)
+    if parsed is None:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=naive_source_tz)
+
+    return parsed
+
+
+def _datetime_from_epoch(value: int | float) -> datetime | None:
+    timestamp = float(value)
+    if timestamp > EPOCH_MILLISECONDS_THRESHOLD:
+        timestamp /= 1000.0
+    try:
+        return datetime.fromtimestamp(timestamp, tz=UTC)
+    except (OverflowError, OSError, ValueError):
+        return None

--- a/app/utils/time_utils.py
+++ b/app/utils/time_utils.py
@@ -89,7 +89,7 @@ def parse_db_timestamp(value: object, *, naive_source_tz: tzinfo) -> datetime | 
 
 def _datetime_from_epoch(value: int | float) -> datetime | None:
     timestamp = float(value)
-    if timestamp > EPOCH_MILLISECONDS_THRESHOLD:
+    if timestamp >= EPOCH_MILLISECONDS_THRESHOLD:
         timestamp /= 1000.0
     try:
         return datetime.fromtimestamp(timestamp, tz=UTC)

--- a/tests/test_alarm_status_service.py
+++ b/tests/test_alarm_status_service.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import json
 from app.services.alarm_status_service import AlarmStatusService
 from app.database.connection import get_db_connection
-from app.utils.time_utils import utc_now_for_db
+from app.utils.time_utils import KST, utc_now, utc_now_for_db
 
 
 def assert_utc_storage(value: str) -> None:
@@ -167,6 +167,44 @@ def test_cleanup_old_tasks_compares_utc_storage_contract(clean_test_db):
             VALUES (?, ?, ?, ?)
             """,
             ("old-utc-task", "bulk", "completed", "2000-01-01T00:00:00+00:00"),
+        )
+        cursor.execute(
+            """
+            INSERT INTO alarm_tasks (task_id, alarm_type, status, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("new-utc-task", "bulk", "pending", utc_now_for_db()),
+        )
+        db.commit()
+
+    deleted_count = AlarmStatusService.cleanup_old_tasks(days=30)
+
+    assert deleted_count == 1
+    with get_db_connection() as db:
+        remaining = [
+            row["task_id"]
+            for row in db.execute("SELECT task_id FROM alarm_tasks ORDER BY task_id").fetchall()
+        ]
+    assert remaining == ["new-utc-task"]
+
+
+def test_cleanup_old_tasks_normalizes_legacy_kst_naive_storage(clean_test_db):
+    """기존 naive KST 저장값도 실제 시점 기준으로 정리해야 함"""
+    legacy_old_instant = utc_now() - timedelta(days=30, hours=1)
+    legacy_kst_storage = (
+        legacy_old_instant.astimezone(KST)
+        .replace(tzinfo=None, microsecond=0)
+        .isoformat(timespec="seconds")
+    )
+
+    with get_db_connection() as db:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            INSERT INTO alarm_tasks (task_id, alarm_type, status, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("legacy-kst-task", "bulk", "completed", legacy_kst_storage),
         )
         cursor.execute(
             """

--- a/tests/test_alarm_status_service.py
+++ b/tests/test_alarm_status_service.py
@@ -1,8 +1,19 @@
 """Test alarm status service functionality"""
 import pytest
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 from app.services.alarm_status_service import AlarmStatusService
+from app.database.connection import get_db_connection
+from app.utils.time_utils import utc_now_for_db
+
+
+def assert_utc_storage(value: str) -> None:
+    parsed = datetime.fromisoformat(value)
+    assert "T" in value
+    assert value.endswith("+00:00")
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() == timedelta(0)
+    assert parsed.microsecond == 0
 
 
 def test_create_alarm_task_basic(clean_test_db):
@@ -21,6 +32,7 @@ def test_create_alarm_task_basic(clean_test_db):
     assert status["alarm_type"] == "individual"
     assert status["status"] == "pending"
     assert status["total_recipients"] == 1
+    assert_utc_storage(status["created_at"])
 
 
 def test_create_alarm_task_with_data(clean_test_db):
@@ -59,6 +71,7 @@ def test_update_alarm_task_status_success(clean_test_db):
     
     status = AlarmStatusService.get_alarm_task_status(task_id)
     assert status["status"] == "processing"
+    assert_utc_storage(status["updated_at"])
     
     # Update to completed
     success = AlarmStatusService.update_alarm_task_status(
@@ -74,6 +87,8 @@ def test_update_alarm_task_status_success(clean_test_db):
     assert status["failed_sends"] == 1
     assert status["success_rate"] == 80.0  # 4/5 = 80%
     assert status["completed_at"] is not None
+    assert_utc_storage(status["updated_at"])
+    assert_utc_storage(status["completed_at"])
 
 
 def test_update_alarm_task_status_with_errors(clean_test_db):
@@ -140,6 +155,37 @@ def test_cleanup_old_tasks_none(clean_test_db):
     """Test cleanup when no old tasks exist"""
     deleted_count = AlarmStatusService.cleanup_old_tasks(days=1)
     assert deleted_count == 0
+
+
+def test_cleanup_old_tasks_compares_utc_storage_contract(clean_test_db):
+    """오래된 작업 정리는 UTC-aware 저장 문자열 기준으로 비교해야 함"""
+    with get_db_connection() as db:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            INSERT INTO alarm_tasks (task_id, alarm_type, status, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("old-utc-task", "bulk", "completed", "2000-01-01T00:00:00+00:00"),
+        )
+        cursor.execute(
+            """
+            INSERT INTO alarm_tasks (task_id, alarm_type, status, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("new-utc-task", "bulk", "pending", utc_now_for_db()),
+        )
+        db.commit()
+
+    deleted_count = AlarmStatusService.cleanup_old_tasks(days=30)
+
+    assert deleted_count == 1
+    with get_db_connection() as db:
+        remaining = [
+            row["task_id"]
+            for row in db.execute("SELECT task_id FROM alarm_tasks ORDER BY task_id").fetchall()
+        ]
+    assert remaining == ["new-utc-task"]
 
 
 def test_success_rate_calculation(clean_test_db):

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -306,6 +306,22 @@ def test_admin_dashboard_displays_times_in_kst(test_client, monkeypatch):
                 1,
             ),
         )
+        cursor.execute(
+            """
+            INSERT INTO users (
+                bot_user_key, first_message_at, last_message_at,
+                route_updated_at, message_count, active
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "utc-user",
+                "2026-05-20T00:20:00+00:00",
+                "2026-05-20T00:30:00+00:00",
+                "2026-05-20T00:40:00+00:00",
+                1,
+                1,
+            ),
+        )
         db.commit()
 
     response = test_client.get("/admin/dashboard", auth=ADMIN_AUTH)
@@ -318,6 +334,9 @@ def test_admin_dashboard_displays_times_in_kst(test_client, monkeypatch):
     assert "2026-05-15 20:00:00 KST" not in response.text
     assert "kst-user" in response.text
     assert "2026-05-20 KST" in response.text
+    assert "utc-user" in response.text
+    assert "2026-05-20 09:30:00 KST" in response.text
+    assert "2026-05-20 09:40:00 KST" in response.text
     assert "2026-05-21" not in response.text
 
 

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -334,9 +334,10 @@ def test_admin_dashboard_displays_times_in_kst(test_client, monkeypatch):
     assert "2026-05-15 20:00:00 KST" not in response.text
     assert "kst-user" in response.text
     assert "2026-05-20 KST" in response.text
-    assert "utc-user" in response.text
-    assert "2026-05-20 09:30:00 KST" in response.text
-    assert "2026-05-20 09:40:00 KST" in response.text
+    utc_user_row = re.search(r"<tr>[\s\S]*?utc-user[\s\S]*?</tr>", response.text)
+    assert utc_user_row is not None
+    assert "2026-05-20 09:30:00 KST" in utc_user_row.group(0)
+    assert "2026-05-20 09:40:00 KST" in utc_user_row.group(0)
     assert "2026-05-21" not in response.text
 
 

--- a/tests/test_api_basic.py
+++ b/tests/test_api_basic.py
@@ -3,12 +3,23 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from fastapi.testclient import TestClient
 from unittest.mock import AsyncMock
 
+from app.database.connection import get_db_connection
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def assert_utc_storage(value: str) -> None:
+    parsed = datetime.fromisoformat(value)
+    assert "T" in value
+    assert value.endswith("+00:00")
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() == timedelta(0)
 
 
 def test_root_endpoint(test_client):
@@ -81,6 +92,36 @@ def test_events_list_empty(test_client, clean_test_db):
     data = response.json()
     assert isinstance(data, list)
     assert len(data) == 0
+
+
+def test_kakao_chat_writes_utc_aware_user_timestamps(test_client, clean_test_db):
+    payload = {
+        "userRequest": {
+            "utterance": "안녕",
+            "user": {
+                "id": "bot-kakao-utc",
+                "type": "botUserKey",
+                "properties": {"plusfriendUserKey": "pf-kakao-utc"},
+            },
+        }
+    }
+
+    response = test_client.post("/kakao/chat", json=payload)
+
+    assert response.status_code == 200
+    with get_db_connection() as db:
+        row = db.execute(
+            """
+            SELECT first_message_at, last_message_at
+            FROM users
+            WHERE bot_user_key = ?
+            """,
+            ("bot-kakao-utc",),
+        ).fetchone()
+
+    assert row is not None
+    assert_utc_storage(row["first_message_at"])
+    assert_utc_storage(row["last_message_at"])
 
 
 def test_scheduler_status(test_client):

--- a/tests/test_smpa_source_upsert.py
+++ b/tests/test_smpa_source_upsert.py
@@ -48,7 +48,12 @@ def selected_coordinate(address="서울특별시 종로구 종로1가", latitude
 
 def test_insert_skip_update_with_real_sqlite_connection():
     conn = make_conn()
-    first = prepare_event_candidate(parsed_event(), selected_coordinate())
+    first_collected_at = datetime(2026, 5, 16, 1, 0, tzinfo=timezone.utc)
+    first = prepare_event_candidate(
+        parsed_event(),
+        selected_coordinate(),
+        collected_at=first_collected_at,
+    )
 
     assert sync_event_candidates(conn, [first]).to_dict() == {
         "inserted": 1,
@@ -63,13 +68,29 @@ def test_insert_skip_update_with_real_sqlite_connection():
         "errors": 0,
     }
 
-    updated = prepare_event_candidate(parsed_event(attendees="500명"), selected_coordinate())
+    updated_collected_at = datetime(2026, 5, 16, 2, 0, tzinfo=timezone.utc)
+    updated = prepare_event_candidate(
+        parsed_event(attendees="500명"),
+        selected_coordinate(),
+        collected_at=updated_collected_at,
+    )
     result = sync_event_candidates(conn, [updated])
 
     assert result.to_dict() == {"inserted": 0, "updated": 1, "skipped": 0, "errors": 0}
-    row = conn.execute("SELECT attendees, source_payload_hash FROM events").fetchone()
+    row = conn.execute(
+        """
+        SELECT attendees, source_payload_hash, start_date, end_date,
+               collected_at, created_at, updated_at
+        FROM events
+        """
+    ).fetchone()
     assert row["attendees"] == "500명"
     assert row["source_payload_hash"] == updated.source_payload_hash
+    assert row["start_date"] == "2026-05-15 11:00:00"
+    assert row["end_date"] == "2026-05-15 13:00:00"
+    assert row["collected_at"] == "2026-05-16T02:00:00+00:00"
+    assert row["created_at"].endswith("+00:00")
+    assert row["updated_at"].endswith("+00:00")
 
 
 def test_empty_source_record_hash_is_rejected_without_db_write():

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -3,10 +3,12 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from app.utils.time_utils import (
+    EPOCH_MILLISECONDS_THRESHOLD,
     KST,
     format_kst_wall_clock_for_db,
     format_utc_datetime_for_db,
     parse_db_timestamp,
+    parse_datetime_value,
     utc_now,
     utc_now_for_db,
 )
@@ -42,6 +44,15 @@ def test_parse_db_timestamp_applies_explicit_legacy_source_timezone():
     assert sqlite_utc.utcoffset() == timedelta(0)
     assert aware_utc is not None
     assert aware_utc.utcoffset() == timedelta(0)
+
+
+def test_parse_datetime_value_treats_epoch_threshold_as_milliseconds():
+    parsed = parse_datetime_value(EPOCH_MILLISECONDS_THRESHOLD)
+
+    assert parsed == datetime.fromtimestamp(
+        EPOCH_MILLISECONDS_THRESHOLD / 1000,
+        tz=timezone.utc,
+    )
 
 
 def test_kst_wall_clock_storage_preserves_naive_smpa_schedule():

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.utils.time_utils import (
+    KST,
+    format_kst_wall_clock_for_db,
+    format_utc_datetime_for_db,
+    parse_db_timestamp,
+    utc_now,
+    utc_now_for_db,
+)
+
+
+def test_utc_now_returns_timezone_aware_utc_datetime():
+    value = utc_now()
+
+    assert value.tzinfo is not None
+    assert value.utcoffset() == timedelta(0)
+
+
+def test_utc_storage_format_requires_aware_datetime():
+    with pytest.raises(ValueError):
+        format_utc_datetime_for_db(datetime(2026, 5, 16, 1, 0, 0))
+
+
+def test_utc_storage_format_uses_offset_iso_seconds_precision():
+    value = datetime(2026, 5, 16, 10, 0, 1, 987654, tzinfo=KST)
+
+    assert format_utc_datetime_for_db(value) == "2026-05-16T01:00:01+00:00"
+    assert utc_now_for_db().endswith("+00:00")
+
+
+def test_parse_db_timestamp_applies_explicit_legacy_source_timezone():
+    legacy_kst = parse_db_timestamp("2026-05-16 10:00:00", naive_source_tz=KST)
+    sqlite_utc = parse_db_timestamp("2026-05-16 01:00:00", naive_source_tz=timezone.utc)
+    aware_utc = parse_db_timestamp("2026-05-16T01:00:00+00:00", naive_source_tz=KST)
+
+    assert legacy_kst is not None
+    assert legacy_kst.tzinfo == KST
+    assert sqlite_utc is not None
+    assert sqlite_utc.utcoffset() == timedelta(0)
+    assert aware_utc is not None
+    assert aware_utc.utcoffset() == timedelta(0)
+
+
+def test_kst_wall_clock_storage_preserves_naive_smpa_schedule():
+    assert (
+        format_kst_wall_clock_for_db(datetime(2026, 5, 16, 10, 30, 45, 123456))
+        == "2026-05-16 10:30:45"
+    )

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -1,6 +1,33 @@
 import sqlite3
+from datetime import datetime, timedelta
 
+from app.models.user import UserPreferences
 from app.services.user_service import UserService
+
+
+def assert_utc_storage(value: str) -> None:
+    parsed = datetime.fromisoformat(value)
+    assert "T" in value
+    assert value.endswith("+00:00")
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() == timedelta(0)
+
+
+def test_save_or_update_user_writes_utc_aware_storage(clean_test_db):
+    conn = sqlite3.connect(clean_test_db)
+
+    UserService.save_or_update_user("bot-new", conn)
+    UserService.save_or_update_user("bot-new", conn)
+
+    row = conn.execute(
+        "SELECT first_message_at, last_message_at, message_count FROM users WHERE bot_user_key = ?",
+        ("bot-new",),
+    ).fetchone()
+    conn.close()
+
+    assert row[2] == 2
+    assert_utc_storage(row[0])
+    assert_utc_storage(row[1])
 
 
 def test_sync_kakao_user_links_existing_bot_user(clean_test_db):
@@ -18,16 +45,73 @@ def test_sync_kakao_user_links_existing_bot_user(clean_test_db):
     UserService.sync_kakao_user("bot_user_key_123", "pf_123", conn)
 
     cursor.execute(
-        "SELECT bot_user_key, plusfriend_user_key, message_count, active FROM users WHERE bot_user_key = ?",
+        "SELECT bot_user_key, plusfriend_user_key, message_count, active, last_message_at FROM users WHERE bot_user_key = ?",
         ("bot_user_key_123",),
     )
     row = cursor.fetchone()
 
-    assert row == ("bot_user_key_123", "pf_123", 2, 1)
+    assert row[:4] == ("bot_user_key_123", "pf_123", 2, 1)
+    assert_utc_storage(row[4])
 
     cursor.execute("SELECT COUNT(*) FROM users")
     assert cursor.fetchone()[0] == 1
     conn.close()
+
+
+def test_delete_user_route_writes_utc_route_timestamp(clean_test_db):
+    conn = sqlite3.connect(clean_test_db)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO users (
+            bot_user_key, plusfriend_user_key, first_message_at, last_message_at,
+            departure_name, departure_x, departure_y, arrival_name, arrival_x, arrival_y,
+            route_updated_at
+        )
+        VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+        """,
+        ("bot-route", "pf-route", "영통역", 127.071, 37.251, "광화문역", 126.9769, 37.5709),
+    )
+    conn.commit()
+
+    result = UserService.delete_user_route("pf-route", conn)
+    row = conn.execute(
+        "SELECT departure_name, arrival_name, route_updated_at FROM users WHERE plusfriend_user_key = ?",
+        ("pf-route",),
+    ).fetchone()
+    conn.close()
+
+    assert result == {"success": True}
+    assert row[0] is None
+    assert row[1] is None
+    assert_utc_storage(row[2])
+
+
+def test_update_user_preferences_accepts_marked_bus_and_language(clean_test_db):
+    conn = sqlite3.connect(clean_test_db)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO users (bot_user_key, first_message_at, last_message_at, message_count, active)
+        VALUES (?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, 1)
+        """,
+        ("bot-preferences",),
+    )
+    conn.commit()
+
+    result = UserService.update_user_preferences(
+        "bot-preferences",
+        UserPreferences(marked_bus="470", language="ko"),
+        conn,
+    )
+    row = conn.execute(
+        "SELECT marked_bus, language FROM users WHERE bot_user_key = ?",
+        ("bot-preferences",),
+    ).fetchone()
+    conn.close()
+
+    assert result == {"success": True}
+    assert row == ("470", "ko")
 
 
 def test_sync_kakao_user_updates_existing_plusfriend_user(clean_test_db):


### PR DESCRIPTION
## Summary
- Add shared timestamp utilities for UTC-aware DB instants, KST wall-clock schedules, and legacy timestamp parsing.
- Store new alarm/user/Kakao/SMPA instant timestamps as UTC-aware ISO strings while preserving SMPA start/end as Seoul local schedule strings.
- Render admin timestamps in KST according to storage meaning and add regression coverage for UTC storage vs KST display behavior.

## Documentation scope
- README is intentionally unchanged per maintainer direction; technical storage details are documented in code/tests and this PR description instead.

## Tests
- `git diff --check`
- `PYTHONPYCACHEPREFIX="$(mktemp -d)" uv run python -m compileall -q app tests`
- `env -u RUN_LIVE_SMPA uv run pytest` — 173 passed, 2 skipped

Refs #119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp accuracy and timezone consistency across user operations, message handling, and system maintenance tasks.
  * Fixed data integrity issues related to mutable default values in data models.

* **Refactor**
  * Standardized datetime parsing and timezone management throughout the application for consistent, reliable timekeeping.
  * Centralized time utility functions to enhance system reliability and reduce code duplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoonly01/kt-demo-alarm/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->