### PR TITLE
Add native runtime readiness preflight path

### DIFF
--- a/.github/workflows/native-runtime.yml
+++ b/.github/workflows/native-runtime.yml
@@ -1,0 +1,89 @@
+name: Native Runtime Preflight
+
+on:
+  workflow_dispatch:
+    inputs:
+      app-dir:
+        description: "Native application directory used when rendering the systemd unit"
+        required: false
+        default: "/opt/kt-demo-alarm"
+      port:
+        description: "Local service port used for preflight rendering"
+        required: false
+        default: "8000"
+
+concurrency:
+  group: native-runtime-preflight-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: Static native runtime preflight
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sync production runtime dependencies
+        run: uv sync --frozen --no-dev
+
+      - name: Check shell syntax
+        run: bash -n scripts/native/*.sh
+
+      - name: Prepare native runtime without browser download
+        env:
+          KT_NATIVE_APP_DIR: ${{ github.workspace }}
+          KT_NATIVE_PORT: ${{ inputs.port }}
+          KT_NATIVE_DATA_DIR: ${{ runner.temp }}/kt-demo-alarm/data
+          KT_NATIVE_LOG_DIR: ${{ runner.temp }}/kt-demo-alarm/logs
+          KT_NATIVE_CACHE_DIR: ${{ runner.temp }}/kt-demo-alarm/topis_cache
+          KT_NATIVE_ATTACHMENT_DIR: ${{ runner.temp }}/kt-demo-alarm/topis_attachments
+          KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/kt-demo-alarm/ms-playwright
+          KT_NATIVE_SKIP_PLAYWRIGHT_BROWSER: "1"
+        run: scripts/native/setup-runtime.sh --skip-playwright-browser
+
+      - name: Run non-mutating native preflight
+        env:
+          KT_NATIVE_APP_DIR: ${{ github.workspace }}
+          KT_NATIVE_PORT: ${{ inputs.port }}
+          KT_NATIVE_DATA_DIR: ${{ runner.temp }}/kt-demo-alarm/data
+          KT_NATIVE_LOG_DIR: ${{ runner.temp }}/kt-demo-alarm/logs
+          KT_NATIVE_CACHE_DIR: ${{ runner.temp }}/kt-demo-alarm/topis_cache
+          KT_NATIVE_ATTACHMENT_DIR: ${{ runner.temp }}/kt-demo-alarm/topis_attachments
+          KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/kt-demo-alarm/ms-playwright
+        run: scripts/native/preflight.sh --skip-port-check
+
+      - name: Render and inspect systemd unit
+        env:
+          KT_NATIVE_APP_DIR: ${{ inputs.app-dir }}
+          KT_NATIVE_PORT: ${{ inputs.port }}
+        run: |
+          set -euo pipefail
+          scripts/native/render-systemd-unit.sh > kt-demo-alarm.service
+          test -s kt-demo-alarm.service
+          ! grep -E '\\{\\{|\\}\\}' kt-demo-alarm.service
+          grep -F 'Type=exec' kt-demo-alarm.service
+          grep -F 'User=' kt-demo-alarm.service
+          grep -F 'Group=' kt-demo-alarm.service
+          grep -F 'WorkingDirectory=' kt-demo-alarm.service
+          grep -F 'EnvironmentFile=' kt-demo-alarm.service
+          grep -F '/.venv/bin/uvicorn main:app' kt-demo-alarm.service
+          grep -F 'Restart=on-failure' kt-demo-alarm.service
+          grep -F 'RestartSec=' kt-demo-alarm.service
+          grep -F 'NoNewPrivileges=true' kt-demo-alarm.service
+          grep -F 'ProtectSystem=strict' kt-demo-alarm.service
+          grep -F 'ReadWritePaths=' kt-demo-alarm.service
+
+      - name: Compile application sources
+        run: .venv/bin/python -m compileall -q app main.py

--- a/.github/workflows/native-runtime.yml
+++ b/.github/workflows/native-runtime.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Render and inspect systemd unit
         env:
-          KT_NATIVE_APP_DIR: ${{ inputs.app-dir }}
+          KT_NATIVE_APP_DIR: ${{ inputs['app-dir'] }}
           KT_NATIVE_PORT: ${{ inputs.port }}
         run: |
           set -euo pipefail

--- a/deploy/systemd/kt-demo-alarm.service.template
+++ b/deploy/systemd/kt-demo-alarm.service.template
@@ -1,0 +1,31 @@
+[Unit]
+Description=KT Demo Alarm native FastAPI service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+User={{KT_NATIVE_SERVICE_USER}}
+Group={{KT_NATIVE_SERVICE_GROUP}}
+WorkingDirectory={{KT_NATIVE_APP_DIR}}
+EnvironmentFile=-{{KT_NATIVE_ENV_FILE}}
+Environment=PYTHONUNBUFFERED=1
+Environment=PYTHONPATH={{KT_NATIVE_APP_DIR}}
+Environment=DATABASE_PATH={{KT_NATIVE_DATABASE_PATH}}
+Environment=CACHE_FILE={{KT_NATIVE_CACHE_FILE}}
+Environment=ATTACHMENT_FOLDER={{KT_NATIVE_ATTACHMENT_DIR}}
+Environment=PLAYWRIGHT_BROWSERS_PATH={{KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH}}
+Environment=PORT={{KT_NATIVE_PORT}}
+ExecStart={{KT_NATIVE_APP_DIR}}/.venv/bin/uvicorn {{KT_NATIVE_UVICORN_APP}} --host {{KT_NATIVE_HOST}} --port {{KT_NATIVE_PORT}}
+Restart=on-failure
+RestartSec={{KT_NATIVE_RESTART_SEC}}
+KillSignal=SIGINT
+TimeoutStopSec=30
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths={{KT_NATIVE_DATA_DIR}} {{KT_NATIVE_LOG_DIR}} {{KT_NATIVE_CACHE_DIR}} {{KT_NATIVE_ATTACHMENT_DIR}} {{KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH}}
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/native/healthcheck.sh
+++ b/scripts/native/healthcheck.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/native/native-defaults.sh
+source "${SCRIPT_DIR}/native-defaults.sh"
+
+health_url="$(native_health_url)"
+
+native_info "Checking ${health_url}"
+for attempt in $(seq 1 "${KT_NATIVE_HEALTH_RETRIES}"); do
+  if command -v curl >/dev/null 2>&1; then
+    if curl -fsS "${health_url}" >/dev/null; then
+      native_info "Health check passed"
+      exit 0
+    fi
+  else
+    KT_NATIVE_HEALTH_URL="${health_url}" "${KT_NATIVE_PYTHON_BIN}" - <<'PY' && exit 0 || true
+import os
+import urllib.request
+
+with urllib.request.urlopen(os.environ["KT_NATIVE_HEALTH_URL"], timeout=5) as response:
+    if response.status >= 400:
+        raise SystemExit(response.status)
+PY
+  fi
+
+  if [[ "${attempt}" -lt "${KT_NATIVE_HEALTH_RETRIES}" ]]; then
+    sleep "${KT_NATIVE_HEALTH_INTERVAL_SECONDS}"
+  fi
+done
+
+native_fail "Health check failed after ${KT_NATIVE_HEALTH_RETRIES} attempts: ${health_url}"

--- a/scripts/native/native-defaults.sh
+++ b/scripts/native/native-defaults.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "native-defaults.sh must be sourced by another native runtime script." >&2
+  exit 64
+fi
+
+KT_NATIVE_SERVICE_NAME="${KT_NATIVE_SERVICE_NAME:-kt-demo-alarm}"
+KT_NATIVE_APP_DIR="${KT_NATIVE_APP_DIR:-/opt/kt-demo-alarm}"
+KT_NATIVE_ENV_FILE="${KT_NATIVE_ENV_FILE:-/etc/kt-demo-alarm/kt-demo-alarm.env}"
+KT_NATIVE_SERVICE_USER="${KT_NATIVE_SERVICE_USER:-kt-demo-alarm}"
+KT_NATIVE_SERVICE_GROUP="${KT_NATIVE_SERVICE_GROUP:-kt-demo-alarm}"
+KT_NATIVE_HOST="${KT_NATIVE_HOST:-0.0.0.0}"
+KT_NATIVE_PORT="${KT_NATIVE_PORT:-8000}"
+KT_NATIVE_HEALTH_HOST="${KT_NATIVE_HEALTH_HOST:-127.0.0.1}"
+KT_NATIVE_HEALTH_PATH="${KT_NATIVE_HEALTH_PATH:-/}"
+KT_NATIVE_UV_BIN="${KT_NATIVE_UV_BIN:-uv}"
+KT_NATIVE_PYTHON_BIN="${KT_NATIVE_PYTHON_BIN:-python3}"
+KT_NATIVE_UVICORN_APP="${KT_NATIVE_UVICORN_APP:-main:app}"
+KT_NATIVE_RESTART_SEC="${KT_NATIVE_RESTART_SEC:-5}"
+KT_NATIVE_HEALTH_RETRIES="${KT_NATIVE_HEALTH_RETRIES:-30}"
+KT_NATIVE_HEALTH_INTERVAL_SECONDS="${KT_NATIVE_HEALTH_INTERVAL_SECONDS:-2}"
+
+KT_NATIVE_DATA_DIR="${KT_NATIVE_DATA_DIR:-${KT_NATIVE_APP_DIR}/data}"
+KT_NATIVE_LOG_DIR="${KT_NATIVE_LOG_DIR:-${KT_NATIVE_APP_DIR}/logs}"
+KT_NATIVE_CACHE_DIR="${KT_NATIVE_CACHE_DIR:-${KT_NATIVE_APP_DIR}/topis_cache}"
+KT_NATIVE_ATTACHMENT_DIR="${KT_NATIVE_ATTACHMENT_DIR:-${KT_NATIVE_APP_DIR}/topis_attachments}"
+KT_NATIVE_DATABASE_PATH="${KT_NATIVE_DATABASE_PATH:-${KT_NATIVE_DATA_DIR}/kt_demo_alarm.db}"
+KT_NATIVE_CACHE_FILE="${KT_NATIVE_CACHE_FILE:-${KT_NATIVE_CACHE_DIR}/topis_cache.json}"
+KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH="${KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH:-${KT_NATIVE_APP_DIR}/.cache/ms-playwright}"
+
+native_repo_root() {
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  cd "${script_dir}/../.." && pwd
+}
+
+native_fail() {
+  echo "❌ $*" >&2
+  exit 1
+}
+
+native_info() {
+  echo "==> $*"
+}
+
+native_health_url() {
+  printf 'http://%s:%s%s' \
+    "${KT_NATIVE_HEALTH_HOST}" \
+    "${KT_NATIVE_PORT}" \
+    "${KT_NATIVE_HEALTH_PATH}"
+}

--- a/scripts/native/preflight.sh
+++ b/scripts/native/preflight.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/native/native-defaults.sh
+source "${SCRIPT_DIR}/native-defaults.sh"
+
+show_help() {
+  cat <<'USAGE'
+Usage: scripts/native/preflight.sh [--skip-port-check]
+
+Run non-mutating checks for the native runtime path.
+
+Checks:
+  - Python and uv availability
+  - uv lockfile and virtualenv runtime command
+  - writable runtime directory configuration
+  - port and active runtime conflict signals
+  - Playwright package/browser dependency readiness notes
+
+This script does not stop/start Docker, systemd, or remote services.
+USAGE
+}
+
+skip_port_check="${KT_NATIVE_SKIP_PORT_CHECK:-0}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-port-check)
+      skip_port_check="1"
+      shift
+      ;;
+    --help|-h)
+      show_help
+      exit 0
+      ;;
+    *)
+      native_fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+repo_root="$(native_repo_root)"
+cd "${repo_root}"
+
+native_info "Checking commands"
+command -v "${KT_NATIVE_UV_BIN}" >/dev/null 2>&1 || native_fail "uv command not found: ${KT_NATIVE_UV_BIN}"
+command -v "${KT_NATIVE_PYTHON_BIN}" >/dev/null 2>&1 || native_fail "Python command not found: ${KT_NATIVE_PYTHON_BIN}"
+
+"${KT_NATIVE_PYTHON_BIN}" - <<'PY'
+import sys
+
+if sys.version_info < (3, 12):
+    raise SystemExit("Python 3.12 or newer is required")
+PY
+
+[[ -f pyproject.toml ]] || native_fail "pyproject.toml not found"
+[[ -f uv.lock ]] || native_fail "uv.lock not found"
+[[ -x .venv/bin/uvicorn ]] || native_fail "Run scripts/native/setup-runtime.sh first; .venv/bin/uvicorn is missing"
+
+native_info "Checking configured runtime directories"
+for required_dir in \
+  "${KT_NATIVE_DATA_DIR}" \
+  "${KT_NATIVE_LOG_DIR}" \
+  "${KT_NATIVE_CACHE_DIR}" \
+  "${KT_NATIVE_ATTACHMENT_DIR}"; do
+  if [[ ! -d "${required_dir}" ]]; then
+    native_fail "Required runtime directory is missing: ${required_dir}"
+  fi
+done
+
+if [[ "${skip_port_check}" != "1" ]]; then
+  native_info "Checking port availability on ${KT_NATIVE_HEALTH_HOST}:${KT_NATIVE_PORT}"
+  KT_NATIVE_HEALTH_HOST="${KT_NATIVE_HEALTH_HOST}" KT_NATIVE_PORT="${KT_NATIVE_PORT}" "${KT_NATIVE_PYTHON_BIN}" - <<'PY'
+import os
+import socket
+import sys
+
+host = os.environ["KT_NATIVE_HEALTH_HOST"]
+port = int(os.environ["KT_NATIVE_PORT"])
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.settimeout(1.0)
+    result = sock.connect_ex((host, port))
+
+if result == 0:
+    raise SystemExit(f"Port already accepts connections: {host}:{port}")
+PY
+fi
+
+if command -v docker >/dev/null 2>&1; then
+  if docker compose ps --status running --services 2>/dev/null | grep -qx "${KT_NATIVE_SERVICE_NAME}"; then
+    native_fail "Docker compose service is already running: ${KT_NATIVE_SERVICE_NAME}"
+  fi
+fi
+
+if command -v systemctl >/dev/null 2>&1; then
+  if systemctl is-active --quiet "${KT_NATIVE_SERVICE_NAME}" 2>/dev/null; then
+    native_fail "systemd service is already active: ${KT_NATIVE_SERVICE_NAME}"
+  fi
+fi
+
+native_info "Checking Playwright Python package import"
+"${KT_NATIVE_UV_BIN}" run --no-dev python - <<'PY'
+from playwright.sync_api import sync_playwright
+
+assert sync_playwright
+PY
+
+if [[ -f /etc/os-release ]]; then
+  # shellcheck disable=SC1091
+  source /etc/os-release
+  os_id="${ID:-unknown}"
+  os_like="${ID_LIKE:-}"
+else
+  os_id="unknown"
+  os_like=""
+fi
+
+case " ${os_id} ${os_like} " in
+  *" ubuntu "*|*" debian "*)
+    native_info "Ubuntu/Debian family detected; setup can run Playwright with --with-deps when KT_NATIVE_INSTALL_PLAYWRIGHT_DEPS=1"
+    ;;
+  *" rhel "*|*" fedora "*|*" centos "*|*" rocky "*|*" amzn "*)
+    native_info "RHEL/Rocky/Amazon family detected; confirm Chromium shared libraries through host package policy before cutover"
+    ;;
+  *)
+    native_info "Unknown OS family; keep this run as readiness preflight only"
+    ;;
+esac
+
+native_info "Native runtime preflight completed"

--- a/scripts/native/preflight.sh
+++ b/scripts/native/preflight.sh
@@ -67,6 +67,9 @@ for required_dir in \
   if [[ ! -d "${required_dir}" ]]; then
     native_fail "Required runtime directory is missing: ${required_dir}"
   fi
+  if [[ ! -w "${required_dir}" ]]; then
+    native_fail "Required runtime directory is not writable: ${required_dir}"
+  fi
 done
 
 if [[ "${skip_port_check}" != "1" ]]; then

--- a/scripts/native/render-systemd-unit.sh
+++ b/scripts/native/render-systemd-unit.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/native/native-defaults.sh
+source "${SCRIPT_DIR}/native-defaults.sh"
+
+repo_root="$(native_repo_root)"
+template_path="${1:-${repo_root}/deploy/systemd/kt-demo-alarm.service.template}"
+output_path="${2:-}"
+
+[[ -f "${template_path}" ]] || native_fail "Template not found: ${template_path}"
+
+rendered="$(
+  KT_NATIVE_SERVICE_NAME="${KT_NATIVE_SERVICE_NAME}" \
+  KT_NATIVE_APP_DIR="${KT_NATIVE_APP_DIR}" \
+  KT_NATIVE_ENV_FILE="${KT_NATIVE_ENV_FILE}" \
+  KT_NATIVE_SERVICE_USER="${KT_NATIVE_SERVICE_USER}" \
+  KT_NATIVE_SERVICE_GROUP="${KT_NATIVE_SERVICE_GROUP}" \
+  KT_NATIVE_HOST="${KT_NATIVE_HOST}" \
+  KT_NATIVE_PORT="${KT_NATIVE_PORT}" \
+  KT_NATIVE_UVICORN_APP="${KT_NATIVE_UVICORN_APP}" \
+  KT_NATIVE_RESTART_SEC="${KT_NATIVE_RESTART_SEC}" \
+  KT_NATIVE_DATA_DIR="${KT_NATIVE_DATA_DIR}" \
+  KT_NATIVE_LOG_DIR="${KT_NATIVE_LOG_DIR}" \
+  KT_NATIVE_CACHE_DIR="${KT_NATIVE_CACHE_DIR}" \
+  KT_NATIVE_ATTACHMENT_DIR="${KT_NATIVE_ATTACHMENT_DIR}" \
+  KT_NATIVE_DATABASE_PATH="${KT_NATIVE_DATABASE_PATH}" \
+  KT_NATIVE_CACHE_FILE="${KT_NATIVE_CACHE_FILE}" \
+  KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH="${KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH}" \
+  "${KT_NATIVE_PYTHON_BIN}" - "${template_path}" <<'PY'
+import os
+import pathlib
+import sys
+
+template = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+keys = [
+    "KT_NATIVE_SERVICE_NAME",
+    "KT_NATIVE_APP_DIR",
+    "KT_NATIVE_ENV_FILE",
+    "KT_NATIVE_SERVICE_USER",
+    "KT_NATIVE_SERVICE_GROUP",
+    "KT_NATIVE_HOST",
+    "KT_NATIVE_PORT",
+    "KT_NATIVE_UVICORN_APP",
+    "KT_NATIVE_RESTART_SEC",
+    "KT_NATIVE_DATA_DIR",
+    "KT_NATIVE_LOG_DIR",
+    "KT_NATIVE_CACHE_DIR",
+    "KT_NATIVE_ATTACHMENT_DIR",
+    "KT_NATIVE_DATABASE_PATH",
+    "KT_NATIVE_CACHE_FILE",
+    "KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH",
+]
+
+rendered = template
+for key in keys:
+    rendered = rendered.replace("{{" + key + "}}", os.environ[key])
+
+if "{{" in rendered or "}}" in rendered:
+    raise SystemExit("Unresolved placeholder remains in rendered unit")
+
+print(rendered, end="")
+PY
+)"
+
+if [[ -n "${output_path}" ]]; then
+  printf '%s' "${rendered}" > "${output_path}"
+else
+  printf '%s' "${rendered}"
+fi

--- a/scripts/native/setup-runtime.sh
+++ b/scripts/native/setup-runtime.sh
@@ -23,7 +23,9 @@ Environment overrides:
   KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH
   KT_NATIVE_INSTALL_PLAYWRIGHT_DEPS=1
 
-This script does not install OS packages and does not start or stop services.
+This script does not start or stop services.
+By default it installs Python packages and the Playwright browser only.
+If KT_NATIVE_INSTALL_PLAYWRIGHT_DEPS=1, Playwright may also install supported OS dependencies.
 USAGE
 }
 

--- a/scripts/native/setup-runtime.sh
+++ b/scripts/native/setup-runtime.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/native/native-defaults.sh
+source "${SCRIPT_DIR}/native-defaults.sh"
+
+show_help() {
+  cat <<'USAGE'
+Usage: scripts/native/setup-runtime.sh [--skip-playwright-browser]
+
+Prepare the native Python runtime in the current checkout.
+
+Environment overrides:
+  KT_NATIVE_UV_BIN
+  KT_NATIVE_PYTHON_BIN
+  KT_NATIVE_APP_DIR
+  KT_NATIVE_DATA_DIR
+  KT_NATIVE_LOG_DIR
+  KT_NATIVE_CACHE_DIR
+  KT_NATIVE_ATTACHMENT_DIR
+  KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH
+  KT_NATIVE_INSTALL_PLAYWRIGHT_DEPS=1
+
+This script does not install OS packages and does not start or stop services.
+USAGE
+}
+
+skip_playwright_browser="${KT_NATIVE_SKIP_PLAYWRIGHT_BROWSER:-0}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-playwright-browser)
+      skip_playwright_browser="1"
+      shift
+      ;;
+    --help|-h)
+      show_help
+      exit 0
+      ;;
+    *)
+      native_fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+repo_root="$(native_repo_root)"
+cd "${repo_root}"
+
+command -v "${KT_NATIVE_UV_BIN}" >/dev/null 2>&1 || native_fail "uv command not found: ${KT_NATIVE_UV_BIN}"
+command -v "${KT_NATIVE_PYTHON_BIN}" >/dev/null 2>&1 || native_fail "Python command not found: ${KT_NATIVE_PYTHON_BIN}"
+
+"${KT_NATIVE_PYTHON_BIN}" - <<'PY'
+import sys
+
+if sys.version_info < (3, 12):
+    raise SystemExit("Python 3.12 or newer is required")
+PY
+
+[[ -f pyproject.toml ]] || native_fail "pyproject.toml not found in ${repo_root}"
+[[ -f uv.lock ]] || native_fail "uv.lock not found in ${repo_root}"
+
+native_info "Syncing production dependencies from uv.lock"
+"${KT_NATIVE_UV_BIN}" sync --frozen --no-dev
+
+native_info "Preparing runtime directories"
+mkdir -p \
+  "${KT_NATIVE_DATA_DIR}" \
+  "${KT_NATIVE_LOG_DIR}" \
+  "${KT_NATIVE_CACHE_DIR}" \
+  "${KT_NATIVE_ATTACHMENT_DIR}/route_images" \
+  "${KT_NATIVE_ATTACHMENT_DIR}/protest_images" \
+  "${KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH}"
+
+if [[ "${skip_playwright_browser}" == "1" ]]; then
+  native_info "Skipping Playwright browser download by request"
+elif [[ "${KT_NATIVE_INSTALL_PLAYWRIGHT_DEPS:-0}" == "1" ]]; then
+  native_info "Installing Chromium and supported OS dependencies through Playwright"
+  PLAYWRIGHT_BROWSERS_PATH="${KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH}" \
+    "${KT_NATIVE_UV_BIN}" run --no-dev playwright install chromium --with-deps
+else
+  native_info "Installing Chromium browser only; run OS dependency preflight separately"
+  PLAYWRIGHT_BROWSERS_PATH="${KT_NATIVE_PLAYWRIGHT_BROWSERS_PATH}" \
+    "${KT_NATIVE_UV_BIN}" run --no-dev playwright install chromium
+fi
+
+[[ -x .venv/bin/uvicorn ]] || native_fail "Expected executable missing: ${repo_root}/.venv/bin/uvicorn"
+
+native_info "Native runtime setup completed"

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -36,6 +36,9 @@ def test_native_workflow_is_manual_preflight_only() -> None:
     assert set(workflow["jobs"]) == {"preflight"}
 
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "${{ inputs['app-dir'] }}" in workflow_text
+    assert "${{ inputs.app-dir }}" not in workflow_text
+
     forbidden_patterns = [
         r"secrets\.EC2_SSH_KEY",
         r"\bssh\b",
@@ -76,12 +79,14 @@ def test_setup_runtime_contains_required_uv_and_playwright_paths() -> None:
     assert "playwright install chromium --with-deps" in setup_text
     assert "playwright install chromium" in setup_text
     assert ".venv/bin/uvicorn" in setup_text
+    assert "may also install supported OS dependencies" in setup_text
 
 
 def test_preflight_reports_conflicts_without_stop_start_mutation() -> None:
     preflight_text = (SCRIPT_DIR / "preflight.sh").read_text(encoding="utf-8")
 
     assert "connect_ex" in preflight_text
+    assert "[[ ! -w \"${required_dir}\" ]]" in preflight_text
     assert "docker compose ps --status running --services" in preflight_text
     assert "systemctl is-active --quiet" in preflight_text
     assert "systemctl start" not in preflight_text

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -1,0 +1,140 @@
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "native-runtime.yml"
+SCRIPT_DIR = REPO_ROOT / "scripts" / "native"
+SYSTEMD_TEMPLATE = REPO_ROOT / "deploy" / "systemd" / "kt-demo-alarm.service.template"
+
+
+def run_command(*args: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+    env = kwargs.pop("env", None)
+    if env is not None:
+        env = {**os.environ, **env}
+
+    return subprocess.run(
+        args,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+        env=env,
+        **kwargs,
+    )
+
+
+def test_native_workflow_is_manual_preflight_only() -> None:
+    workflow = yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+    triggers = workflow["on"]
+    assert set(triggers) == {"workflow_dispatch"}
+    assert set(workflow["jobs"]) == {"preflight"}
+
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    forbidden_patterns = [
+        r"secrets\.EC2_SSH_KEY",
+        r"\bssh\b",
+        r"\bscp\b",
+        r"docker\s+compose\s+(down|up)",
+        r"systemctl\s+(start|stop|restart|reload)",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, workflow_text)
+
+
+def test_native_scripts_are_syntax_valid_and_non_mutating_by_default() -> None:
+    scripts = sorted(SCRIPT_DIR.glob("*.sh"))
+    assert {script.name for script in scripts} == {
+        "healthcheck.sh",
+        "native-defaults.sh",
+        "preflight.sh",
+        "render-systemd-unit.sh",
+        "setup-runtime.sh",
+    }
+
+    run_command("bash", "-n", *[str(script) for script in scripts])
+
+    combined = "\n".join(script.read_text(encoding="utf-8") for script in scripts)
+    forbidden_patterns = [
+        r"\bsudo\b",
+        r"docker\s+compose\s+(down|up)",
+        r"systemctl\s+(start|stop|restart|reload)",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, combined)
+
+
+def test_setup_runtime_contains_required_uv_and_playwright_paths() -> None:
+    setup_text = (SCRIPT_DIR / "setup-runtime.sh").read_text(encoding="utf-8")
+
+    assert "sync --frozen --no-dev" in setup_text
+    assert "playwright install chromium --with-deps" in setup_text
+    assert "playwright install chromium" in setup_text
+    assert ".venv/bin/uvicorn" in setup_text
+
+
+def test_preflight_reports_conflicts_without_stop_start_mutation() -> None:
+    preflight_text = (SCRIPT_DIR / "preflight.sh").read_text(encoding="utf-8")
+
+    assert "connect_ex" in preflight_text
+    assert "docker compose ps --status running --services" in preflight_text
+    assert "systemctl is-active --quiet" in preflight_text
+    assert "systemctl start" not in preflight_text
+    assert "systemctl stop" not in preflight_text
+    assert "docker compose down" not in preflight_text
+    assert "docker compose up" not in preflight_text
+
+
+def test_rendered_systemd_unit_has_required_directives() -> None:
+    assert SYSTEMD_TEMPLATE.exists()
+
+    result = run_command(
+        "bash",
+        "scripts/native/render-systemd-unit.sh",
+        env={
+            "KT_NATIVE_APP_DIR": "/srv/kt-demo-alarm",
+            "KT_NATIVE_PORT": "18000",
+            "KT_NATIVE_SERVICE_USER": "demo-user",
+            "KT_NATIVE_SERVICE_GROUP": "demo-group",
+        },
+    )
+    unit = result.stdout
+
+    assert "{{" not in unit
+    assert "}}" not in unit
+    assert "Type=exec" in unit
+    assert "User=demo-user" in unit
+    assert "Group=demo-group" in unit
+    assert "WorkingDirectory=/srv/kt-demo-alarm" in unit
+    assert "EnvironmentFile=" in unit
+    assert "ExecStart=/srv/kt-demo-alarm/.venv/bin/uvicorn main:app --host 0.0.0.0 --port 18000" in unit
+    assert "Restart=on-failure" in unit
+    assert "RestartSec=" in unit
+    assert "NoNewPrivileges=true" in unit
+    assert "ProtectSystem=strict" in unit
+    assert "ReadWritePaths=" in unit
+
+
+def test_preflight_can_run_in_non_mutating_test_mode(tmp_path: Path) -> None:
+    runtime_dirs = {
+        "KT_NATIVE_DATA_DIR": str(tmp_path / "data"),
+        "KT_NATIVE_LOG_DIR": str(tmp_path / "logs"),
+        "KT_NATIVE_CACHE_DIR": str(tmp_path / "topis_cache"),
+        "KT_NATIVE_ATTACHMENT_DIR": str(tmp_path / "topis_attachments"),
+    }
+    for path in runtime_dirs.values():
+        Path(path).mkdir(parents=True, exist_ok=True)
+
+    run_command(
+        "bash",
+        "scripts/native/preflight.sh",
+        "--skip-port-check",
+        env={
+            **runtime_dirs,
+        },
+    )

--- a/tests/test_notification_attendees.py
+++ b/tests/test_notification_attendees.py
@@ -1,21 +1,21 @@
 from app.services.notification_service import NotificationService
 
 
-def test_notification_uses_attendees_not_description():
+def test_notification_includes_description_and_attendees():
     message = NotificationService._format_event_message(
         [
             {
                 "location": "교보빌딩 남측 -> 청진공원",
                 "start_date": "2026-05-15 11:00:00",
                 "end_date": "2026-05-15 13:00:00",
-                "description": "legacy description must not appear",
+                "description": "교통 통제 상세 안내",
                 "attendees": "100명",
             }
         ]
     )
 
+    assert "상세 내용 : 교통 통제 상세 안내" in message
     assert "신고 인원 : 100명" in message
-    assert "legacy description" not in message
 
 
 def test_notification_attendees_default_is_unknown():

--- a/tests/test_notification_templates.py
+++ b/tests/test_notification_templates.py
@@ -98,13 +98,13 @@ async def test_events_today_protests_uses_numbered_brief_template(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_kakao_skills_upcoming_protests_uses_numbered_brief_template(monkeypatch):
+async def test_kakao_skills_upcoming_protests_includes_description_and_attendees(monkeypatch):
     monkeypatch.setattr(
         kakao_skills.EventService,
         "get_upcoming_events",
         lambda limit, db: [
             SimpleNamespace(
-                description="legacy description must not be used",
+                description="집회 상세 안내",
                 attendees="300명",
                 location_name="광화문 월대 -> 舊)효자치안센터",
                 start_date="2026-05-14T14:30:00",
@@ -120,5 +120,6 @@ async def test_kakao_skills_upcoming_protests_uses_numbered_brief_template(monke
         "1.\n"
         "집회 일시 : 14:30 ~ 16:00\n"
         "집회 장소 : 광화문 월대 -> 舊)효자치안센터\n"
+        "상세 내용 : 집회 상세 안내\n"
         "신고 인원 : 300명"
     )


### PR DESCRIPTION
## Summary
- Add Docker-free native runtime readiness scripts under `scripts/native/`.
- Add a systemd service template under `deploy/systemd/`.
- Add a preflight-only manual workflow at `.github/workflows/native-runtime.yml`.
- Preserve existing Docker deployment assets and existing notification output unchanged.

## Scope guard
- No `docs/` files in this PR.
- No Dockerfile, docker-compose, deploy workflow, or `scripts/setup-ec2.sh` changes.
- No production deploy, SSH, secret migration, cutover, or merge action.
- The manual workflow is intentionally `workflow_dispatch` only. GitHub only lets this workflow be manually run from the UI after the workflow file exists on the default branch.

## Notification output guard
- #137 was closed because removing `상세 내용` is not part of the docker-free goal.
- This PR keeps the current notification implementation intact and updates assertions to preserve the existing description output where that path already emits it.

## Validation completed on this branch
- `uv run pytest` → 183 passed, 2 skipped
- `uv run pytest tests/test_notification_attendees.py tests/test_notification_templates.py -q` → 6 passed
- `uv run pytest tests/test_native_runtime_assets.py -q` → 6 passed as part of full pytest
- `bash -n scripts/native/*.sh` → passed
- `uv run ruff check tests/test_native_runtime_assets.py tests/test_notification_attendees.py tests/test_notification_templates.py` → passed
- `git diff --check` → passed
- Previous native preflight asset guards retained: rendered systemd unit verification, workflow YAML/trigger/secret/deploy guard, docs guard, Docker asset guard.

## Known non-green gates
- Repo-wide `uv run ruff check` has an existing baseline outside this PR; changed-file ruff passed.

Closes #136.
