### PR TITLE
Disable automatic Docker deploy during native migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,11 @@
 name: Deploy to AWS EC2
 
 on:
-  push:
-    branches:
-      - main
+  # Docker EC2 deploy is intentionally manual while the Docker-free
+  # native runtime migration is in progress.
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 concurrency:

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -8,6 +8,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "native-runtime.yml"
+DEPLOY_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "deploy.yml"
 SCRIPT_DIR = REPO_ROOT / "scripts" / "native"
 SYSTEMD_TEMPLATE = REPO_ROOT / "deploy" / "systemd" / "kt-demo-alarm.service.template"
 
@@ -48,6 +49,18 @@ def test_native_workflow_is_manual_preflight_only() -> None:
     ]
     for pattern in forbidden_patterns:
         assert not re.search(pattern, workflow_text)
+
+
+def test_docker_deploy_workflow_is_manual_only_during_native_migration() -> None:
+    workflow = yaml.load(DEPLOY_WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+    assert set(workflow["on"]) == {"workflow_dispatch"}
+
+    workflow_text = DEPLOY_WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "Build Docker Image" in workflow_text
+    assert "docker compose up -d --no-build" in workflow_text
+    assert "# push:" in workflow_text
+    assert "#     - main" in workflow_text
 
 
 def test_native_scripts_are_syntax_valid_and_non_mutating_by_default() -> None:


### PR DESCRIPTION
## Summary
- Comment out the `main` push trigger in the existing Docker EC2 deploy workflow.
- Keep `workflow_dispatch` so Docker deploy remains manually available for rollback/operator use.
- Add a regression guard proving the workflow is manual-only while Docker-free migration proceeds.

## Validation
- `uv run pytest tests/test_native_runtime_assets.py -q` → 7 passed
- `uv run ruff check tests/test_native_runtime_assets.py` → passed
- `uv run pytest` → 184 passed, 2 skipped
- `git diff --check` → passed

Closes #139.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite verifying deployment workflow is properly configured for manual-only triggering and includes all required Docker image building and deployment steps

* **Chores**
  * Disabled automatic deployment workflow triggers that previously fired on main branch pushes
  * Updated deployment workflow to require manual activation exclusively via workflow dispatch interface
  * All existing deployment configuration, concurrency settings, and permissions remain intact

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoonly01/kt-demo-alarm/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->