### PR TITLE
Restore notification attendee template contract

### DIFF
--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -4,7 +4,7 @@ import logging
 import httpx
 from datetime import datetime
 from typing import List, Dict, Any, Optional, Iterator, Tuple
-from app.models.alarm import AlarmRequest, FilteredAlarmRequest
+from app.models.alarm import AlarmRequest
 from app.models.kakao import EventAPIRequest, Event, EventUser
 from app.config.settings import settings
 
@@ -70,13 +70,10 @@ class NotificationService:
         attendees = str(event.get("attendees") or "").strip() or "미상"
         if attendees != "미상" and attendees.isdigit() and not attendees.endswith("명"):
             attendees = f"{attendees}명"
-        desc = event.get("description")
-        desc_line = f"상세 내용 : {desc}\n" if desc and str(desc).strip() else ""
         return (
             f"{index}.\n"
             f"집회 일시 : {NotificationService._format_event_time_range(event)}\n"
             f"집회 장소 : {event['location']}\n"
-            f"{desc_line}"
             f"신고 인원 : {attendees}"
         )
 


### PR DESCRIPTION
## Summary
- Restore notification attendee template contract by removing legacy `description` from numbered protest notification blocks.
- Remove the now-unused `FilteredAlarmRequest` import in `notification_service.py`.
- Keep this baseline fix separate from the native runtime readiness PR so native scope stays clean.

## Why separate
The native runtime branch from `origin/main` fails full pytest because this baseline is already red on `origin/main`. This PR should merge first; then the native runtime branch for #136 can be rebased or recreated without absorbing notification scope.

## Validation
- `uv run pytest tests/test_notification_attendees.py::test_notification_uses_attendees_not_description tests/test_notification_templates.py::test_kakao_skills_upcoming_protests_uses_numbered_brief_template -q` → 2 passed
- `uv run pytest` → 177 passed, 2 skipped
- `uv run ruff check app/services/notification_service.py` → passed
- `uv run python -m compileall -q app/services/notification_service.py` → passed
- `uv run python -m compileall -q app tests main.py` → passed
- `git diff --check` → passed

## Known gap
- `uv run ruff check` repo-wide still fails on the existing 80-item lint baseline outside this PR.

Related to #136.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Simplified event notification messages to display only essential details: time range, location, and attendee count.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoonly01/kt-demo-alarm/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->