### PR TITLE
Fix deploy-blocking notification template regression

### DIFF
--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -70,13 +70,10 @@ class NotificationService:
         attendees = str(event.get("attendees") or "").strip() or "미상"
         if attendees != "미상" and attendees.isdigit() and not attendees.endswith("명"):
             attendees = f"{attendees}명"
-        desc = event.get("description")
-        desc_line = f"상세 내용 : {desc}\n" if desc and str(desc).strip() else ""
         return (
             f"{index}.\n"
             f"집회 일시 : {NotificationService._format_event_time_range(event)}\n"
             f"집회 장소 : {event['location']}\n"
-            f"{desc_line}"
             f"신고 인원 : {attendees}"
         )
 

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -292,8 +292,8 @@ def test_admin_dashboard_displays_times_in_kst(test_client, monkeypatch):
             """
             INSERT INTO events (
                 title, location_name, latitude, longitude, start_date,
-                severity_level, status, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                severity_level, status, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "KST 표시 검증 집회",
@@ -304,14 +304,15 @@ def test_admin_dashboard_displays_times_in_kst(test_client, monkeypatch):
                 1,
                 "active",
                 "2026-05-15 00:30:00",
+                "2026-05-15 00:30:00",
             ),
         )
         cursor.execute(
             """
             INSERT INTO alarm_tasks (
                 task_id, alarm_type, status, total_recipients,
-                successful_sends, failed_sends, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                successful_sends, failed_sends, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "task-kst-display",
@@ -321,14 +322,15 @@ def test_admin_dashboard_displays_times_in_kst(test_client, monkeypatch):
                 3,
                 0,
                 "2026-05-15T09:40:00",
+                "2026-05-15T09:40:00",
             ),
         )
         cursor.execute(
             """
             INSERT INTO alarm_tasks (
                 task_id, alarm_type, status, total_recipients,
-                successful_sends, failed_sends, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                successful_sends, failed_sends, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "task-utc-offset-display",
@@ -337,6 +339,7 @@ def test_admin_dashboard_displays_times_in_kst(test_client, monkeypatch):
                 2,
                 2,
                 0,
+                "2026-05-15T00:50:00+00:00",
                 "2026-05-15T00:50:00+00:00",
             ),
         )


### PR DESCRIPTION
## 목적

Closes #130

`61253713fa8d206c41903a061bb51f2e35daa4ba` 이후 배포 workflow의 `Run Tests` 단계가 실패해 Docker build와 EC2 deploy가 skipped 되는 문제를 복구합니다.

## 변경 사항

- 알림 번호형 템플릿에서 재도입된 `description`/`상세 내용` 노출 제거
- 숫자 참석자에 `명`을 붙이는 기존 개선은 유지
- admin dashboard KST 표시 테스트 fixture의 `updated_at`을 명시해 DB `CURRENT_TIMESTAMP` 실행 날짜가 HTML에 섞이지 않도록 고정

## 원인

- PR #35 경로에서 `NotificationService._format_event_block()`이 `description`을 `상세 내용`으로 다시 노출했습니다.
- 기존 회귀 테스트는 사용자 알림 템플릿이 `집회 일시`, `집회 장소`, `신고 인원`만 포함한다고 검증하고 있어 `Run Tests`가 실패했습니다.
- KST 표시 테스트는 일부 fixture row의 `updated_at`을 DB 기본값에 맡겨 실행 날짜가 응답 HTML에 포함되는 날짜 민감성이 있었습니다.

## 검증

```bash
uv run python -m pytest tests/test_notification_attendees.py tests/test_notification_templates.py tests/test_api_admin.py::test_admin_dashboard_displays_times_in_kst -q
uv run python -m compileall -q app main.py tests
uv run python -m pytest tests/ -q
git diff --check
```

결과:

```text
7 passed, 1 warning
177 passed, 2 skipped, 10 warnings
```

추가 확인:

- LSP diagnostics: `app/services/notification_service.py` 0건
- LSP diagnostics: `tests/test_api_admin.py` 0건

## 롤백 기준

| 상황 | 조치 |
|---|---|
| 이 PR 자체에서 알림 템플릿 또는 admin dashboard 회귀 발생 | 이 PR revert |
| `61253713` 이후 배포 상태가 계속 불안정하고 원인 범위가 불명확 | 직전 성공 배포 커밋 `fa79d673f1d6a12e67164f1b5a21487940baee3f` 기준 rollback |
| `/attachments` mount 또는 이미지 경로 회귀가 함께 관측됨 | #127 기준 최소 revert 대상 `fe56a46b5a4dd418603f028677100b3ab415c40d` 재검토 |
| PR #33/#34 이후 광범위 운영 회귀가 관측됨 | #127 기준 보수적 기준점 `4a35e9a8a066473d8d10232b12b0d239be7c8e6f` 검토 |

## 비고

- live SMPA/Kakao smoke tests는 기존 default test gate 정책대로 skipped 상태입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event notification formatting has been updated to exclude detailed description content from event blocks, streamlining displayed information.

* **Tests**
  * Test fixtures and database seed data have been enhanced to include timestamp tracking for event records and alarm task scheduling information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoonly01/kt-demo-alarm/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->