### PR TITLE
Docker 없는 native FastAPI 배포 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,239 +13,251 @@ concurrency:
 permissions:
   contents: read
 
-jobs:
-  deploy-test-bypass:
-    runs-on: ubuntu-latest
-    name: Deploy test gate bypass
-    steps:
-      - name: Record bypass notice
-        run: |
-          echo "::warning title=Run Tests bypassed::Deployment is proceeding without the pytest gate. Use the linked issue/PR rollback criteria if production health or notification contracts regress."
-          {
-            echo "## Run Tests bypassed"
-            echo ""
-            echo "Deployment is intentionally proceeding without the pytest gate."
-            echo "Use the linked issue/PR rollback criteria if production health or notification contracts regress."
-          } >> "$GITHUB_STEP_SUMMARY"
+env:
+  APP_NAME: kt-demo-alarm
+  APP_ROOT: /opt/kt-demo-alarm
+  APP_BIND_HOST: 127.0.0.1
+  APP_PORT: "8000"
+  HEALTH_TIMEOUT_SECONDS: "180"
+  HEALTH_INTERVAL_SECONDS: "3"
+  RELEASE_KEEP: "5"
+  BUNDLE_NAME: source-bundle.tar.gz
+  CHECKSUM_NAME: source-bundle.sha256
 
-  build:
-    needs: deploy-test-bypass
+jobs:
+  test:
     runs-on: ubuntu-latest
-    name: Build Docker Image
+    name: Run tests
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Docker image
-        uses: docker/build-push-action@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          context: .
-          tags: kt-demo-alarm:latest,kt-demo-alarm:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          outputs: type=docker,dest=kt-demo-alarm-image.tar
+          python-version-file: .python-version
 
-      - name: Compress Docker image
-        run: gzip kt-demo-alarm-image.tar
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
 
-      - name: Upload Docker image artifact
+      - name: Check lockfile freshness
+        run: uv lock --check
+
+      - name: Run pytest
+        run: uv run pytest
+
+  package-source:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Package source bundle
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build allowlisted source bundle
+        env:
+          BUNDLE_NAME: ${{ env.BUNDLE_NAME }}
+          CHECKSUM_NAME: ${{ env.CHECKSUM_NAME }}
+        run: |
+          set -euo pipefail
+
+          staging_dir="$(mktemp -d)"
+          trap 'rm -r -- "${staging_dir}"' EXIT
+
+          source_paths=(
+            app
+            main.py
+            pyproject.toml
+            uv.lock
+            .python-version
+            deploy/native
+            docs/native-linux-deploy-guide.md
+            docs/docker-free-fastapi-deploy-runbook.md
+          )
+
+          if [[ -d nginx ]]; then
+            source_paths+=(nginx)
+          fi
+
+          for path in "${source_paths[@]}"; do
+            if [[ ! -e "${path}" ]]; then
+              echo "::error title=Missing bundle path::${path}"
+              exit 1
+            fi
+          done
+
+          tar \
+            --exclude='__pycache__' \
+            --exclude='*/__pycache__' \
+            --exclude='*.pyc' \
+            --exclude='.pytest_cache' \
+            --exclude='.ruff_cache' \
+            --exclude='.venv' \
+            --exclude='.env' \
+            --exclude='.env.*' \
+            --exclude='*.pem' \
+            -cf - "${source_paths[@]}" | tar -xf - -C "${staging_dir}"
+
+          denied_paths="$(
+            find "${staging_dir}" \
+              \( -name '.env' -o -name '.env.*' -o -name '.venv' -o -name '.pytest_cache' -o -name '.ruff_cache' -o -name '__pycache__' -o -name '*.pyc' -o -name '*.pyo' \
+                 -o -name '*.db' -o -name '*.sqlite' -o -name '*.sqlite3' \
+                 -o -name 'attachments' -o -name 'topis_attachments' -o -name 'topis_cache' \
+                 -o -name '*.key' -o -name '*.pem' -o -name 'id_rsa' -o -name 'credentials.json' \
+                 -o -name '*-image.tar' -o -name '*-image.tar.gz' -o -name '*.image.tar' -o -name '*.image.tar.gz' \) \
+              -print
+          )"
+          if [[ -n "${denied_paths}" ]]; then
+            echo "::error title=Denied files in source bundle::${denied_paths}"
+            exit 1
+          fi
+
+          (
+            cd "${staging_dir}"
+            find . -mindepth 1 \( -type f -o -type l \) \
+              | sed 's#^\./##' \
+              | sort > bundle-manifest.txt
+            tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner -czf "../${BUNDLE_NAME}" .
+          )
+
+          mv "${staging_dir}/../${BUNDLE_NAME}" "${BUNDLE_NAME}"
+          sha256sum "${BUNDLE_NAME}" > "${CHECKSUM_NAME}"
+          tar -tzf "${BUNDLE_NAME}" | sed 's#^\./##' | sort > tar-list.txt
+
+          if ! grep -Fxq bundle-manifest.txt tar-list.txt; then
+            echo "::error title=Bundle manifest missing::bundle-manifest.txt was not packaged"
+            exit 1
+          fi
+
+          echo "Created ${BUNDLE_NAME}"
+          echo "Bundle file count: $(wc -l < tar-list.txt)"
+
+      - name: Upload source bundle artifact
         uses: actions/upload-artifact@v4
         with:
-          name: docker-image
-          path: kt-demo-alarm-image.tar.gz
+          name: source-bundle
+          path: |
+            ${{ env.BUNDLE_NAME }}
+            ${{ env.CHECKSUM_NAME }}
           retention-days: 1
 
-  deploy:
-    needs: build
+  deploy-native:
+    needs: package-source
     runs-on: ubuntu-latest
-    name: Deploy to EC2
+    name: Deploy native systemd release
     steps:
-      - name: Checkout code
+      - name: Checkout deploy scripts
         uses: actions/checkout@v4
 
-      - name: Download Docker image artifact
+      - name: Download source bundle artifact
         uses: actions/download-artifact@v4
         with:
-          name: docker-image
+          name: source-bundle
+          path: release-artifact
 
-      - name: Deploy to EC2
+      - name: Deploy source bundle to EC2
         env:
           EC2_HOST: ${{ secrets.EC2_HOST }}
           EC2_USERNAME: ${{ secrets.EC2_USERNAME }}
           EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
-          PUBLIC_DOMAIN: ${{ secrets.PUBLIC_DOMAIN }}
-          KAKAO_EVENT_API_KEY: ${{ secrets.KAKAO_EVENT_API_KEY }}
-          KAKAO_LOCATION_API_KEY: ${{ secrets.KAKAO_LOCATION_API_KEY }}
-          BOT_ID: ${{ secrets.BOT_ID }}
-          API_KEY: ${{ secrets.API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          SEOUL_BUS_API_KEY: ${{ secrets.SEOUL_BUS_API_KEY }}
-          ADMIN_USER: ${{ secrets.ADMIN_USER }}
-          ADMIN_PASS: ${{ secrets.ADMIN_PASS }}
-          TMAP_APP_KEY: ${{ secrets.TMAP_APP_KEY }}
-          ALARM_SAVE_BLOCK_ID: ${{ secrets.ALARM_SAVE_BLOCK_ID }}
-          FAVORITE_ZONE_SAVE_BLOCK_ID: ${{ secrets.FAVORITE_ZONE_SAVE_BLOCK_ID }}
-          ROUTE_SETUP_BLOCK_ID: ${{ secrets.ROUTE_SETUP_BLOCK_ID }}
-          ROUTE_DELETE_BLOCK_ID: ${{ secrets.ROUTE_DELETE_BLOCK_ID }}
-          WORKS_AI_API_KEY: ${{ secrets.WORKS_AI_API_KEY }}
+          APP_NAME: ${{ env.APP_NAME }}
+          APP_ROOT: ${{ env.APP_ROOT }}
+          APP_BIND_HOST: ${{ env.APP_BIND_HOST }}
+          APP_PORT: ${{ env.APP_PORT }}
+          HEALTH_TIMEOUT_SECONDS: ${{ env.HEALTH_TIMEOUT_SECONDS }}
+          HEALTH_INTERVAL_SECONDS: ${{ env.HEALTH_INTERVAL_SECONDS }}
+          RELEASE_KEEP: ${{ env.RELEASE_KEEP }}
+          BUNDLE_NAME: ${{ env.BUNDLE_NAME }}
+          CHECKSUM_NAME: ${{ env.CHECKSUM_NAME }}
+          RELEASE_ID: ${{ github.run_id }}-${{ github.sha }}
         run: |
           set -euo pipefail
 
-          # SSH key
-          echo "$EC2_SSH_KEY" > ec2-key.pem
-          chmod 600 ec2-key.pem
-
-          # PUBLIC_DOMAIN 설정 확인
-          if [[ -z "${PUBLIC_DOMAIN}" ]]; then
-            echo "❌ PUBLIC_DOMAIN secret이 설정되지 않았습니다."
-            exit 1
-          fi
-
-          # Create .env on runner (printf prevents shell injection from special chars in secret values)
-          # 주의: 이 워크플로는 민감한 앱 설정만 .env로 전달하며, DATABASE_PATH 등 일부 기본/인프라 설정은 별도 설정(예: docker-compose.yml 또는 애플리케이션 기본값)에서 관리합니다.
-          printf '%s\n' \
-            "KAKAO_EVENT_API_KEY=${KAKAO_EVENT_API_KEY}" \
-            "KAKAO_LOCATION_API_KEY=${KAKAO_LOCATION_API_KEY}" \
-            "BOT_ID=${BOT_ID}" \
-            "API_KEY=${API_KEY}" \
-            "GEMINI_API_KEY=${GEMINI_API_KEY}" \
-            "SEOUL_BUS_API_KEY=${SEOUL_BUS_API_KEY}" \
-            "TMAP_APP_KEY=${TMAP_APP_KEY}" \
-            "ALARM_SAVE_BLOCK_ID=${ALARM_SAVE_BLOCK_ID}" \
-            "FAVORITE_ZONE_SAVE_BLOCK_ID=${FAVORITE_ZONE_SAVE_BLOCK_ID}" \
-            "ROUTE_SETUP_BLOCK_ID=${ROUTE_SETUP_BLOCK_ID}" \
-            "ROUTE_DELETE_BLOCK_ID=${ROUTE_DELETE_BLOCK_ID}" \
-            "RENDER_EXTERNAL_URL=https://${PUBLIC_DOMAIN}" \
-            "WORKS_AI_API_KEY=${WORKS_AI_API_KEY}" \
-            "ADMIN_USER=${ADMIN_USER}" \
-            "ADMIN_PASS=${ADMIN_PASS}" \
-            > .env
-
-          # Upload artifacts/config to EC2
-          scp -o StrictHostKeyChecking=no -i ec2-key.pem \
-            kt-demo-alarm-image.tar.gz \
-            ${EC2_USERNAME}@${EC2_HOST}:/opt/kt-demo-alarm/kt-demo-alarm-image.tar.gz
-
-          scp -o StrictHostKeyChecking=no -i ec2-key.pem \
-            docker-compose.yml .env \
-            ${EC2_USERNAME}@${EC2_HOST}:/opt/kt-demo-alarm/
-
-          # DOMAIN_PLACEHOLDER를 실제 도메인으로 치환한 뒤 EC2로 전송
-          # /tmp 대신 예측 불가능한 임시 파일 사용
-          NGINX_TMP=$(mktemp)
-          sed "s|DOMAIN_PLACEHOLDER|${PUBLIC_DOMAIN}|g" nginx/nginx.conf > "${NGINX_TMP}"
-          scp -o StrictHostKeyChecking=no -i ec2-key.pem \
-            "${NGINX_TMP}" \
-            ${EC2_USERNAME}@${EC2_HOST}:/opt/kt-demo-alarm/nginx-pending.conf
-          rm -f "${NGINX_TMP}"
-
-          # Remote deploy (improved: pre-prune + disk diagnostics + safer perms)
-          ssh -o StrictHostKeyChecking=no -i ec2-key.pem \
-            ${EC2_USERNAME}@${EC2_HOST} << 'ENDSSH'
-            set -euo pipefail
-            cd /opt/kt-demo-alarm
-
-            echo "=== Disk usage (before) ==="
-            df -h
-            docker system df || true
-
-            # Make directory with sudo and change owner to $USER
-            sudo mkdir -p data logs topis_attachments topis_cache
-            sudo chown -R $USER:$USER data logs topis_attachments topis_cache
-            chmod -R 755 data logs topis_attachments topis_cache || true
-
-            # Stop old stack (ignore if not running)
-            docker compose down || true
-
-            # Remove all unused images before loading the new release image.
-            docker image prune -af || true
-
-            echo "=== Disk usage (after prune) ==="
-            df -h
-            docker system df || true
-
-            # Load new image (uploaded as gzip)
-            gunzip -c /opt/kt-demo-alarm/kt-demo-alarm-image.tar.gz | docker load
-            rm -f /opt/kt-demo-alarm/kt-demo-alarm-image.tar.gz
-
-            # Protect env file (must succeed — failure means .env is readable by all users)
-            chmod 600 .env
-
-            # Start without building (important!)
-            docker compose up -d --no-build
-
-            # Nginx 설정 업데이트 (변경된 경우)
-            if [ -f /opt/kt-demo-alarm/nginx-pending.conf ]; then
-              sudo cp /opt/kt-demo-alarm/nginx-pending.conf /etc/nginx/conf.d/kt-demo-alarm.conf
-              sudo nginx -t && sudo systemctl reload nginx
-              rm -f /opt/kt-demo-alarm/nginx-pending.conf
-            fi
-
-            # Ensure appuser owns data and attachments inside container (don't fail deploy if container isn't ready yet)
-            docker compose exec -u root kt-demo-alarm \
-              chown -R appuser:appuser /app/data /app/topis_attachments /app/topis_cache || true
-
-            echo "Waiting for service health..."
-            service_healthy=0
-            for i in {1..60}; do
-              if curl -fsS http://localhost:8000/ > /dev/null 2>&1; then
-                echo "✅ Service is healthy on localhost:8000"
-                service_healthy=1
-                break
-              fi
-              echo "Attempt $i: not ready yet..."
-              sleep 5
-            done
-
-            if [ "$service_healthy" -ne 1 ]; then
-              echo "❌ Service did not become healthy on localhost:8000 within 300 seconds"
-              echo "docker compose ps:"
-              docker compose ps
-              echo "Recent logs:"
-              docker compose logs --tail=100
+          required_env=(EC2_HOST EC2_USERNAME EC2_SSH_KEY APP_NAME APP_ROOT RELEASE_ID)
+          for name in "${required_env[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error title=Missing deploy input::${name} is required"
               exit 1
             fi
-
-            echo "docker compose ps:"
-            docker compose ps
-
-            echo "Recent logs:"
-            docker compose logs --tail=100
-
-            echo "=== Disk usage (end) ==="
-            df -h
-            docker system df || true
-          ENDSSH
-
-          # Cleanup runner files
-          rm -f ec2-key.pem .env
-
-      - name: Verify deployment (public)
-        env:
-          PUBLIC_DOMAIN: ${{ secrets.PUBLIC_DOMAIN }}
-        run: |
-          set -euo pipefail
-          echo "Checking public health endpoint..."
-          for i in {1..60}; do
-            if curl -fsS https://${PUBLIC_DOMAIN}/ > /dev/null 2>&1; then
-              echo "✅ Application is reachable: https://${PUBLIC_DOMAIN}/"
-              exit 0
-            fi
-            echo "Attempt $i: waiting..."
-            sleep 5
           done
-          echo "❌ Public health check failed (verify Nginx + SSL + SG inbound 443 for ${PUBLIC_DOMAIN})"
-          exit 1
+
+          ssh_key_file="$(mktemp)"
+          trap 'rm -f -- "${ssh_key_file}"' EXIT
+          printf '%s\n' "${EC2_SSH_KEY}" > "${ssh_key_file}"
+          chmod 600 "${ssh_key_file}"
+
+          ssh_options=(
+            -o StrictHostKeyChecking=no
+            -o IdentitiesOnly=yes
+            -i "${ssh_key_file}"
+          )
+
+          quote_remote() {
+            printf '%q' "$1"
+          }
+
+          remote_incoming_dir="${APP_ROOT}/incoming/${RELEASE_ID}"
+          remote_incoming_dir_q="$(quote_remote "${remote_incoming_dir}")"
+          ssh "${ssh_options[@]}" "${EC2_USERNAME}@${EC2_HOST}" \
+            "mkdir -p ${remote_incoming_dir_q} && chmod 700 ${remote_incoming_dir_q}"
+
+          scp "${ssh_options[@]}" \
+            "release-artifact/${BUNDLE_NAME}" \
+            "release-artifact/${CHECKSUM_NAME}" \
+            deploy/native/deploy-release.sh \
+            "${EC2_USERNAME}@${EC2_HOST}:${remote_incoming_dir}/"
+
+          remote_deploy_command="$(
+            printf 'APP_NAME=%q APP_ROOT=%q APP_BIND_HOST=%q APP_PORT=%q HEALTH_TIMEOUT_SECONDS=%q HEALTH_INTERVAL_SECONDS=%q RELEASE_KEEP=%q RELEASE_ID=%q BUNDLE_PATH=%q CHECKSUM_PATH=%q bash %q' \
+              "${APP_NAME}" \
+              "${APP_ROOT}" \
+              "${APP_BIND_HOST}" \
+              "${APP_PORT}" \
+              "${HEALTH_TIMEOUT_SECONDS}" \
+              "${HEALTH_INTERVAL_SECONDS}" \
+              "${RELEASE_KEEP}" \
+              "${RELEASE_ID}" \
+              "${remote_incoming_dir}/${BUNDLE_NAME}" \
+              "${remote_incoming_dir}/${CHECKSUM_NAME}" \
+              "${remote_incoming_dir}/deploy-release.sh"
+          )"
+          ssh "${ssh_options[@]}" "${EC2_USERNAME}@${EC2_HOST}" \
+            "${remote_deploy_command}"
 
       - name: Notify deployment status
         if: always()
         run: |
-          if [ "${{ job.status }}" = "success" ]; then
-            echo "✅ Deployment successful!"
+          if [[ "${{ job.status }}" == "success" ]]; then
+            echo "✅ Native deployment completed."
           else
-            echo "❌ Deployment failed!"
+            echo "❌ Native deployment failed."
             exit 1
           fi
+
+# ---------------------------------------------------------------------------
+# Inactive legacy Docker deploy path retained for audit/handover only.
+# Do not uncomment without a new PRD and explicit operator approval.
+#
+# Previous active graph:
+#   deploy-test-bypass -> build -> deploy
+#
+# Previous Docker responsibilities:
+#   - docker/setup-buildx-action
+#   - docker/build-push-action with tags kt-demo-alarm:latest and kt-demo-alarm:${{ github.sha }}
+#   - gzip kt-demo-alarm-image.tar
+#   - upload/download Docker image artifact named docker-image
+#   - create runner-side app .env from GitHub secrets
+#   - scp kt-demo-alarm-image.tar.gz, docker-compose.yml, and .env to /opt/kt-demo-alarm
+#   - remote docker compose down
+#   - remote docker image prune
+#   - remote gunzip ... | docker load
+#   - remote docker compose up -d --no-build
+#   - public curl health check
+#
+# The active path above intentionally performs none of those Docker image or
+# Compose runtime actions. It packages source, verifies the bundle, syncs the
+# server-side uv environment, installs a verified systemd unit, switches the
+# current symlink, and performs local health before pruning old releases.
+# ---------------------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,9 @@ backup_oldfiles/
 *.md
 !README.md
 !DEPLOYMENT.md
+!docs/
+!docs/native-linux-deploy-guide.md
+!docs/docker-free-fastapi-deploy-runbook.md
 
 # Design files
 *.vuerd.json

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -70,13 +70,10 @@ class NotificationService:
         attendees = str(event.get("attendees") or "").strip() or "미상"
         if attendees != "미상" and attendees.isdigit() and not attendees.endswith("명"):
             attendees = f"{attendees}명"
-        desc = event.get("description")
-        desc_line = f"상세 내용 : {desc}\n" if desc and str(desc).strip() else ""
         return (
             f"{index}.\n"
             f"집회 일시 : {NotificationService._format_event_time_range(event)}\n"
             f"집회 장소 : {event['location']}\n"
-            f"{desc_line}"
             f"신고 인원 : {attendees}"
         )
 

--- a/deploy/native/README.md
+++ b/deploy/native/README.md
@@ -1,0 +1,65 @@
+# Native deployment scripts
+
+## Contract
+
+These scripts implement the active Docker-free deployment path for `kt-demo-alarm`.
+They expect GitHub Actions to upload a source bundle plus checksum and then execute
+`deploy-release.sh` on the target server.
+
+| Item | Default | Override |
+|---|---|---|
+| App root | `/opt/kt-demo-alarm` | `APP_ROOT` |
+| Releases | `${APP_ROOT}/releases` | `RELEASES_DIR` |
+| Active release | `${APP_ROOT}/current` | `CURRENT_LINK` |
+| Shared state | `${APP_ROOT}/shared` | `SHARED_DIR` |
+| Server-owned env | `${SHARED_DIR}/.env` | `ENV_FILE` |
+| Bind address | `127.0.0.1:8000` | `APP_BIND_HOST`, `APP_PORT` |
+| Service unit | `/etc/systemd/system/kt-demo-alarm.service` | `SERVICE_UNIT_PATH` |
+| `env` executable | `/usr/bin/env` | `ENV_BIN` |
+| uv executable | `uv` | `UV_BIN` |
+
+## Required server state
+
+| Requirement | Reason |
+|---|---|
+| `uv` is installed and on `PATH` or provided through `UV_BIN`. | `deploy-release.sh` runs `uv sync --frozen --no-dev`. |
+| `systemd` is available. | The app is started via `systemctl start/restart`. |
+| `APP_USER` and `APP_GROUP` exist. | The unit runs without root application privileges. |
+| `${ENV_FILE}` exists with no world-readable bits. | Secrets stay server-owned and are never copied from GitHub. |
+| Existing Docker runtime is stopped or `ALLOW_DOCKER_CUTOVER=true` is set for an approved transition. | Prevents duplicate scheduler/runtime execution. |
+
+## Source bundle requirements
+
+The bundle must contain `bundle-manifest.txt` and only allowlisted source paths:
+
+- `app/`
+- `main.py`
+- `pyproject.toml`
+- `uv.lock`
+- `.python-version`
+- `deploy/native/`
+- `docs/native-linux-deploy-guide.md`
+- `docs/docker-free-fastapi-deploy-runbook.md`
+- `nginx/` when present
+
+Denied paths include `.env*`, `.venv/`, cache directories, SQLite/DB files,
+attachments, `*.key`, `*.pem`, `id_rsa`, credentials, path traversal entries,
+and Docker image archives.
+
+## Rollback behavior
+
+| Branch | Behavior |
+|---|---|
+| Previous `current` exists | Restore the previous symlink, restart the service, remove the failed release, and exit non-zero. |
+| No previous `current` | Stop the native service if started, unlink failed `current`, remove the failed release, and exit non-zero without claiming rollback. |
+
+## Local verification
+
+Run these commands from the repository before relying on the workflow:
+
+```bash
+bash -n deploy/native/*.sh
+systemd-analyze verify <rendered-candidate-unit>
+```
+
+Do not print `.env` contents while debugging. Use `stat` for existence/mode only.

--- a/deploy/native/deploy-release.sh
+++ b/deploy/native/deploy-release.sh
@@ -1,0 +1,443 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="${APP_NAME:-kt-demo-alarm}"
+APP_ROOT="${APP_ROOT:-/opt/kt-demo-alarm}"
+RELEASE_ID="${RELEASE_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+RELEASES_DIR="${RELEASES_DIR:-${APP_ROOT}/releases}"
+CURRENT_LINK="${CURRENT_LINK:-${APP_ROOT}/current}"
+SHARED_DIR="${SHARED_DIR:-${APP_ROOT}/shared}"
+DATA_DIR="${DATA_DIR:-${SHARED_DIR}/data}"
+LOG_DIR="${LOG_DIR:-${SHARED_DIR}/logs}"
+CACHE_DIR="${CACHE_DIR:-${SHARED_DIR}/topis_cache}"
+ATTACHMENT_DIR="${ATTACHMENT_DIR:-${SHARED_DIR}/topis_attachments}"
+ENV_FILE="${ENV_FILE:-${SHARED_DIR}/.env}"
+APP_USER="${APP_USER:-${APP_NAME}}"
+APP_GROUP="${APP_GROUP:-${APP_USER}}"
+APP_BIND_HOST="${APP_BIND_HOST:-127.0.0.1}"
+APP_PORT="${APP_PORT:-8000}"
+DATABASE_PATH="${DATABASE_PATH:-${DATA_DIR}/kt_demo_alarm.db}"
+CACHE_FILE="${CACHE_FILE:-${CACHE_DIR}/topis_cache.json}"
+ATTACHMENT_FOLDER="${ATTACHMENT_FOLDER:-${ATTACHMENT_DIR}}"
+PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-${SHARED_DIR}/ms-playwright}"
+TZ="${TZ:-Asia/Seoul}"
+SERVICE_UNIT_PATH="${SERVICE_UNIT_PATH:-/etc/systemd/system/${APP_NAME}.service}"
+RELEASE_KEEP="${RELEASE_KEEP:-5}"
+HEALTH_URL="${HEALTH_URL:-http://${APP_BIND_HOST}:${APP_PORT}/}"
+HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-180}"
+HEALTH_INTERVAL_SECONDS="${HEALTH_INTERVAL_SECONDS:-3}"
+ALLOW_PORT_TAKEOVER="${ALLOW_PORT_TAKEOVER:-false}"
+ALLOW_DOCKER_CUTOVER="${ALLOW_DOCKER_CUTOVER:-false}"
+CHOWN_SHARED_DIRS="${CHOWN_SHARED_DIRS:-true}"
+UV_BIN="${UV_BIN:-uv}"
+ENV_BIN="${ENV_BIN:-/usr/bin/env}"
+SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
+SYSTEMD_ANALYZE_BIN="${SYSTEMD_ANALYZE_BIN:-systemd-analyze}"
+SUDO_BIN="${SUDO_BIN:-sudo}"
+BUNDLE_PATH="${BUNDLE_PATH:-}"
+CHECKSUM_PATH="${CHECKSUM_PATH:-}"
+
+RELEASE_DIR="${RELEASES_DIR}/${RELEASE_ID}"
+UNIT_CANDIDATE="${RELEASE_DIR}/${APP_NAME}.service.candidate"
+PREVIOUS_CURRENT=""
+DEPLOY_PHASE="pre-switch"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+fail() {
+  printf '[%s] ERROR: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
+  exit 1
+}
+
+is_truthy() {
+  case "${1,,}" in
+    1|true|yes|y|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+run_privileged() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  else
+    "${SUDO_BIN}" "$@"
+  fi
+}
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed -e 's/[&|\]/\\&/g'
+}
+
+safe_release_path() {
+  local path="$1"
+  [[ "${path}" == "${RELEASES_DIR}/"* ]] || fail "Refusing to modify non-release path: ${path}"
+  [[ "${path}" != "${RELEASES_DIR}" ]] || fail "Refusing to modify releases root"
+}
+
+safe_remove_release_dir() {
+  local path="$1"
+  safe_release_path "${path}"
+  if [[ -d "${path}" ]]; then
+    rm -r -- "${path}"
+  fi
+}
+
+cleanup_pre_switch_failure() {
+  local status=$?
+  if [[ "${status}" -ne 0 && "${DEPLOY_PHASE}" == "pre-switch" && -d "${RELEASE_DIR}" ]]; then
+    log "Cleaning failed pre-switch release directory: ${RELEASE_DIR}"
+    safe_remove_release_dir "${RELEASE_DIR}" || true
+  fi
+  exit "${status}"
+}
+
+trap cleanup_pre_switch_failure EXIT
+
+validate_inputs() {
+  [[ -n "${BUNDLE_PATH}" ]] || fail "BUNDLE_PATH is required"
+  [[ -n "${CHECKSUM_PATH}" ]] || fail "CHECKSUM_PATH is required"
+  [[ -f "${BUNDLE_PATH}" ]] || fail "Bundle not found: ${BUNDLE_PATH}"
+  [[ -f "${CHECKSUM_PATH}" ]] || fail "Checksum file not found: ${CHECKSUM_PATH}"
+  [[ "${RELEASE_ID}" =~ ^[A-Za-z0-9._-]+$ ]] || fail "RELEASE_ID contains unsafe characters"
+  [[ "${APP_PORT}" =~ ^[0-9]+$ ]] || fail "APP_PORT must be numeric"
+  [[ "${RELEASE_KEEP}" =~ ^[0-9]+$ ]] || fail "RELEASE_KEEP must be numeric"
+}
+
+preflight_commands() {
+  require_command tar
+  require_command sha256sum
+  require_command find
+  require_command stat
+  require_command sed
+  require_command "${UV_BIN}"
+  require_command "${ENV_BIN}"
+  require_command "${SYSTEMCTL_BIN}"
+  require_command "${SYSTEMD_ANALYZE_BIN}"
+  if [[ "$(id -u)" -ne 0 ]]; then
+    require_command "${SUDO_BIN}"
+  fi
+}
+
+native_service_active() {
+  "${SYSTEMCTL_BIN}" is-active --quiet "${APP_NAME}" >/dev/null 2>&1
+}
+
+preflight_runtime() {
+  if command -v ss >/dev/null 2>&1 && ss -ltn "sport = :${APP_PORT}" | grep -q LISTEN; then
+    if native_service_active; then
+      log "Port ${APP_PORT} is already used by active ${APP_NAME}; restart is allowed."
+    elif is_truthy "${ALLOW_PORT_TAKEOVER}"; then
+      log "ALLOW_PORT_TAKEOVER=true; continuing despite port ${APP_PORT} listener."
+    else
+      fail "Port ${APP_PORT} is occupied by a non-target process. Set ALLOW_PORT_TAKEOVER=true only for an approved cutover."
+    fi
+  fi
+
+  if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' 2>/dev/null | grep -Eq "(^|[-_])${APP_NAME}($|[-_])"; then
+    if is_truthy "${ALLOW_DOCKER_CUTOVER}"; then
+      log "ALLOW_DOCKER_CUTOVER=true; continuing with an existing Docker runtime visible."
+    else
+      fail "Existing Docker runtime for ${APP_NAME} is visible. Set ALLOW_DOCKER_CUTOVER=true only during an approved transition."
+    fi
+  fi
+
+  if ! id "${APP_USER}" >/dev/null 2>&1; then
+    fail "Service user does not exist: ${APP_USER}"
+  fi
+
+  if ! getent group "${APP_GROUP}" >/dev/null 2>&1; then
+    fail "Service group does not exist: ${APP_GROUP}"
+  fi
+}
+
+prepare_release_dirs() {
+  mkdir -p "${RELEASES_DIR}" "${SHARED_DIR}" "${DATA_DIR}" "${LOG_DIR}" "${CACHE_DIR}" "${ATTACHMENT_DIR}" "${DATA_DIR}/attachments"
+  [[ ! -e "${RELEASE_DIR}" ]] || fail "Release directory already exists: ${RELEASE_DIR}"
+  mkdir -p "${RELEASE_DIR}"
+
+  if is_truthy "${CHOWN_SHARED_DIRS}"; then
+    run_privileged chown -R "${APP_USER}:${APP_GROUP}" "${SHARED_DIR}"
+  fi
+}
+
+verify_checksum() {
+  local bundle_dir
+  bundle_dir="$(dirname "${BUNDLE_PATH}")"
+  (
+    cd "${bundle_dir}"
+    sha256sum -c "$(basename "${CHECKSUM_PATH}")"
+  )
+}
+
+path_is_allowed() {
+  local path="$1"
+  path="${path#./}"
+  path="${path%/}"
+
+  case "${path}" in
+    ""|bundle-manifest.txt|app|deploy|deploy/native|docs|nginx) return 0 ;;
+    app/*|deploy/native/*|nginx/*) return 0 ;;
+    main.py|pyproject.toml|uv.lock|.python-version) return 0 ;;
+    docs/native-linux-deploy-guide.md|docs/docker-free-fastapi-deploy-runbook.md) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+path_is_denied() {
+  local path="$1"
+  path="${path#./}"
+
+  case "${path}" in
+    /*|..|../*|*/../*|*/..) return 0 ;;
+    .env|.env.*|*/.env|*/.env.*) return 0 ;;
+    .venv|.venv/*|*/.venv|*/.venv/*) return 0 ;;
+    .pytest_cache|.pytest_cache/*|*/.pytest_cache|*/.pytest_cache/*) return 0 ;;
+    .ruff_cache|.ruff_cache/*|*/.ruff_cache|*/.ruff_cache/*) return 0 ;;
+    __pycache__|__pycache__/*|*/__pycache__|*/__pycache__/*) return 0 ;;
+    *.pyc|*.pyo) return 0 ;;
+    attachments|attachments/*|*/attachments|*/attachments/*) return 0 ;;
+    topis_attachments|topis_attachments/*|*/topis_attachments|*/topis_attachments/*) return 0 ;;
+    topis_cache|topis_cache/*|*/topis_cache|*/topis_cache/*) return 0 ;;
+    *.db|*.sqlite|*.sqlite3|*.key|*.pem|id_rsa|*/id_rsa|credentials.json|*/credentials.json) return 0 ;;
+    *-image.tar|*-image.tar.gz|*.image.tar|*.image.tar.gz) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+verify_bundle_manifest() {
+  local tar_list manifest_file manifest_list
+  tar_list="$(mktemp)"
+  manifest_file="$(mktemp)"
+  manifest_list="$(mktemp)"
+
+  tar -tzf "${BUNDLE_PATH}" | sed 's#^\./##' | sort > "${tar_list}"
+
+  if ! grep -Fxq bundle-manifest.txt "${tar_list}"; then
+    fail "bundle-manifest.txt is missing from source bundle"
+  fi
+
+  while IFS= read -r path; do
+    [[ -n "${path}" ]] || continue
+    if path_is_denied "${path}"; then
+      fail "Denied path found in bundle: ${path}"
+    fi
+    if ! path_is_allowed "${path}"; then
+      fail "Path outside source bundle allowlist: ${path}"
+    fi
+  done < "${tar_list}"
+
+  if tar -xOzf "${BUNDLE_PATH}" bundle-manifest.txt > "${manifest_file}.raw" 2>/dev/null; then
+    :
+  else
+    tar -xOzf "${BUNDLE_PATH}" ./bundle-manifest.txt > "${manifest_file}.raw"
+  fi
+  sed 's#^\./##' "${manifest_file}.raw" | sort > "${manifest_file}"
+  awk 'NF && $0 !~ /\/$/' "${tar_list}" > "${manifest_list}"
+  if ! diff -u "${manifest_file}" "${manifest_list}" >/dev/null; then
+    rm -f -- "${tar_list}" "${manifest_file}" "${manifest_file}.raw" "${manifest_list}"
+    fail "bundle-manifest.txt does not match packaged file list"
+  fi
+
+  rm -f -- "${tar_list}" "${manifest_file}" "${manifest_file}.raw" "${manifest_list}"
+}
+
+unpack_release() {
+  tar -xzf "${BUNDLE_PATH}" -C "${RELEASE_DIR}"
+  while IFS= read -r path; do
+    rel="${path#${RELEASE_DIR}/}"
+    if path_is_denied "${rel}"; then
+      fail "Denied path found after unpack: ${rel}"
+    fi
+  done < <(find "${RELEASE_DIR}" -mindepth 1 -print)
+}
+
+create_compat_symlinks() {
+  local shared_real target_real
+  shared_real="$(realpath -m "${SHARED_DIR}")"
+
+  declare -A links=(
+    ["topis_attachments"]="${ATTACHMENT_DIR}"
+    ["topis_cache"]="${CACHE_DIR}"
+    ["data"]="${DATA_DIR}"
+    ["logs"]="${LOG_DIR}"
+    ["attachments"]="${DATA_DIR}/attachments"
+  )
+
+  for link_name in "${!links[@]}"; do
+    local target="${links[${link_name}]}"
+    local link_path="${RELEASE_DIR}/${link_name}"
+    target_real="$(realpath -m "${target}")"
+    [[ "${target_real}" == "${shared_real}" || "${target_real}" == "${shared_real}/"* ]] \
+      || fail "Symlink target escapes shared directory: ${link_name} -> ${target}"
+    [[ ! -e "${link_path}" && ! -L "${link_path}" ]] || fail "Release path already exists: ${link_path}"
+    ln -s "${target}" "${link_path}"
+  done
+}
+
+check_env_file() {
+  [[ -f "${ENV_FILE}" ]] || fail "Server-owned env file is missing: ${ENV_FILE}"
+
+  local mode
+  mode="$(stat -c '%a' "${ENV_FILE}")"
+  if (( 8#${mode} & 0027 )); then
+    fail "Env file mode ${mode} is too open for ${ENV_FILE}; expected no group write/execute and no world access."
+  fi
+
+  log "Env file exists with acceptable mode ${mode}: ${ENV_FILE}"
+}
+
+sync_dependencies() {
+  (
+    cd "${RELEASE_DIR}"
+    "${UV_BIN}" sync --frozen --no-dev
+  )
+}
+
+render_systemd_unit() {
+  local template="${RELEASE_DIR}/deploy/native/kt-demo-alarm.service.template"
+  [[ -f "${template}" ]] || fail "systemd template missing: ${template}"
+
+  sed \
+    -e "s|__APP_USER__|$(escape_sed_replacement "${APP_USER}")|g" \
+    -e "s|__APP_GROUP__|$(escape_sed_replacement "${APP_GROUP}")|g" \
+    -e "s|__CURRENT_LINK__|$(escape_sed_replacement "${CURRENT_LINK}")|g" \
+    -e "s|__ENV_FILE__|$(escape_sed_replacement "${ENV_FILE}")|g" \
+    -e "s|__APP_BIND_HOST__|$(escape_sed_replacement "${APP_BIND_HOST}")|g" \
+    -e "s|__APP_PORT__|$(escape_sed_replacement "${APP_PORT}")|g" \
+    -e "s|__DATABASE_PATH__|$(escape_sed_replacement "${DATABASE_PATH}")|g" \
+    -e "s|__CACHE_FILE__|$(escape_sed_replacement "${CACHE_FILE}")|g" \
+    -e "s|__ATTACHMENT_FOLDER__|$(escape_sed_replacement "${ATTACHMENT_FOLDER}")|g" \
+    -e "s|__LOG_DIR__|$(escape_sed_replacement "${LOG_DIR}")|g" \
+    -e "s|__PLAYWRIGHT_BROWSERS_PATH__|$(escape_sed_replacement "${PLAYWRIGHT_BROWSERS_PATH}")|g" \
+    -e "s|__TZ__|$(escape_sed_replacement "${TZ}")|g" \
+    -e "s|__ENV_BIN__|$(escape_sed_replacement "${ENV_BIN}")|g" \
+    -e "s|__UV_BIN__|$(escape_sed_replacement "${UV_BIN}")|g" \
+    -e "s|__SHARED_DIR__|$(escape_sed_replacement "${SHARED_DIR}")|g" \
+    "${template}" > "${UNIT_CANDIDATE}"
+
+  "${SYSTEMD_ANALYZE_BIN}" verify "${UNIT_CANDIDATE}"
+}
+
+install_systemd_unit() {
+  local unit_dir
+  unit_dir="$(dirname "${SERVICE_UNIT_PATH}")"
+  if [[ -w "${unit_dir}" ]]; then
+    install -m 0644 "${UNIT_CANDIDATE}" "${SERVICE_UNIT_PATH}"
+  else
+    run_privileged install -m 0644 "${UNIT_CANDIDATE}" "${SERVICE_UNIT_PATH}"
+  fi
+  run_privileged "${SYSTEMCTL_BIN}" daemon-reload
+}
+
+capture_previous_current() {
+  if [[ -L "${CURRENT_LINK}" ]]; then
+    PREVIOUS_CURRENT="$(readlink -f "${CURRENT_LINK}")"
+    log "Previous current release: ${PREVIOUS_CURRENT}"
+  else
+    PREVIOUS_CURRENT=""
+    log "No previous current symlink exists; first native deploy rollback is limited."
+  fi
+}
+
+switch_current() {
+  local next_link="${CURRENT_LINK}.next"
+  ln -sfn "${RELEASE_DIR}" "${next_link}"
+  mv -Tf "${next_link}" "${CURRENT_LINK}"
+  DEPLOY_PHASE="post-switch"
+}
+
+restart_service() {
+  if native_service_active; then
+    run_privileged "${SYSTEMCTL_BIN}" restart "${APP_NAME}"
+  else
+    run_privileged "${SYSTEMCTL_BIN}" start "${APP_NAME}"
+  fi
+}
+
+rollback_after_switch() {
+  local reason="$1"
+  log "Post-switch failure: ${reason}"
+
+  if [[ -n "${PREVIOUS_CURRENT}" && -d "${PREVIOUS_CURRENT}" ]]; then
+    log "Restoring previous current symlink: ${PREVIOUS_CURRENT}"
+    ln -sfn "${PREVIOUS_CURRENT}" "${CURRENT_LINK}.rollback"
+    mv -Tf "${CURRENT_LINK}.rollback" "${CURRENT_LINK}"
+    run_privileged "${SYSTEMCTL_BIN}" restart "${APP_NAME}" || true
+    log "Rollback attempted; inspect service logs without printing secrets."
+  else
+    log "No previous current release exists; stopping native service and unlinking failed current."
+    run_privileged "${SYSTEMCTL_BIN}" stop "${APP_NAME}" || true
+    if [[ -L "${CURRENT_LINK}" ]]; then
+      rm -- "${CURRENT_LINK}"
+    fi
+  fi
+
+  safe_remove_release_dir "${RELEASE_DIR}" || true
+  exit 1
+}
+
+run_healthcheck() {
+  local healthcheck_script="${RELEASE_DIR}/deploy/native/healthcheck.sh"
+  [[ -x "${healthcheck_script}" ]] || chmod +x "${healthcheck_script}"
+
+  APP_BIND_HOST="${APP_BIND_HOST}" \
+  APP_PORT="${APP_PORT}" \
+  HEALTH_URL="${HEALTH_URL}" \
+  HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS}" \
+  HEALTH_INTERVAL_SECONDS="${HEALTH_INTERVAL_SECONDS}" \
+    "${healthcheck_script}"
+}
+
+prune_old_releases() {
+  (( RELEASE_KEEP > 0 )) || return 0
+
+  local current_real
+  current_real="$(readlink -f "${CURRENT_LINK}" 2>/dev/null || true)"
+  mapfile -t releases < <(find "${RELEASES_DIR}" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | cut -d' ' -f2-)
+
+  local kept=0
+  for release in "${releases[@]}"; do
+    if [[ "${release}" == "${current_real}" ]]; then
+      kept=$((kept + 1))
+      continue
+    fi
+
+    if (( kept < RELEASE_KEEP )); then
+      kept=$((kept + 1))
+      continue
+    fi
+
+    log "Pruning old release: ${release}"
+    safe_remove_release_dir "${release}"
+  done
+}
+
+main() {
+  validate_inputs
+  preflight_commands
+  preflight_runtime
+  prepare_release_dirs
+  verify_checksum
+  verify_bundle_manifest
+  unpack_release
+  create_compat_symlinks
+  check_env_file
+  sync_dependencies
+  render_systemd_unit
+  install_systemd_unit
+  capture_previous_current
+  switch_current
+  restart_service || rollback_after_switch "systemd start/restart failed"
+  run_healthcheck || rollback_after_switch "local health check failed"
+  prune_old_releases
+  DEPLOY_PHASE="complete"
+  log "Native deployment completed for release ${RELEASE_ID}"
+}
+
+main "$@"

--- a/deploy/native/healthcheck.sh
+++ b/deploy/native/healthcheck.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_BIND_HOST="${APP_BIND_HOST:-127.0.0.1}"
+APP_PORT="${APP_PORT:-8000}"
+HEALTH_URL="${HEALTH_URL:-http://${APP_BIND_HOST}:${APP_PORT}/}"
+HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-180}"
+HEALTH_INTERVAL_SECONDS="${HEALTH_INTERVAL_SECONDS:-3}"
+CURL_BIN="${CURL_BIN:-curl}"
+
+if ! [[ "${HEALTH_TIMEOUT_SECONDS}" =~ ^[0-9]+$ ]] || [[ "${HEALTH_TIMEOUT_SECONDS}" -lt 1 ]]; then
+  echo "HEALTH_TIMEOUT_SECONDS must be a positive integer" >&2
+  exit 2
+fi
+
+if ! [[ "${HEALTH_INTERVAL_SECONDS}" =~ ^[0-9]+$ ]] || [[ "${HEALTH_INTERVAL_SECONDS}" -lt 1 ]]; then
+  echo "HEALTH_INTERVAL_SECONDS must be a positive integer" >&2
+  exit 2
+fi
+
+deadline=$((SECONDS + HEALTH_TIMEOUT_SECONDS))
+attempt=1
+
+while (( SECONDS <= deadline )); do
+  if "${CURL_BIN}" -fsS "${HEALTH_URL}" >/dev/null; then
+    echo "Local health check succeeded: ${HEALTH_URL}"
+    exit 0
+  fi
+
+  echo "Health attempt ${attempt} failed; retrying in ${HEALTH_INTERVAL_SECONDS}s"
+  attempt=$((attempt + 1))
+  sleep "${HEALTH_INTERVAL_SECONDS}"
+done
+
+echo "Local health check failed within ${HEALTH_TIMEOUT_SECONDS}s: ${HEALTH_URL}" >&2
+exit 1

--- a/deploy/native/kt-demo-alarm.service.template
+++ b/deploy/native/kt-demo-alarm.service.template
@@ -1,0 +1,29 @@
+[Unit]
+Description=KT Demo Alarm FastAPI service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+User=__APP_USER__
+Group=__APP_GROUP__
+WorkingDirectory=__CURRENT_LINK__
+EnvironmentFile=__ENV_FILE__
+Environment=APP_BIND_HOST=__APP_BIND_HOST__
+Environment=APP_PORT=__APP_PORT__
+Environment=DATABASE_PATH=__DATABASE_PATH__
+Environment=CACHE_FILE=__CACHE_FILE__
+Environment=ATTACHMENT_FOLDER=__ATTACHMENT_FOLDER__
+Environment=LOG_DIR=__LOG_DIR__
+Environment=PLAYWRIGHT_BROWSERS_PATH=__PLAYWRIGHT_BROWSERS_PATH__
+Environment=TZ=__TZ__
+ExecStart=__ENV_BIN__ __UV_BIN__ run --no-sync --no-dev uvicorn main:app --host ${APP_BIND_HOST} --port ${APP_PORT}
+Restart=on-failure
+RestartSec=10
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+ReadWritePaths=__SHARED_DIR__
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/docker-free-fastapi-deploy-runbook.md
+++ b/docs/docker-free-fastapi-deploy-runbook.md
@@ -1,0 +1,103 @@
+# Docker-free FastAPI Deploy Runbook
+
+## 0. 목적
+
+이 runbook은 `kt-demo-alarm`을 Docker/Compose 없이 native Linux release로 배포할 때 운영자가 확인할 절차를 정리한다. 명령 예시는 secret 값을 포함하지 않으며, source bundle에는 `.env*`, `*.key`, `*.pem`, `id_rsa`, `credentials.json`이 들어가면 안 된다.
+
+## 1. 준비 체크리스트
+
+| 완료 | 항목 | 기준 |
+|---|---|---|
+| [ ] | 서비스 계정 | `APP_USER`/`APP_GROUP`이 존재 |
+| [ ] | uv | `uv --version` 또는 `UV_BIN`으로 실행 가능 |
+| [ ] | systemd | `systemctl`/`systemd-analyze` 실행 가능 |
+| [ ] | app root | `${APP_ROOT}` 생성 및 deploy user 접근 가능 |
+| [ ] | env file | `${SHARED_DIR}/.env` 존재, world-readable 아님 |
+| [ ] | single scheduler | 기존 Docker/AWS runtime과 native runtime이 동시에 장시간 실행되지 않도록 cutover window 확정 |
+
+`.env` 내용은 `cat`, `grep`, CI summary, issue, chat에 출력하지 않는다.
+
+## 2. 서버 디렉터리
+
+```text
+${APP_ROOT}/
+  incoming/
+  releases/
+  current -> releases/<release-id>
+  shared/
+    .env
+    data/
+      attachments/
+    logs/
+    topis_cache/
+    topis_attachments/
+    ms-playwright/
+```
+
+Shared state는 release pruning 대상이 아니다.
+
+## 3. Cutover 전 확인
+
+| Gate | Command 후보 | 통과 기준 |
+|---|---|---|
+| Env file mode | `stat -c '%a %U %G %n' "${SHARED_DIR}/.env"` | path/mode만 확인, world access 없음 |
+| Port | `ss -ltn sport = :8000` | 미사용 또는 target native service만 사용 |
+| Docker duplicate | `docker ps --format '{{.Names}}'` | 같은 앱 Docker runtime 없음, 또는 승인된 `ALLOW_DOCKER_CUTOVER=true` |
+| Native service | `systemctl status kt-demo-alarm --no-pager` | 첫 배포면 inactive 가능, 재배포면 target service만 active |
+| Public proxy | 운영 proxy 담당자 확인 | `/rally` public path 변경 없음 |
+
+## 4. GitHub Actions 배포 흐름
+
+| Step | 성공 조건 |
+|---|---|
+| `test` | `uv lock --check`, `uv run pytest` 통과 |
+| `package-source` | allowlisted source bundle과 SHA-256 checksum 생성 |
+| `deploy-native` | remote checksum/manifest 검증, `uv sync --frozen --no-dev`, systemd verify/install, local health 통과 |
+
+Deploy가 실패하면 workflow는 non-zero로 종료되어야 하며, 실패한 release를 active로 남기지 않는다.
+
+## 5. 수동 dry-run 후보
+
+운영 서버에서 bundle과 checksum을 받은 뒤 아래 형태로 실행한다. 값은 운영 환경에 맞게 조정한다.
+
+```bash
+APP_NAME="kt-demo-alarm" \
+APP_ROOT="/opt/kt-demo-alarm" \
+RELEASE_ID="<release-id>" \
+BUNDLE_PATH="/opt/kt-demo-alarm/incoming/<release-id>/source-bundle.tar.gz" \
+CHECKSUM_PATH="/opt/kt-demo-alarm/incoming/<release-id>/source-bundle.sha256" \
+bash /opt/kt-demo-alarm/incoming/<release-id>/deploy-release.sh
+```
+
+Planned cutover에서만 아래 override를 사용한다.
+
+| Override | 의미 |
+|---|---|
+| `ALLOW_PORT_TAKEOVER=true` | 기존 non-target port listener를 운영자가 확인했고 전환을 승인 |
+| `ALLOW_DOCKER_CUTOVER=true` | 기존 Docker runtime 존재를 운영자가 확인했고 전환을 승인 |
+
+## 6. 실패 대응
+
+| 실패 지점 | 조치 |
+|---|---|
+| checksum/manifest 실패 | artifact 오염 또는 packaging 오류로 간주; release switch 전 중단 |
+| `.env` missing/mode 실패 | 서버에서 env file을 준비/권한 수정한 뒤 재실행; 내용 출력 금지 |
+| `uv sync --frozen --no-dev` 실패 | lockfile/서버 Python/uv 상태 확인; service restart 금지 |
+| `systemd-analyze verify` 실패 | rendered candidate unit 확인; `/etc` 설치 전 중단 |
+| systemd start/restart 실패 | previous `current`가 있으면 restore 후 restart, 없으면 service stop/current unlink |
+| local health 실패 | previous `current`가 있으면 restore 후 restart, 없으면 service stop/current unlink |
+
+## 7. 정상 완료 확인
+
+| Check | Command 후보 |
+|---|---|
+| Active symlink | `readlink -f "${APP_ROOT}/current"` |
+| Service | `systemctl status kt-demo-alarm --no-pager` |
+| Local health | `curl -fsS http://127.0.0.1:8000/` |
+| Recent logs | `journalctl -u kt-demo-alarm -n 100 --no-pager` |
+
+Log review 중에도 secret values를 복사하거나 공유하지 않는다.
+
+## 8. Docker legacy policy
+
+`Dockerfile`과 `docker-compose.yml`은 삭제하지 않는다. 기존 Docker 배포 경로는 workflow의 inactive legacy comment block에만 남아 있으며, 재활성화하려면 새 PRD와 운영 승인 후 별도 변경으로 진행한다.

--- a/docs/native-linux-deploy-guide.md
+++ b/docs/native-linux-deploy-guide.md
@@ -1,0 +1,175 @@
+# Native Linux Deploy Guide — Docker-free active path
+
+## 0. 결론
+
+`kt-demo-alarm`의 active deploy path는 Docker image/Compose가 아니라 **source bundle → server-side `uv sync --frozen --no-dev` → systemd-managed `uvicorn main:app`** 방식이다.
+
+| 항목 | 결정 |
+|---|---|
+| Runtime | host Linux + systemd |
+| Process | `uvicorn main:app` |
+| Dependency gate | `uv sync --frozen --no-dev` |
+| Active release | `${APP_ROOT}/current` symlink |
+| Mutable state | `${APP_ROOT}/shared` |
+| Secret source | server-owned `${SHARED_DIR}/.env` only |
+| Public prefix | 기존 `/rally` 정책 유지; 이번 변경은 public URL/prefix를 바꾸지 않음 |
+| Legacy Docker | `Dockerfile`/`docker-compose.yml` 보존, workflow에서는 inactive comment block only |
+
+## 1. Release layout
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `APP_ROOT` | `/opt/kt-demo-alarm` | app home |
+| `RELEASES_DIR` | `${APP_ROOT}/releases` | immutable release directories |
+| `CURRENT_LINK` | `${APP_ROOT}/current` | systemd `WorkingDirectory` target |
+| `SHARED_DIR` | `${APP_ROOT}/shared` | release-independent mutable state |
+| `ENV_FILE` | `${SHARED_DIR}/.env` | server-owned app config/secrets |
+| `DATA_DIR` | `${SHARED_DIR}/data` | SQLite and data attachments |
+| `LOG_DIR` | `${SHARED_DIR}/logs` | application logs |
+| `CACHE_DIR` | `${SHARED_DIR}/topis_cache` | TOPIS cache |
+| `ATTACHMENT_DIR` | `${SHARED_DIR}/topis_attachments` | static attachments |
+
+The deploy script creates these compatibility symlinks inside each release:
+
+| Release path | Target |
+|---|---|
+| `${RELEASE_DIR}/topis_attachments` | `${SHARED_DIR}/topis_attachments` |
+| `${RELEASE_DIR}/topis_cache` | `${SHARED_DIR}/topis_cache` |
+| `${RELEASE_DIR}/data` | `${SHARED_DIR}/data` |
+| `${RELEASE_DIR}/logs` | `${SHARED_DIR}/logs` |
+| `${RELEASE_DIR}/attachments` | `${SHARED_DIR}/data/attachments` |
+
+All targets must resolve under `${SHARED_DIR}`. This preserves existing relative app paths without changing FastAPI business logic.
+
+## 2. GitHub Actions graph
+
+The workflow graph is fixed:
+
+```text
+test -> package-source -> deploy-native
+```
+
+| Job | Responsibility | Gate |
+|---|---|---|
+| `test` | checkout, Python from `.python-version`, uv setup, `uv lock --check`, `uv run pytest` | failure blocks packaging |
+| `package-source` | allowlisted source bundle, `bundle-manifest.txt`, SHA-256 checksum | `needs: test` |
+| `deploy-native` | remote checksum/manifest validation, release deploy, systemd restart, local health | `needs: package-source` |
+
+The active path must not build, load, or run Docker images. The old Docker path is retained only as an inactive workflow comment block for audit and handover context.
+
+## 3. Source bundle contract
+
+### Must include
+
+- `app/`
+- `main.py`
+- `pyproject.toml`
+- `uv.lock`
+- `.python-version`
+- `deploy/native/`
+- `docs/native-linux-deploy-guide.md`
+- `docs/docker-free-fastapi-deploy-runbook.md`
+- `nginx/` when present
+
+### Must exclude
+
+- `.env`, `.env.*`
+- `.venv/`
+- `.pytest_cache/`, `.ruff_cache/`, `__pycache__/`
+- `*.db`, `*.sqlite`, `*.sqlite3`
+- `attachments/`, `topis_attachments/`, `topis_cache/`
+- `*.key`, `*.pem`, `id_rsa`, `credentials.json`
+- Docker image tar/gzip artifacts
+
+The remote script verifies the checksum and manifest before switching `${CURRENT_LINK}`.
+
+## 4. Server preflight
+
+| Gate | Default behavior |
+|---|---|
+| `127.0.0.1:${APP_PORT}` occupied by non-target process | fail fast unless `ALLOW_PORT_TAKEOVER=true` is explicitly set for approved cutover |
+| Existing Docker runtime for same app | fail fast unless `ALLOW_DOCKER_CUTOVER=true` is explicitly set for approved transition |
+| Existing native service active | allowed when the service name matches `${APP_NAME}` |
+| `${ENV_FILE}` missing or too open | fail before dependency sync or restart; print path/mode only |
+| `APP_USER`/`APP_GROUP` missing | fail before release switch |
+| `uv`, `systemd`, `sha256sum`, `tar` missing | fail before release switch |
+
+Do not print `.env` contents. Use only existence and mode checks.
+
+## 5. Remote deploy order
+
+1. Validate inputs and command availability.
+2. Run port/Docker/native/env preflight.
+3. Prepare `${RELEASE_DIR}` and shared directories.
+4. Verify bundle checksum.
+5. Verify `bundle-manifest.txt` allowlist/denylist.
+6. Unpack source bundle.
+7. Re-check unpacked tree for denied paths.
+8. Create and validate compatibility symlinks.
+9. Check `${ENV_FILE}` exists and mode is acceptable.
+10. Run `uv sync --frozen --no-dev`.
+11. Render systemd candidate unit outside `/etc`.
+12. Run `systemd-analyze verify <candidate>`.
+13. Install unit and run `systemctl daemon-reload`.
+14. Switch `${CURRENT_LINK}` to the new release.
+15. Start or restart `${APP_NAME}`.
+16. Run local health against `http://127.0.0.1:8000/` by default.
+17. Prune old releases only after successful local health.
+
+## 6. systemd unit behavior
+
+The template is `deploy/native/kt-demo-alarm.service.template`.
+
+| Unit field | Contract |
+|---|---|
+| `WorkingDirectory` | rendered `${CURRENT_LINK}` |
+| `EnvironmentFile` | rendered `${ENV_FILE}` |
+| `ExecStart` | rendered `${ENV_BIN:-/usr/bin/env} ${UV_BIN:-uv} run --no-sync --no-dev uvicorn main:app --host ${APP_BIND_HOST} --port ${APP_PORT}` |
+| `ReadWritePaths` | rendered `${SHARED_DIR}` |
+| `UMask` | `0077` |
+| `Restart` | `on-failure` |
+
+`systemd-analyze verify` checks the rendered candidate before it is installed.
+
+## 7. Rollback
+
+| Branch | Behavior |
+|---|---|
+| Previous `current` exists | Restore previous symlink, restart service, remove failed release, exit non-zero. |
+| First native deploy, no previous `current` | Stop native service if started, unlink failed `current`, remove failed release, exit non-zero. Do not claim rollback. |
+| Successful deploy | Keep previous release for rollback and prune only old release directories after local health. Never prune `${SHARED_DIR}`. |
+
+Docker/public fallback is an operator runbook action, not an automatic workflow branch.
+
+## 8. Secret safety
+
+| Rule | Implementation |
+|---|---|
+| No app `.env` creation on GitHub runner | Workflow no longer renders app secrets into `.env`. |
+| No app `.env` upload | Deploy job uploads only source bundle, checksum, and deploy script. |
+| No secret summary/log output | Script prints path and mode only for `${ENV_FILE}`. |
+| Server-owned config | Operators prepare `${SHARED_DIR}/.env` on the server before cutover. |
+
+SSH key material is written only to a temporary runner file for the SSH connection and removed by a trap.
+
+## 9. Local verification
+
+Run from repository root:
+
+```bash
+uv run pytest
+python - <<'PY'
+from pathlib import Path
+import yaml
+yaml.safe_load(Path('.github/workflows/deploy.yml').read_text())
+print('workflow yaml ok')
+PY
+bash -n deploy/native/*.sh
+git check-ignore -v docs/native-linux-deploy-guide.md docs/docker-free-fastapi-deploy-runbook.md
+```
+
+`git check-ignore` must return no ignored result for the two required docs.
+
+## 10. Public `/rally` note
+
+This deploy path validates local app health only. Existing public `/rally` routing stays unchanged and remains a separate proxy/cutover gate. Do not change Kakao webhook or public URL settings as part of this deployment refactor.


### PR DESCRIPTION
Closes #143

## 요약

- active deploy workflow를 Docker image/Compose 경로에서 `test -> package-source -> deploy-native` native systemd release 경로로 전환했습니다.
- source bundle allowlist/denylist, `bundle-manifest.txt`, SHA-256 checksum, remote manifest 검증을 추가했습니다.
- server-side `uv sync --frozen --no-dev`, rendered systemd unit verify, `current` symlink switch, local health, rollback flow를 추가했습니다.
- GitHub runner에서 app `.env`를 생성/업로드하지 않도록 바꾸고, 서버 소유 `${SHARED_DIR}/.env` 계약을 문서화했습니다.
- restored pytest gate를 막던 notification template 회귀를 함께 수정했습니다.

## 검증

- [x] `uv run pytest` → 177 passed, 2 skipped
- [x] `git diff --check`
- [x] `uv lock --check`
- [x] workflow YAML/DAG parse: `test -> package-source -> deploy-native`
- [x] `bash -n deploy/native/*.sh`
- [x] rendered `systemd-analyze verify`
- [x] required docs `git add -n` tracking dry-run
- [x] active workflow Docker/app `.env` create/upload scan
- [x] local source bundle allowlist/denylist/checksum check
- [x] LSP diagnostics for `app/services/notification_service.py`: no diagnostics

## 운영 메모

- 실제 EC2 배포, real `systemctl restart/start`, target host local health는 이 PR 머지 후 운영 환경에서 확인해야 합니다.
- `Dockerfile` 및 `docker-compose.yml`은 삭제하지 않았고, 기존 Docker 배포 흐름은 workflow의 inactive legacy comment block으로만 보존했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced native Linux (systemd) deployment as an alternative to Docker-based deployment.

* **Documentation**
  * Added comprehensive deployment guides and operational runbooks for native Linux deployment procedures.

* **Bug Fixes**
  * Simplified event notification formatting by removing optional description field.

* **Chores**
  * Updated deployment pipeline infrastructure to support systemd-based releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoonly01/kt-demo-alarm/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->