### PR TITLE
Stabilize native EC2 deploy runtime selection and cutover contract

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -226,17 +226,21 @@ jobs:
           resolved_app_group="${APP_GROUP:-${resolved_app_user}}"
           remote_incoming_root="${APP_ROOT}/incoming"
           remote_incoming_dir="${remote_incoming_root}/${RELEASE_ID}"
+          remote_incoming_owner_q="$(quote_remote "${EC2_USERNAME}:${resolved_app_group}")"
           resolved_app_group_q="$(quote_remote "${resolved_app_group}")"
           remote_incoming_root_q="$(quote_remote "${remote_incoming_root}")"
           remote_incoming_dir_q="$(quote_remote "${remote_incoming_dir}")"
           ssh "${ssh_options[@]}" "${EC2_USERNAME}@${EC2_HOST}" \
             "set -euo pipefail
+            remote_incoming_owner=${remote_incoming_owner_q}
             resolved_app_group=${resolved_app_group_q}
             remote_incoming_root=${remote_incoming_root_q}
             remote_incoming_dir=${remote_incoming_dir_q}
             sudo mkdir -p \"\${remote_incoming_root}\" \"\${remote_incoming_dir}\"
             sudo chgrp \"\${resolved_app_group}\" \"\${remote_incoming_root}\" \"\${remote_incoming_dir}\"
+            sudo chown \"\${remote_incoming_owner}\" \"\${remote_incoming_dir}\"
             sudo chmod g+rx \"\${remote_incoming_root}\" \"\${remote_incoming_dir}\"
+            sudo chmod u+rwx \"\${remote_incoming_dir}\"
             sudo chmod g+s \"\${remote_incoming_root}\" \"\${remote_incoming_dir}\""
 
           scp "${ssh_options[@]}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -222,10 +222,22 @@ jobs:
             printf '%q' "$1"
           }
 
-          remote_incoming_dir="${APP_ROOT}/incoming/${RELEASE_ID}"
+          resolved_app_user="${APP_USER:-${APP_NAME}}"
+          resolved_app_group="${APP_GROUP:-${resolved_app_user}}"
+          remote_incoming_root="${APP_ROOT}/incoming"
+          remote_incoming_dir="${remote_incoming_root}/${RELEASE_ID}"
+          resolved_app_group_q="$(quote_remote "${resolved_app_group}")"
+          remote_incoming_root_q="$(quote_remote "${remote_incoming_root}")"
           remote_incoming_dir_q="$(quote_remote "${remote_incoming_dir}")"
           ssh "${ssh_options[@]}" "${EC2_USERNAME}@${EC2_HOST}" \
-            "mkdir -p ${remote_incoming_dir_q} && chmod 700 ${remote_incoming_dir_q}"
+            "set -euo pipefail
+            resolved_app_group=${resolved_app_group_q}
+            remote_incoming_root=${remote_incoming_root_q}
+            remote_incoming_dir=${remote_incoming_dir_q}
+            sudo mkdir -p \"\${remote_incoming_root}\" \"\${remote_incoming_dir}\"
+            sudo chgrp \"\${resolved_app_group}\" \"\${remote_incoming_root}\" \"\${remote_incoming_dir}\"
+            sudo chmod g+rx \"\${remote_incoming_root}\" \"\${remote_incoming_dir}\"
+            sudo chmod g+s \"\${remote_incoming_root}\" \"\${remote_incoming_dir}\""
 
           scp "${ssh_options[@]}" \
             "release-artifact/${BUNDLE_NAME}" \
@@ -235,8 +247,10 @@ jobs:
             "${EC2_USERNAME}@${EC2_HOST}:${remote_incoming_dir}/"
 
           remote_deploy_command="$(
-            printf 'APP_NAME=%q APP_ROOT=%q APP_BIND_HOST=%q APP_PORT=%q HEALTH_TIMEOUT_SECONDS=%q HEALTH_INTERVAL_SECONDS=%q RELEASE_KEEP=%q RELEASE_ID=%q BUNDLE_PATH=%q CHECKSUM_PATH=%q VERIFY_SOURCE_BUNDLE_BIN=%q bash %q' \
+            printf 'APP_NAME=%q APP_USER=%q APP_GROUP=%q APP_ROOT=%q APP_BIND_HOST=%q APP_PORT=%q HEALTH_TIMEOUT_SECONDS=%q HEALTH_INTERVAL_SECONDS=%q RELEASE_KEEP=%q RELEASE_ID=%q BUNDLE_PATH=%q CHECKSUM_PATH=%q VERIFY_SOURCE_BUNDLE_BIN=%q bash %q' \
               "${APP_NAME}" \
+              "${resolved_app_user}" \
+              "${resolved_app_group}" \
               "${APP_ROOT}" \
               "${APP_BIND_HOST}" \
               "${APP_PORT}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,7 +231,7 @@ jobs:
           remote_incoming_root_q="$(quote_remote "${remote_incoming_root}")"
           remote_incoming_dir_q="$(quote_remote "${remote_incoming_dir}")"
           ssh "${ssh_options[@]}" "${EC2_USERNAME}@${EC2_HOST}" \
-            "set -euo pipefail
+            "set -eu
             remote_incoming_owner=${remote_incoming_owner_q}
             resolved_app_group=${resolved_app_group_q}
             remote_incoming_root=${remote_incoming_root_q}
@@ -241,6 +241,7 @@ jobs:
             sudo chown \"\${remote_incoming_owner}\" \"\${remote_incoming_dir}\"
             sudo chmod g+rx \"\${remote_incoming_root}\" \"\${remote_incoming_dir}\"
             sudo chmod u+rwx \"\${remote_incoming_dir}\"
+            sudo chmod o-rwx \"\${remote_incoming_root}\" \"\${remote_incoming_dir}\"
             sudo chmod g+s \"\${remote_incoming_root}\" \"\${remote_incoming_dir}\""
 
           scp "${ssh_options[@]}" \

--- a/deploy/native/deploy-release.sh
+++ b/deploy/native/deploy-release.sh
@@ -32,6 +32,7 @@ ALLOW_PORT_TAKEOVER="${ALLOW_PORT_TAKEOVER:-false}"
 ALLOW_DOCKER_CUTOVER="${ALLOW_DOCKER_CUTOVER:-false}"
 CHOWN_SHARED_DIRS="${CHOWN_SHARED_DIRS:-true}"
 UV_BIN="${UV_BIN:-uv}"
+PYTHON_BIN="${PYTHON_BIN:-${KT_NATIVE_PYTHON_BIN:-python3}}"
 ENV_BIN="${ENV_BIN:-/usr/bin/env}"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
 SYSTEMD_ANALYZE_BIN="${SYSTEMD_ANALYZE_BIN:-systemd-analyze}"
@@ -122,6 +123,7 @@ preflight_commands() {
   require_command stat
   require_command sed
   require_command "${UV_BIN}"
+  require_command "${PYTHON_BIN}"
   require_command "${ENV_BIN}"
   require_command "${SYSTEMCTL_BIN}"
   require_command "${SYSTEMD_ANALYZE_BIN}"
@@ -129,6 +131,15 @@ preflight_commands() {
   if [[ "$(id -u)" -ne 0 ]]; then
     require_command "${SUDO_BIN}"
   fi
+}
+
+preflight_python() {
+  "${PYTHON_BIN}" - <<'PY'
+import sys
+
+if sys.version_info < (3, 12):
+    raise SystemExit("Python 3.12 or newer is required")
+PY
 }
 
 native_service_active() {
@@ -235,7 +246,7 @@ check_env_file() {
 sync_dependencies() {
   (
     cd "${RELEASE_DIR}"
-    "${UV_BIN}" sync --frozen --no-dev
+    "${UV_BIN}" sync --frozen --no-dev --python "${PYTHON_BIN}" --no-managed-python --no-python-downloads
   )
   normalize_release_tree_permissions
 }
@@ -398,6 +409,7 @@ prune_old_releases() {
 main() {
   validate_inputs
   preflight_commands
+  preflight_python
   preflight_runtime
   prepare_release_dirs
   verify_bundle_contract

--- a/deploy/native/deploy-release.sh
+++ b/deploy/native/deploy-release.sh
@@ -185,6 +185,7 @@ normalize_release_tree_permissions() {
   run_privileged find -P "${RELEASE_DIR}" -type d -exec chmod g+rx,g+s {} +
   run_privileged find -P "${RELEASE_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +
   run_privileged find -P "${RELEASE_DIR}" -type f -exec chmod g+r {} +
+  run_privileged find -P "${RELEASE_DIR}" -type f -perm /111 -exec chmod g+rx {} +
 }
 
 verify_bundle_contract() {
@@ -304,6 +305,7 @@ capture_runtime_diagnostics() {
   local path
   local -a diagnostic_paths=(
     "${CURRENT_LINK}"
+    "${CURRENT_LINK}/.venv/bin/uvicorn"
     "${RELEASE_DIR}"
     "${SHARED_DIR}"
     "${ENV_FILE}"

--- a/deploy/native/deploy-release.sh
+++ b/deploy/native/deploy-release.sh
@@ -277,7 +277,7 @@ prepare_managed_python_install_dir() {
 
 normalize_managed_python_install_permissions() {
   [[ "${PYTHON_MODE}" == "managed" ]] || return 0
-  run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -exec chmod g-w {} +
+  run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" \( -type d -o -type f \) -exec chmod g-w {} +
   run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chgrp "${APP_GROUP}" {} +
   run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chmod g+rx,g+s {} +
   run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +
@@ -336,7 +336,7 @@ normalize_release_root_permissions() {
 }
 
 normalize_release_tree_permissions() {
-  run_privileged find -P "${RELEASE_DIR}" -exec chmod g-w {} +
+  run_privileged find -P "${RELEASE_DIR}" \( -type d -o -type f \) -exec chmod g-w {} +
   run_privileged find -P "${RELEASE_DIR}" -type d -exec chgrp "${APP_GROUP}" {} +
   run_privileged find -P "${RELEASE_DIR}" -type d -exec chmod g+rx,g+s {} +
   run_privileged find -P "${RELEASE_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +

--- a/deploy/native/deploy-release.sh
+++ b/deploy/native/deploy-release.sh
@@ -164,10 +164,24 @@ prepare_release_dirs() {
   mkdir -p "${RELEASES_DIR}" "${SHARED_DIR}" "${DATA_DIR}" "${LOG_DIR}" "${CACHE_DIR}" "${ATTACHMENT_DIR}" "${DATA_DIR}/attachments"
   [[ ! -e "${RELEASE_DIR}" ]] || fail "Release directory already exists: ${RELEASE_DIR}"
   mkdir -p "${RELEASE_DIR}"
+  normalize_release_root_permissions
 
   if is_truthy "${CHOWN_SHARED_DIRS}"; then
     run_privileged chown -R "${APP_USER}:${APP_GROUP}" "${SHARED_DIR}"
   fi
+}
+
+normalize_release_root_permissions() {
+  run_privileged chgrp "${APP_GROUP}" "${RELEASES_DIR}" "${RELEASE_DIR}"
+  run_privileged chmod g+rx "${RELEASES_DIR}" "${RELEASE_DIR}"
+  run_privileged chmod g+s "${RELEASES_DIR}" "${RELEASE_DIR}"
+}
+
+normalize_release_tree_permissions() {
+  run_privileged find -P "${RELEASE_DIR}" -type d -exec chgrp "${APP_GROUP}" {} +
+  run_privileged find -P "${RELEASE_DIR}" -type d -exec chmod g+rx,g+s {} +
+  run_privileged find -P "${RELEASE_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +
+  run_privileged find -P "${RELEASE_DIR}" -type f -exec chmod g+r {} +
 }
 
 verify_bundle_contract() {
@@ -176,6 +190,7 @@ verify_bundle_contract() {
 
 unpack_release() {
   tar -xzf "${BUNDLE_PATH}" -C "${RELEASE_DIR}"
+  normalize_release_tree_permissions
 }
 
 create_compat_symlinks() {
@@ -218,6 +233,7 @@ sync_dependencies() {
     cd "${RELEASE_DIR}"
     "${UV_BIN}" sync --frozen --no-dev
   )
+  normalize_release_tree_permissions
 }
 
 render_systemd_unit() {

--- a/deploy/native/deploy-release.sh
+++ b/deploy/native/deploy-release.sh
@@ -35,7 +35,10 @@ UV_BIN="${UV_BIN:-uv}"
 ENV_BIN="${ENV_BIN:-/usr/bin/env}"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
 SYSTEMD_ANALYZE_BIN="${SYSTEMD_ANALYZE_BIN:-systemd-analyze}"
+JOURNALCTL_BIN="${JOURNALCTL_BIN:-journalctl}"
+NAMEI_BIN="${NAMEI_BIN:-namei}"
 SUDO_BIN="${SUDO_BIN:-sudo}"
+DIAGNOSTIC_JOURNAL_LINES="${DIAGNOSTIC_JOURNAL_LINES:-80}"
 BUNDLE_PATH="${BUNDLE_PATH:-}"
 CHECKSUM_PATH="${CHECKSUM_PATH:-}"
 VERIFY_SOURCE_BUNDLE_BIN="${VERIFY_SOURCE_BUNDLE_BIN:-${SCRIPT_DIR}/verify-source-bundle.sh}"
@@ -297,9 +300,43 @@ restart_service() {
   fi
 }
 
+capture_runtime_diagnostics() {
+  local path
+  local -a diagnostic_paths=(
+    "${CURRENT_LINK}"
+    "${RELEASE_DIR}"
+    "${SHARED_DIR}"
+    "${ENV_FILE}"
+    "${DATABASE_PATH}"
+    "${LOG_DIR}"
+    "${CACHE_FILE}"
+    "${ATTACHMENT_FOLDER}"
+  )
+
+  log "Capturing post-switch diagnostics for ${APP_NAME}"
+
+  run_privileged "${SYSTEMCTL_BIN}" --no-pager --full status "${APP_NAME}" || true
+
+  if command -v "${JOURNALCTL_BIN}" >/dev/null 2>&1; then
+    run_privileged "${JOURNALCTL_BIN}" --no-pager -u "${APP_NAME}" -n "${DIAGNOSTIC_JOURNAL_LINES}" || true
+  else
+    log "Skipping journal diagnostics because ${JOURNALCTL_BIN} is unavailable."
+  fi
+
+  if command -v "${NAMEI_BIN}" >/dev/null 2>&1; then
+    for path in "${diagnostic_paths[@]}"; do
+      log "namei -om ${path}"
+      "${NAMEI_BIN}" -om "${path}" || true
+    done
+  else
+    log "Skipping path diagnostics because ${NAMEI_BIN} is unavailable."
+  fi
+}
+
 rollback_after_switch() {
   local reason="$1"
   log "Post-switch failure: ${reason}"
+  capture_runtime_diagnostics
 
   if [[ -n "${PREVIOUS_CURRENT}" && -d "${PREVIOUS_CURRENT}" ]]; then
     log "Restoring previous current symlink: ${PREVIOUS_CURRENT}"

--- a/deploy/native/deploy-release.sh
+++ b/deploy/native/deploy-release.sh
@@ -305,6 +305,7 @@ capture_runtime_diagnostics() {
   local path
   local -a diagnostic_paths=(
     "${CURRENT_LINK}"
+    "${CURRENT_LINK}/.venv/bin/python"
     "${CURRENT_LINK}/.venv/bin/uvicorn"
     "${RELEASE_DIR}"
     "${SHARED_DIR}"

--- a/deploy/native/deploy-release.sh
+++ b/deploy/native/deploy-release.sh
@@ -37,6 +37,11 @@ if [[ -n "${PYTHON_BIN:-}" || -n "${KT_NATIVE_PYTHON_BIN:-}" ]]; then
   PYTHON_BIN_WAS_EXPLICIT=1
 fi
 PYTHON_BIN="${PYTHON_BIN:-${KT_NATIVE_PYTHON_BIN:-python3}}"
+PYTHON_REQUEST="${PYTHON_BIN}"
+PYTHON_MODE="system"
+MANAGED_PYTHON_VERSION="${MANAGED_PYTHON_VERSION:-3.12}"
+MANAGED_PYTHON_INSTALL_DIR="${UV_PYTHON_INSTALL_DIR:-${SHARED_DIR}/uv/python}"
+MANAGED_PYTHON_INSTALL_OWNER="${MANAGED_PYTHON_INSTALL_OWNER:-$(id -un)}"
 ENV_BIN="${ENV_BIN:-/usr/bin/env}"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
 SYSTEMD_ANALYZE_BIN="${SYSTEMD_ANALYZE_BIN:-systemd-analyze}"
@@ -122,6 +127,7 @@ validate_inputs() {
 }
 
 preflight_commands() {
+  require_command install
   require_command tar
   require_command find
   require_command stat
@@ -224,6 +230,8 @@ preflight_python() {
   local candidate
   local resolved_python_bin=""
   local -a candidates=("${PYTHON_BIN}")
+  PYTHON_MODE="system"
+  PYTHON_REQUEST="${PYTHON_BIN}"
   if [[ "${PYTHON_BIN_WAS_EXPLICIT}" != "1" ]]; then
     candidates+=("python3.12")
   fi
@@ -241,10 +249,30 @@ preflight_python() {
   done
 
   log_python_candidate_details "${PYTHON_BIN}"
-  if [[ "${PYTHON_BIN_WAS_EXPLICIT}" != "1" ]]; then
-    log_python_candidate_details "python3.12"
+  if [[ "${PYTHON_BIN_WAS_EXPLICIT}" == "1" ]]; then
+    fail "Python 3.12 or newer is required"
   fi
-  fail "Python 3.12 or newer is required"
+
+  log_python_candidate_details "python3.12"
+  PYTHON_MODE="managed"
+  PYTHON_REQUEST="${MANAGED_PYTHON_VERSION}"
+  log "Falling back to uv-managed Python ${MANAGED_PYTHON_VERSION} under ${MANAGED_PYTHON_INSTALL_DIR}"
+}
+
+prepare_managed_python_install_dir() {
+  [[ "${PYTHON_MODE}" == "managed" ]] || return 0
+  [[ "${MANAGED_PYTHON_INSTALL_DIR}" != "${HOME}/"* ]] \
+    || fail "Managed Python install dir must not live under HOME: ${MANAGED_PYTHON_INSTALL_DIR}"
+  run_privileged install -d -o "${MANAGED_PYTHON_INSTALL_OWNER}" -g "${APP_GROUP}" -m 2775 "${MANAGED_PYTHON_INSTALL_DIR}"
+}
+
+normalize_managed_python_install_permissions() {
+  [[ "${PYTHON_MODE}" == "managed" ]] || return 0
+  run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chgrp "${APP_GROUP}" {} +
+  run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chmod g+rx,g+s {} +
+  run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +
+  run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -exec chmod g+r {} +
+  run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -perm /111 -exec chmod g+rx {} +
 }
 
 native_service_active() {
@@ -288,6 +316,7 @@ prepare_release_dirs() {
   if is_truthy "${CHOWN_SHARED_DIRS}"; then
     run_privileged chown -R "${APP_USER}:${APP_GROUP}" "${SHARED_DIR}"
   fi
+  prepare_managed_python_install_dir
 }
 
 normalize_release_root_permissions() {
@@ -351,8 +380,14 @@ check_env_file() {
 sync_dependencies() {
   (
     cd "${RELEASE_DIR}"
-    "${UV_BIN}" sync --frozen --no-dev --python "${PYTHON_BIN}" --no-managed-python --no-python-downloads
+    if [[ "${PYTHON_MODE}" == "managed" ]]; then
+      UV_PYTHON_INSTALL_DIR="${MANAGED_PYTHON_INSTALL_DIR}" \
+        "${UV_BIN}" sync --frozen --no-dev --python "${PYTHON_REQUEST}" --managed-python
+    else
+      "${UV_BIN}" sync --frozen --no-dev --python "${PYTHON_REQUEST}" --no-managed-python --no-python-downloads
+    fi
   )
+  normalize_managed_python_install_permissions
   normalize_release_tree_permissions
 }
 
@@ -425,6 +460,7 @@ capture_runtime_diagnostics() {
     "${CURRENT_LINK}/.venv/bin/uvicorn"
     "${RELEASE_DIR}"
     "${SHARED_DIR}"
+    "${MANAGED_PYTHON_INSTALL_DIR}"
     "${ENV_FILE}"
     "${DATABASE_PATH}"
     "${LOG_DIR}"

--- a/deploy/native/deploy-release.sh
+++ b/deploy/native/deploy-release.sh
@@ -32,6 +32,10 @@ ALLOW_PORT_TAKEOVER="${ALLOW_PORT_TAKEOVER:-false}"
 ALLOW_DOCKER_CUTOVER="${ALLOW_DOCKER_CUTOVER:-false}"
 CHOWN_SHARED_DIRS="${CHOWN_SHARED_DIRS:-true}"
 UV_BIN="${UV_BIN:-uv}"
+PYTHON_BIN_WAS_EXPLICIT=0
+if [[ -n "${PYTHON_BIN:-}" || -n "${KT_NATIVE_PYTHON_BIN:-}" ]]; then
+  PYTHON_BIN_WAS_EXPLICIT=1
+fi
 PYTHON_BIN="${PYTHON_BIN:-${KT_NATIVE_PYTHON_BIN:-python3}}"
 ENV_BIN="${ENV_BIN:-/usr/bin/env}"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
@@ -123,7 +127,6 @@ preflight_commands() {
   require_command stat
   require_command sed
   require_command "${UV_BIN}"
-  require_command "${PYTHON_BIN}"
   require_command "${ENV_BIN}"
   require_command "${SYSTEMCTL_BIN}"
   require_command "${SYSTEMD_ANALYZE_BIN}"
@@ -133,13 +136,60 @@ preflight_commands() {
   fi
 }
 
-preflight_python() {
-  "${PYTHON_BIN}" - <<'PY'
+python_candidate_satisfies_contract() {
+  local candidate="$1"
+  command -v "${candidate}" >/dev/null 2>&1 || return 1
+  "${candidate}" - <<'PY' >/dev/null 2>&1
 import sys
 
 if sys.version_info < (3, 12):
-    raise SystemExit("Python 3.12 or newer is required")
+    raise SystemExit(1)
 PY
+}
+
+log_python_candidate_details() {
+  local candidate="$1"
+  local candidate_path
+  local candidate_summary
+  if ! command -v "${candidate}" >/dev/null 2>&1; then
+    log "Python candidate not found: ${candidate}"
+    return 0
+  fi
+
+  candidate_path="$(command -v "${candidate}")"
+  candidate_summary="$("${candidate}" - <<'PY'
+import pathlib
+import sys
+
+print(f"version={sys.version.split()[0]} executable={pathlib.Path(sys.executable).resolve()}")
+PY
+)" || candidate_summary="version-check failed"
+  log "Python candidate ${candidate} resolved to ${candidate_path} (${candidate_summary})"
+}
+
+preflight_python() {
+  local candidate
+  local -a candidates=("${PYTHON_BIN}")
+  if [[ "${PYTHON_BIN_WAS_EXPLICIT}" != "1" ]]; then
+    candidates+=("python3.12")
+  fi
+
+  for candidate in "${candidates[@]}"; do
+    if python_candidate_satisfies_contract "${candidate}"; then
+      if [[ "${candidate}" != "${PYTHON_BIN}" ]]; then
+        log "Using compatible system Python candidate ${candidate} instead of default ${PYTHON_BIN}"
+      fi
+      PYTHON_BIN="${candidate}"
+      log "Using system Python binary ${PYTHON_BIN} ($(command -v "${PYTHON_BIN}"))"
+      return 0
+    fi
+  done
+
+  log_python_candidate_details "${PYTHON_BIN}"
+  if [[ "${PYTHON_BIN_WAS_EXPLICIT}" != "1" ]]; then
+    log_python_candidate_details "python3.12"
+  fi
+  fail "Python 3.12 or newer is required"
 }
 
 native_service_active() {

--- a/deploy/native/deploy-release.sh
+++ b/deploy/native/deploy-release.sh
@@ -176,6 +176,13 @@ print(pathlib.Path(sys.executable).resolve())
 PY
 }
 
+path_is_under_home() {
+  local path="$1"
+  local home_prefix="${HOME:-}"
+  [[ -n "${home_prefix}" ]] || return 1
+  [[ "${path}" == "${home_prefix}/"* ]]
+}
+
 python_path_satisfies_contract() {
   local candidate_path="$1"
   local -a probe=()
@@ -186,7 +193,8 @@ python_path_satisfies_contract() {
   [[ -n "${candidate_executable}" ]] || return 1
   (( ${probe[0]:-0} == 3 )) || return 1
   (( ${probe[1]:-0} >= 12 )) || return 1
-  [[ "${candidate_executable}" != "${HOME}/"* ]] || return 1
+  path_is_under_home "${candidate_executable}" && return 1
+  return 0
 }
 
 resolve_python_candidate_path() {
@@ -243,6 +251,7 @@ preflight_python() {
         log "Using compatible system Python candidate ${candidate} instead of default ${PYTHON_BIN}"
       fi
       PYTHON_BIN="${resolved_python_bin}"
+      PYTHON_REQUEST="${PYTHON_BIN}"
       log "Using system Python binary ${PYTHON_BIN}"
       return 0
     fi
@@ -261,13 +270,14 @@ preflight_python() {
 
 prepare_managed_python_install_dir() {
   [[ "${PYTHON_MODE}" == "managed" ]] || return 0
-  [[ "${MANAGED_PYTHON_INSTALL_DIR}" != "${HOME}/"* ]] \
+  ! path_is_under_home "${MANAGED_PYTHON_INSTALL_DIR}" \
     || fail "Managed Python install dir must not live under HOME: ${MANAGED_PYTHON_INSTALL_DIR}"
   run_privileged install -d -o "${MANAGED_PYTHON_INSTALL_OWNER}" -g "${APP_GROUP}" -m 2775 "${MANAGED_PYTHON_INSTALL_DIR}"
 }
 
 normalize_managed_python_install_permissions() {
   [[ "${PYTHON_MODE}" == "managed" ]] || return 0
+  run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -exec chmod g-w {} +
   run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chgrp "${APP_GROUP}" {} +
   run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chmod g+rx,g+s {} +
   run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +
@@ -326,6 +336,7 @@ normalize_release_root_permissions() {
 }
 
 normalize_release_tree_permissions() {
+  run_privileged find -P "${RELEASE_DIR}" -exec chmod g-w {} +
   run_privileged find -P "${RELEASE_DIR}" -type d -exec chgrp "${APP_GROUP}" {} +
   run_privileged find -P "${RELEASE_DIR}" -type d -exec chmod g+rx,g+s {} +
   run_privileged find -P "${RELEASE_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +

--- a/deploy/native/deploy-release.sh
+++ b/deploy/native/deploy-release.sh
@@ -136,51 +136,106 @@ preflight_commands() {
   fi
 }
 
-python_candidate_satisfies_contract() {
+python_candidate_paths() {
   local candidate="$1"
-  command -v "${candidate}" >/dev/null 2>&1 || return 1
-  "${candidate}" - <<'PY' >/dev/null 2>&1
+  local path_dir
+  local candidate_path
+  local -a path_dirs=()
+
+  if [[ "${candidate}" == */* ]]; then
+    [[ -x "${candidate}" && ! -d "${candidate}" ]] && printf '%s\n' "${candidate}"
+    return 0
+  fi
+
+  IFS=':' read -r -a path_dirs <<< "${PATH}"
+  for path_dir in "${path_dirs[@]}"; do
+    if [[ -z "${path_dir}" ]]; then
+      candidate_path="./${candidate}"
+    else
+      candidate_path="${path_dir%/}/${candidate}"
+    fi
+    [[ -x "${candidate_path}" && ! -d "${candidate_path}" ]] && printf '%s\n' "${candidate_path}"
+  done
+}
+
+python_path_probe() {
+  local candidate_path="$1"
+  "${candidate_path}" - <<'PY'
+import pathlib
 import sys
 
-if sys.version_info < (3, 12):
-    raise SystemExit(1)
+print(sys.version_info[0])
+print(sys.version_info[1])
+print(pathlib.Path(sys.executable).resolve())
 PY
+}
+
+python_path_satisfies_contract() {
+  local candidate_path="$1"
+  local -a probe=()
+  local candidate_executable
+  mapfile -t probe < <(python_path_probe "${candidate_path}" 2>/dev/null) || return 1
+
+  candidate_executable="${probe[2]:-}"
+  [[ -n "${candidate_executable}" ]] || return 1
+  (( ${probe[0]:-0} == 3 )) || return 1
+  (( ${probe[1]:-0} >= 12 )) || return 1
+  [[ "${candidate_executable}" != "${HOME}/"* ]] || return 1
+}
+
+resolve_python_candidate_path() {
+  local candidate="$1"
+  local candidate_path
+  while IFS= read -r candidate_path; do
+    [[ -n "${candidate_path}" ]] || continue
+    if python_path_satisfies_contract "${candidate_path}"; then
+      printf '%s\n' "${candidate_path}"
+      return 0
+    fi
+  done < <(python_candidate_paths "${candidate}")
 }
 
 log_python_candidate_details() {
   local candidate="$1"
   local candidate_path
+  local -a candidate_paths=()
   local candidate_summary
-  if ! command -v "${candidate}" >/dev/null 2>&1; then
+  mapfile -t candidate_paths < <(python_candidate_paths "${candidate}")
+  if (( ${#candidate_paths[@]} == 0 )); then
     log "Python candidate not found: ${candidate}"
     return 0
   fi
 
-  candidate_path="$(command -v "${candidate}")"
-  candidate_summary="$("${candidate}" - <<'PY'
+  for candidate_path in "${candidate_paths[@]}"; do
+    candidate_summary="$("${candidate_path}" - <<'PY'
 import pathlib
 import sys
 
-print(f"version={sys.version.split()[0]} executable={pathlib.Path(sys.executable).resolve()}")
+resolved = pathlib.Path(sys.executable).resolve()
+location = "user-home" if str(resolved).startswith(str(pathlib.Path.home()) + "/") else "system"
+print(f"version={sys.version.split()[0]} executable={resolved} location={location}")
 PY
-)" || candidate_summary="version-check failed"
-  log "Python candidate ${candidate} resolved to ${candidate_path} (${candidate_summary})"
+)" || candidate_summary="probe failed"
+    log "Python candidate ${candidate} path ${candidate_path} (${candidate_summary})"
+  done
 }
 
 preflight_python() {
   local candidate
+  local resolved_python_bin=""
   local -a candidates=("${PYTHON_BIN}")
   if [[ "${PYTHON_BIN_WAS_EXPLICIT}" != "1" ]]; then
     candidates+=("python3.12")
   fi
 
   for candidate in "${candidates[@]}"; do
-    if python_candidate_satisfies_contract "${candidate}"; then
+    resolved_python_bin="$(resolve_python_candidate_path "${candidate}" || true)"
+    if [[ -n "${resolved_python_bin}" ]]; then
       if [[ "${candidate}" != "${PYTHON_BIN}" ]]; then
         log "Using compatible system Python candidate ${candidate} instead of default ${PYTHON_BIN}"
       fi
-      PYTHON_BIN="${candidate}"
-      log "Using system Python binary ${PYTHON_BIN} ($(command -v "${PYTHON_BIN}"))"
+      PYTHON_BIN="${resolved_python_bin}"
+      log "Using system Python binary ${PYTHON_BIN}"
       return 0
     fi
   done

--- a/deploy/native/kt-demo-alarm.service.template
+++ b/deploy/native/kt-demo-alarm.service.template
@@ -19,7 +19,7 @@ Environment=ATTACHMENT_FOLDER=__ATTACHMENT_FOLDER__
 Environment=LOG_DIR=__LOG_DIR__
 Environment=PLAYWRIGHT_BROWSERS_PATH=__PLAYWRIGHT_BROWSERS_PATH__
 Environment=TZ=__TZ__
-ExecStart=__ENV_BIN__ __UV_BIN__ run --no-sync --no-dev uvicorn main:app --host ${APP_BIND_HOST} --port ${APP_PORT}
+ExecStart=__CURRENT_LINK__/.venv/bin/uvicorn main:app --host ${APP_BIND_HOST} --port ${APP_PORT}
 Restart=on-failure
 RestartSec=10
 KillSignal=SIGINT

--- a/deploy/native/kt-demo-alarm.service.template
+++ b/deploy/native/kt-demo-alarm.service.template
@@ -19,7 +19,7 @@ Environment=ATTACHMENT_FOLDER=__ATTACHMENT_FOLDER__
 Environment=LOG_DIR=__LOG_DIR__
 Environment=PLAYWRIGHT_BROWSERS_PATH=__PLAYWRIGHT_BROWSERS_PATH__
 Environment=TZ=__TZ__
-ExecStart=__CURRENT_LINK__/.venv/bin/uvicorn main:app --host ${APP_BIND_HOST} --port ${APP_PORT}
+ExecStart=__CURRENT_LINK__/.venv/bin/python -m uvicorn main:app --host ${APP_BIND_HOST} --port ${APP_PORT}
 Restart=on-failure
 RestartSec=10
 KillSignal=SIGINT

--- a/scripts/native/setup-runtime.sh
+++ b/scripts/native/setup-runtime.sh
@@ -64,7 +64,7 @@ PY
 [[ -f uv.lock ]] || native_fail "uv.lock not found in ${repo_root}"
 
 native_info "Syncing production dependencies from uv.lock"
-"${KT_NATIVE_UV_BIN}" sync --frozen --no-dev
+"${KT_NATIVE_UV_BIN}" sync --frozen --no-dev --python "${KT_NATIVE_PYTHON_BIN}" --no-managed-python --no-python-downloads
 
 native_info "Preparing runtime directories"
 mkdir -p \

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -360,6 +360,34 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
         deploy_text,
         re.MULTILINE,
     )
+    assert re.search(
+        r'^\s*run_privileged "\$\{SYSTEMCTL_BIN\}" --no-pager --full status "\$\{APP_NAME\}" \|\| true$',
+        deploy_text,
+        re.MULTILINE,
+    )
+    assert re.search(
+        r'^\s*run_privileged "\$\{JOURNALCTL_BIN\}" --no-pager -u "\$\{APP_NAME\}" -n "\$\{DIAGNOSTIC_JOURNAL_LINES\}" \|\| true$',
+        deploy_text,
+        re.MULTILINE,
+    )
+    assert re.search(r'^\s*"\$\{NAMEI_BIN\}" -om "\$\{path\}" \|\| true$', deploy_text, re.MULTILINE)
+    rollback_match = re.search(r"rollback_after_switch\(\) \{\n(?P<body>.*?)\n\}", deploy_text, re.DOTALL)
+    assert rollback_match is not None
+    assert "capture_runtime_diagnostics" in rollback_match.group("body")
+    diagnostics_match = re.search(r"capture_runtime_diagnostics\(\) \{\n(?P<body>.*?)\n\}", deploy_text, re.DOTALL)
+    assert diagnostics_match is not None
+    diagnostics_body = diagnostics_match.group("body")
+    for required_path in (
+        '"${CURRENT_LINK}"',
+        '"${RELEASE_DIR}"',
+        '"${SHARED_DIR}"',
+        '"${ENV_FILE}"',
+        '"${DATABASE_PATH}"',
+        '"${LOG_DIR}"',
+        '"${CACHE_FILE}"',
+        '"${ATTACHMENT_FOLDER}"',
+    ):
+        assert required_path in diagnostics_body
 
 
 def test_deploy_release_script_normalizes_release_permissions_for_service_group() -> None:

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -342,6 +342,18 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
         deploy_text,
         re.MULTILINE,
     )
+    assert re.search(r'^\s*PYTHON_REQUEST="\$\{PYTHON_BIN\}"$', deploy_text, re.MULTILINE)
+    assert re.search(r'^\s*PYTHON_MODE="system"$', deploy_text, re.MULTILINE)
+    assert re.search(
+        r'^\s*MANAGED_PYTHON_VERSION="\$\{MANAGED_PYTHON_VERSION:-3\.12\}"$',
+        deploy_text,
+        re.MULTILINE,
+    )
+    assert re.search(
+        r'^\s*MANAGED_PYTHON_INSTALL_DIR="\$\{UV_PYTHON_INSTALL_DIR:-\$\{SHARED_DIR\}/uv/python\}"$',
+        deploy_text,
+        re.MULTILINE,
+    )
     assert re.search(
         r'^\s*UNIT_CANDIDATE="\$\{RELEASE_DIR\}/\$\{APP_NAME\}\.candidate\.service"$',
         deploy_text,
@@ -361,17 +373,17 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
     assert re.search(r"^\s*python_path_satisfies_contract\(\) \{$", deploy_text, re.MULTILINE)
     assert re.search(r"^\s*resolve_python_candidate_path\(\) \{$", deploy_text, re.MULTILINE)
     assert re.search(r"^\s*log_python_candidate_details\(\) \{$", deploy_text, re.MULTILINE)
+    assert re.search(r"^\s*prepare_managed_python_install_dir\(\) \{$", deploy_text, re.MULTILINE)
+    assert re.search(r"^\s*normalize_managed_python_install_permissions\(\) \{$", deploy_text, re.MULTILINE)
     assert 'location = "user-home"' in deploy_text
     assert 'candidates+=("python3.12")' in deploy_text
     assert 'Using compatible system Python candidate ${candidate} instead of default ${PYTHON_BIN}' in deploy_text
     assert 'Using system Python binary ${PYTHON_BIN}' in deploy_text
     assert 'log_python_candidate_details "python3.12"' in deploy_text
+    assert 'PYTHON_REQUEST="${MANAGED_PYTHON_VERSION}"' in deploy_text
+    assert 'log "Falling back to uv-managed Python ${MANAGED_PYTHON_VERSION} under ${MANAGED_PYTHON_INSTALL_DIR}"' in deploy_text
+    assert 'Managed Python install dir must not live under HOME: ${MANAGED_PYTHON_INSTALL_DIR}' in deploy_text
     assert "Python 3.12 or newer is required" in deploy_text
-    assert re.search(
-        r'^\s*"\$\{UV_BIN\}" sync --frozen --no-dev --python "\$\{PYTHON_BIN\}" --no-managed-python --no-python-downloads$',
-        deploy_text,
-        re.MULTILINE,
-    )
     assert re.search(r'^\s*"\$\{SYSTEMD_ANALYZE_BIN\}" verify "\$\{UNIT_CANDIDATE\}"$', deploy_text, re.MULTILINE)
     assert "resolve_runtime_uv_bin" not in deploy_text
     assert re.search(
@@ -407,6 +419,7 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
         '"${CURRENT_LINK}/.venv/bin/uvicorn"',
         '"${RELEASE_DIR}"',
         '"${SHARED_DIR}"',
+        '"${MANAGED_PYTHON_INSTALL_DIR}"',
         '"${ENV_FILE}"',
         '"${DATABASE_PATH}"',
         '"${LOG_DIR}"',
@@ -429,10 +442,17 @@ def test_deploy_release_script_normalizes_release_permissions_for_service_group(
     assert 'run_privileged find -P "${RELEASE_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +' in deploy_text
     assert 'run_privileged find -P "${RELEASE_DIR}" -type f -exec chmod g+r {} +' in deploy_text
     assert 'run_privileged find -P "${RELEASE_DIR}" -type f -perm /111 -exec chmod g+rx {} +' in deploy_text
+    assert 'run_privileged install -d -o "${MANAGED_PYTHON_INSTALL_OWNER}" -g "${APP_GROUP}" -m 2775 "${MANAGED_PYTHON_INSTALL_DIR}"' in deploy_text
+    assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chgrp "${APP_GROUP}" {} +' in deploy_text
+    assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chmod g+rx,g+s {} +' in deploy_text
+    assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +' in deploy_text
+    assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -exec chmod g+r {} +' in deploy_text
+    assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -perm /111 -exec chmod g+rx {} +' in deploy_text
 
     prepare_match = re.search(r"prepare_release_dirs\(\) \{\n(?P<body>.*?)\n\}", deploy_text, re.DOTALL)
     assert prepare_match is not None
     assert "normalize_release_root_permissions" in prepare_match.group("body")
+    assert "prepare_managed_python_install_dir" in prepare_match.group("body")
 
     unpack_match = re.search(r"unpack_release\(\) \{\n(?P<body>.*?)\n\}", deploy_text, re.DOTALL)
     assert unpack_match is not None
@@ -444,9 +464,10 @@ def test_deploy_release_script_normalizes_release_permissions_for_service_group(
     sync_match = re.search(r"sync_dependencies\(\) \{\n(?P<body>.*?)\n\}", deploy_text, re.DOTALL)
     assert sync_match is not None
     sync_body = sync_match.group("body")
-    assert sync_body.index(
-        '"${UV_BIN}" sync --frozen --no-dev --python "${PYTHON_BIN}" --no-managed-python --no-python-downloads'
-    ) < sync_body.index(
+    assert 'UV_PYTHON_INSTALL_DIR="${MANAGED_PYTHON_INSTALL_DIR}" \\' in sync_body
+    assert '"${UV_BIN}" sync --frozen --no-dev --python "${PYTHON_REQUEST}" --managed-python' in sync_body
+    assert '"${UV_BIN}" sync --frozen --no-dev --python "${PYTHON_REQUEST}" --no-managed-python --no-python-downloads' in sync_body
+    assert sync_body.index("normalize_managed_python_install_permissions") < sync_body.index(
         "normalize_release_tree_permissions"
     )
 
@@ -647,6 +668,74 @@ def test_uv_sync_uses_requested_system_python_for_project_venv(tmp_path: Path) -
     assert Path(runtime_info["base_executable"]).is_relative_to(managed_python_root) is False
 
 
+def test_uv_sync_can_use_custom_managed_python_install_dir_for_project_venv(tmp_path: Path) -> None:
+    uv_bin = shutil.which("uv")
+    assert uv_bin is not None
+
+    project_dir = tmp_path / "uv-managed-python-check"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "uv-managed-python-check"',
+                'version = "0.0.0"',
+                'requires-python = ">=3.12"',
+                "dependencies = []",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    managed_python_root = tmp_path / "shared-python"
+    env = {"UV_PYTHON_INSTALL_DIR": str(managed_python_root)}
+
+    _ = run_command(
+        uv_bin,
+        "lock",
+        "--python",
+        "3.12",
+        "--managed-python",
+        cwd=project_dir,
+        env=env,
+    )
+    _ = run_command(
+        uv_bin,
+        "sync",
+        "--frozen",
+        "--no-dev",
+        "--python",
+        "3.12",
+        "--managed-python",
+        cwd=project_dir,
+        env=env,
+    )
+
+    venv_python = project_dir / ".venv" / "bin" / "python"
+    assert venv_python.exists()
+
+    inspect = run_command(
+        str(venv_python),
+        "-c",
+        (
+            "import json, pathlib, sys; "
+            "print(json.dumps({"
+            "'executable': str(pathlib.Path(sys.executable).resolve()), "
+            "'base_executable': str(pathlib.Path(getattr(sys, '_base_executable', sys.executable)).resolve()), "
+            "'prefix': str(pathlib.Path(sys.prefix).resolve())"
+            "}))"
+        ),
+        cwd=project_dir,
+    )
+    runtime_info = json.loads(inspect.stdout)
+    base_executable = Path(runtime_info["base_executable"])
+    assert Path(runtime_info["prefix"]) == (project_dir / ".venv").resolve()
+    assert managed_python_root.exists()
+    assert base_executable.is_relative_to(managed_python_root.resolve())
+    assert base_executable.is_relative_to(Path.home() / ".local" / "share" / "uv" / "python") is False
+
+
 def test_deploy_release_preflight_prefers_python312_candidate_when_default_python3_fails(
     tmp_path: Path,
 ) -> None:
@@ -660,7 +749,7 @@ def test_deploy_release_preflight_prefers_python312_candidate_when_default_pytho
     fake_python3.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
     fake_python3.chmod(0o755)
     (fake_bin / "python3.12").symlink_to(Path(system_python).resolve())
-    for helper in ("bash", "date", "dirname"):
+    for helper in ("bash", "date", "dirname", "id"):
         helper_path = shutil.which(helper)
         assert helper_path is not None
         (fake_bin / helper).symlink_to(Path(helper_path).resolve())
@@ -684,6 +773,51 @@ def test_deploy_release_preflight_prefers_python312_candidate_when_default_pytho
     assert "Using compatible system Python candidate python3.12 instead of default python3" in result.stdout
     assert f"Using system Python binary {fake_bin / 'python3.12'}" in result.stdout
     assert f"selected={fake_bin / 'python3.12'}" in result.stdout
+
+
+def test_deploy_release_preflight_falls_back_to_shared_managed_python_when_no_system_candidate(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    fake_python3 = fake_bin / "python3"
+    fake_python3.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+    fake_python3.chmod(0o755)
+    for helper in ("bash", "date", "dirname", "id"):
+        helper_path = shutil.which(helper)
+        assert helper_path is not None
+        (fake_bin / helper).symlink_to(Path(helper_path).resolve())
+
+    script_copy = tmp_path / "deploy-release-preflight-managed.sh"
+    script_copy.write_text(
+        DEPLOY_SCRIPT.read_text(encoding="utf-8").replace(
+            'main "$@"',
+            (
+                'preflight_python\n'
+                'printf "mode=%s\\nrequest=%s\\ndir=%s\\n" '
+                '"${PYTHON_MODE}" "${PYTHON_REQUEST}" "${MANAGED_PYTHON_INSTALL_DIR}"'
+            ),
+        ),
+        encoding="utf-8",
+    )
+    script_copy.chmod(0o755)
+
+    shared_dir = tmp_path / "shared"
+    result = run_command(
+        "bash",
+        str(script_copy),
+        env={
+            "PATH": str(fake_bin),
+            "HOME": str(tmp_path / "home"),
+            "SHARED_DIR": str(shared_dir),
+        },
+    )
+
+    assert f"Falling back to uv-managed Python 3.12 under {shared_dir / 'uv' / 'python'}" in result.stdout
+    assert "mode=managed" in result.stdout
+    assert "request=3.12" in result.stdout
+    assert f"dir={shared_dir / 'uv' / 'python'}" in result.stdout
 
 
 def test_active_native_docs_retire_advisory_lane() -> None:

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -354,8 +354,15 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
         deploy_text,
         re.MULTILINE,
     )
-    assert re.search(r'^\s*require_command "\$\{PYTHON_BIN\}"$', deploy_text, re.MULTILINE)
-    assert re.search(r'''^\s*"\$\{PYTHON_BIN\}" - <<'PY'$''', deploy_text, re.MULTILINE)
+    assert "PYTHON_BIN_WAS_EXPLICIT=0" in deploy_text
+    assert 'if [[ -n "${PYTHON_BIN:-}" || -n "${KT_NATIVE_PYTHON_BIN:-}" ]]; then' in deploy_text
+    assert re.search(r"^\s*python_candidate_satisfies_contract\(\) \{$", deploy_text, re.MULTILINE)
+    assert re.search(r"^\s*log_python_candidate_details\(\) \{$", deploy_text, re.MULTILINE)
+    assert '"${candidate}" - <<\'PY\'' in deploy_text
+    assert 'candidates+=("python3.12")' in deploy_text
+    assert 'Using compatible system Python candidate ${candidate} instead of default ${PYTHON_BIN}' in deploy_text
+    assert 'Using system Python binary ${PYTHON_BIN} ($(command -v "${PYTHON_BIN}"))' in deploy_text
+    assert 'log_python_candidate_details "python3.12"' in deploy_text
     assert "Python 3.12 or newer is required" in deploy_text
     assert re.search(
         r'^\s*"\$\{UV_BIN\}" sync --frozen --no-dev --python "\$\{PYTHON_BIN\}" --no-managed-python --no-python-downloads$',
@@ -635,6 +642,38 @@ def test_uv_sync_uses_requested_system_python_for_project_venv(tmp_path: Path) -
     assert Path(runtime_info["prefix"]) == (project_dir / ".venv").resolve()
     assert Path(runtime_info["base_executable"]) == requested_python
     assert Path(runtime_info["base_executable"]).is_relative_to(managed_python_root) is False
+
+
+def test_deploy_release_preflight_prefers_python312_candidate_when_default_python3_fails(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    fake_python3 = fake_bin / "python3"
+    fake_python3.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+    fake_python3.chmod(0o755)
+    (fake_bin / "python3.12").symlink_to(Path(sys.executable).resolve())
+
+    script_copy = tmp_path / "deploy-release-preflight.sh"
+    script_copy.write_text(
+        DEPLOY_SCRIPT.read_text(encoding="utf-8").replace(
+            'main "$@"',
+            'preflight_python\nprintf "selected=%s\\n" "${PYTHON_BIN}"',
+        ),
+        encoding="utf-8",
+    )
+    script_copy.chmod(0o755)
+
+    result = run_command(
+        "bash",
+        str(script_copy),
+        env={"PATH": f"{fake_bin}:{os.environ['PATH']}"},
+    )
+
+    assert "Using compatible system Python candidate python3.12 instead of default python3" in result.stdout
+    assert "Using system Python binary python3.12" in result.stdout
+    assert "selected=python3.12" in result.stdout
 
 
 def test_active_native_docs_retire_advisory_lane() -> None:

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -337,6 +337,11 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
     deploy_text = uncommented_text(DEPLOY_SCRIPT)
 
     assert re.search(
+        r'^\s*PYTHON_BIN="\$\{PYTHON_BIN:-\$\{KT_NATIVE_PYTHON_BIN:-python3\}\}"$',
+        deploy_text,
+        re.MULTILINE,
+    )
+    assert re.search(
         r'^\s*UNIT_CANDIDATE="\$\{RELEASE_DIR\}/\$\{APP_NAME\}\.candidate\.service"$',
         deploy_text,
         re.MULTILINE,
@@ -348,7 +353,14 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
         deploy_text,
         re.MULTILINE,
     )
-    assert re.search(r'^\s*"\$\{UV_BIN\}" sync --frozen --no-dev$', deploy_text, re.MULTILINE)
+    assert re.search(r'^\s*require_command "\$\{PYTHON_BIN\}"$', deploy_text, re.MULTILINE)
+    assert re.search(r'''^\s*"\$\{PYTHON_BIN\}" - <<'PY'$''', deploy_text, re.MULTILINE)
+    assert "Python 3.12 or newer is required" in deploy_text
+    assert re.search(
+        r'^\s*"\$\{UV_BIN\}" sync --frozen --no-dev --python "\$\{PYTHON_BIN\}" --no-managed-python --no-python-downloads$',
+        deploy_text,
+        re.MULTILINE,
+    )
     assert re.search(r'^\s*"\$\{SYSTEMD_ANALYZE_BIN\}" verify "\$\{UNIT_CANDIDATE\}"$', deploy_text, re.MULTILINE)
     assert "resolve_runtime_uv_bin" not in deploy_text
     assert re.search(
@@ -421,7 +433,9 @@ def test_deploy_release_script_normalizes_release_permissions_for_service_group(
     sync_match = re.search(r"sync_dependencies\(\) \{\n(?P<body>.*?)\n\}", deploy_text, re.DOTALL)
     assert sync_match is not None
     sync_body = sync_match.group("body")
-    assert sync_body.index('"${UV_BIN}" sync --frozen --no-dev') < sync_body.index(
+    assert sync_body.index(
+        '"${UV_BIN}" sync --frozen --no-dev --python "${PYTHON_BIN}" --no-managed-python --no-python-downloads'
+    ) < sync_body.index(
         "normalize_release_tree_permissions"
     )
 
@@ -535,7 +549,11 @@ def test_preflight_reports_conflicts_without_service_mutation() -> None:
 def test_setup_runtime_contains_required_uv_and_playwright_paths() -> None:
     setup_text = uncommented_text(SCRIPT_DIR / "setup-runtime.sh")
 
-    assert re.search(r'^\s*"\$\{KT_NATIVE_UV_BIN\}" sync --frozen --no-dev$', setup_text, re.MULTILINE)
+    assert re.search(
+        r'^\s*"\$\{KT_NATIVE_UV_BIN\}" sync --frozen --no-dev --python "\$\{KT_NATIVE_PYTHON_BIN\}" --no-managed-python --no-python-downloads$',
+        setup_text,
+        re.MULTILINE,
+    )
     assert re.search(
         r'^\s*"\$\{KT_NATIVE_UV_BIN\}" run --no-dev playwright install chromium --with-deps$',
         setup_text,

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import shutil
@@ -566,6 +567,74 @@ def test_setup_runtime_contains_required_uv_and_playwright_paths() -> None:
     )
     assert re.search(r'^\s*\[\[ -x \.venv/bin/uvicorn \]\] \|\| native_fail ', setup_text, re.MULTILINE)
     assert "may also install supported OS dependencies" in setup_text
+
+
+def test_uv_sync_uses_requested_system_python_for_project_venv(tmp_path: Path) -> None:
+    uv_bin = shutil.which("uv")
+    python_bin = shutil.which("python3")
+    assert uv_bin is not None
+    assert python_bin is not None
+
+    project_dir = tmp_path / "uv-system-python-check"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "uv-system-python-check"',
+                'version = "0.0.0"',
+                'requires-python = ">=3.12"',
+                "dependencies = []",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    requested_python = Path(python_bin).resolve()
+    managed_python_root = Path.home() / ".local" / "share" / "uv" / "python"
+
+    _ = run_command(
+        uv_bin,
+        "lock",
+        "--python",
+        str(requested_python),
+        "--no-managed-python",
+        "--no-python-downloads",
+        cwd=project_dir,
+    )
+    _ = run_command(
+        uv_bin,
+        "sync",
+        "--frozen",
+        "--no-dev",
+        "--python",
+        str(requested_python),
+        "--no-managed-python",
+        "--no-python-downloads",
+        cwd=project_dir,
+    )
+
+    venv_python = project_dir / ".venv" / "bin" / "python"
+    assert venv_python.exists()
+
+    inspect = run_command(
+        str(venv_python),
+        "-c",
+        (
+            "import json, pathlib, sys; "
+            "print(json.dumps({"
+            "'executable': str(pathlib.Path(sys.executable).resolve()), "
+            "'base_executable': str(pathlib.Path(getattr(sys, '_base_executable', sys.executable)).resolve()), "
+            "'prefix': str(pathlib.Path(sys.prefix).resolve())"
+            "}))"
+        ),
+        cwd=project_dir,
+    )
+    runtime_info = json.loads(inspect.stdout)
+    assert Path(runtime_info["prefix"]) == (project_dir / ".venv").resolve()
+    assert Path(runtime_info["base_executable"]) == requested_python
+    assert Path(runtime_info["base_executable"]).is_relative_to(managed_python_root) is False
 
 
 def test_active_native_docs_retire_advisory_lane() -> None:

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -468,6 +468,10 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
 
 def test_deploy_release_script_normalizes_release_permissions_for_service_group() -> None:
     deploy_text = uncommented_text(DEPLOY_SCRIPT)
+    safe_managed_chmod = (
+        'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" \\( -type d -o -type f \\) -exec chmod g-w {} +'
+    )
+    safe_release_chmod = 'run_privileged find -P "${RELEASE_DIR}" \\( -type d -o -type f \\) -exec chmod g-w {} +'
 
     assert re.search(r"^\s*normalize_release_root_permissions\(\) \{$", deploy_text, re.MULTILINE)
     assert 'run_privileged chgrp "${APP_GROUP}" "${RELEASES_DIR}" "${RELEASE_DIR}"' in deploy_text
@@ -480,13 +484,15 @@ def test_deploy_release_script_normalizes_release_permissions_for_service_group(
     assert 'run_privileged find -P "${RELEASE_DIR}" -type f -exec chmod g+r {} +' in deploy_text
     assert 'run_privileged find -P "${RELEASE_DIR}" -type f -perm /111 -exec chmod g+rx {} +' in deploy_text
     assert 'run_privileged install -d -o "${MANAGED_PYTHON_INSTALL_OWNER}" -g "${APP_GROUP}" -m 2775 "${MANAGED_PYTHON_INSTALL_DIR}"' in deploy_text
-    assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -exec chmod g-w {} +' in deploy_text
+    assert safe_managed_chmod in deploy_text
+    assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -exec chmod g-w {} +' not in deploy_text
     assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chgrp "${APP_GROUP}" {} +' in deploy_text
     assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chmod g+rx,g+s {} +' in deploy_text
     assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +' in deploy_text
     assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -exec chmod g+r {} +' in deploy_text
     assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -perm /111 -exec chmod g+rx {} +' in deploy_text
-    assert 'run_privileged find -P "${RELEASE_DIR}" -exec chmod g-w {} +' in deploy_text
+    assert safe_release_chmod in deploy_text
+    assert 'run_privileged find -P "${RELEASE_DIR}" -exec chmod g-w {} +' not in deploy_text
 
     managed_match = re.search(
         r"normalize_managed_python_install_permissions\(\) \{\n(?P<body>.*?)\n\}",
@@ -495,7 +501,7 @@ def test_deploy_release_script_normalizes_release_permissions_for_service_group(
     )
     assert managed_match is not None
     managed_body = managed_match.group("body")
-    assert managed_body.index('run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -exec chmod g-w {} +') < managed_body.index(
+    assert managed_body.index(safe_managed_chmod) < managed_body.index(
         'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chmod g+rx,g+s {} +'
     )
 
@@ -506,7 +512,7 @@ def test_deploy_release_script_normalizes_release_permissions_for_service_group(
     )
     assert release_tree_match is not None
     release_tree_body = release_tree_match.group("body")
-    assert release_tree_body.index('run_privileged find -P "${RELEASE_DIR}" -exec chmod g-w {} +') < release_tree_body.index(
+    assert release_tree_body.index(safe_release_chmod) < release_tree_body.index(
         'run_privileged find -P "${RELEASE_DIR}" -type d -exec chmod g+rx,g+s {} +'
     )
 
@@ -531,6 +537,59 @@ def test_deploy_release_script_normalizes_release_permissions_for_service_group(
     assert sync_body.index("normalize_managed_python_install_permissions") < sync_body.index(
         "normalize_release_tree_permissions"
     )
+
+
+def test_safe_find_chmod_normalization_skips_symlink_targets_outside_root(tmp_path: Path) -> None:
+    normalization_root = tmp_path / "normalization-root"
+    normalization_root.mkdir()
+    inside_file = normalization_root / "inside-file.txt"
+    inside_dir = normalization_root / "inside-dir"
+    outside_file = tmp_path / "outside-file.txt"
+    outside_dir = tmp_path / "outside-dir"
+    link_to_outside_file = normalization_root / "outside-file-link"
+    link_to_outside_dir = normalization_root / "outside-dir-link"
+
+    inside_file.write_text("inside\n", encoding="utf-8")
+    inside_dir.mkdir()
+    outside_file.write_text("outside\n", encoding="utf-8")
+    outside_dir.mkdir()
+    link_to_outside_file.symlink_to(outside_file)
+    link_to_outside_dir.symlink_to(outside_dir, target_is_directory=True)
+
+    os.chmod(normalization_root, 0o775)
+    os.chmod(inside_file, 0o664)
+    os.chmod(inside_dir, 0o775)
+    os.chmod(outside_file, 0o664)
+    os.chmod(outside_dir, 0o775)
+
+    outside_file_mode_before = outside_file.stat().st_mode & 0o777
+    outside_dir_mode_before = outside_dir.stat().st_mode & 0o777
+
+    _ = run_command(
+        "find",
+        "-P",
+        str(normalization_root),
+        "(",
+        "-type",
+        "d",
+        "-o",
+        "-type",
+        "f",
+        ")",
+        "-exec",
+        "chmod",
+        "g-w",
+        "{}",
+        "+",
+    )
+
+    assert (normalization_root.stat().st_mode & 0o777) == 0o755
+    assert (inside_file.stat().st_mode & 0o777) == 0o644
+    assert (inside_dir.stat().st_mode & 0o777) == 0o755
+    assert (outside_file.stat().st_mode & 0o777) == outside_file_mode_before
+    assert (outside_dir.stat().st_mode & 0o777) == outside_dir_mode_before
+    assert link_to_outside_file.is_symlink()
+    assert link_to_outside_dir.is_symlink()
 
 
 def test_rendered_systemd_unit_has_required_directives() -> None:

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -350,6 +350,7 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
     )
     assert re.search(r'^\s*"\$\{UV_BIN\}" sync --frozen --no-dev$', deploy_text, re.MULTILINE)
     assert re.search(r'^\s*"\$\{SYSTEMD_ANALYZE_BIN\}" verify "\$\{UNIT_CANDIDATE\}"$', deploy_text, re.MULTILINE)
+    assert "resolve_runtime_uv_bin" not in deploy_text
     assert re.search(
         r'^\s*log "No previous current symlink exists; first native deploy rollback is limited\."$',
         deploy_text,
@@ -443,7 +444,11 @@ def test_rendered_systemd_unit_has_required_directives() -> None:
     assert "Group=demo-group" in unit
     assert "WorkingDirectory=/srv/kt-demo-alarm/current" in unit
     assert "EnvironmentFile=/srv/kt-demo-alarm/shared/.env" in unit
-    assert "ExecStart=/usr/bin/env uv run --no-sync --no-dev uvicorn main:app --host ${APP_BIND_HOST} --port ${APP_PORT}" in unit
+    assert (
+        "ExecStart=/srv/kt-demo-alarm/current/.venv/bin/uvicorn main:app --host ${APP_BIND_HOST} --port ${APP_PORT}"
+        in unit
+    )
+    assert "uv run --no-sync --no-dev" not in unit
     assert "Restart=on-failure" in unit
     assert "ProtectSystem=strict" in unit
     assert "ReadWritePaths=/srv/kt-demo-alarm/shared" in unit

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -158,8 +158,14 @@ def test_deploy_workflow_normalizes_incoming_permissions_for_service_group() -> 
     assert 'resolved_app_user="${APP_USER:-${APP_NAME}}"' in workflow_text
     assert 'resolved_app_group="${APP_GROUP:-${resolved_app_user}}"' in workflow_text
     assert 'remote_incoming_root="${APP_ROOT}/incoming"' in workflow_text
+    assert 'remote_incoming_owner_q="$(quote_remote "${EC2_USERNAME}:${resolved_app_group}")"' in workflow_text
     assert re.search(
         r"^\s*sudo chgrp .*resolved_app_group.*remote_incoming_root.*remote_incoming_dir.*$",
+        workflow_text,
+        re.MULTILINE,
+    )
+    assert re.search(
+        r"^\s*sudo chown .*remote_incoming_owner.*remote_incoming_dir.*$",
         workflow_text,
         re.MULTILINE,
     )
@@ -168,6 +174,7 @@ def test_deploy_workflow_normalizes_incoming_permissions_for_service_group() -> 
         workflow_text,
         re.MULTILINE,
     )
+    assert re.search(r"^\s*sudo chmod u\+rwx .*remote_incoming_dir.*$", workflow_text, re.MULTILINE)
     assert re.search(
         r"^\s*sudo chmod g\+s .*remote_incoming_root.*remote_incoming_dir.*$",
         workflow_text,

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -95,6 +95,33 @@ def uncommented_text(path: Path) -> str:
     )
 
 
+def _python_version(executable: str | Path) -> tuple[int, int]:
+    inspect = run_command(
+        str(executable),
+        "-c",
+        "import json, sys; print(json.dumps(list(sys.version_info[:2])))",
+    )
+    major, minor = json.loads(inspect.stdout)
+    return int(major), int(minor)
+
+
+def _compatible_python_or_skip(*names: str, require_non_home: bool = False) -> Path:
+    home = Path.home().resolve()
+    for name in names:
+        python_bin = shutil.which(name)
+        if python_bin is None:
+            continue
+        resolved = Path(python_bin).resolve()
+        if _python_version(resolved) < (3, 12):
+            continue
+        if require_non_home and resolved.is_relative_to(home):
+            continue
+        return resolved
+
+    scope = "non-HOME " if require_non_home else ""
+    pytest.skip(f"{scope}Python 3.12+ interpreter is required for this test")
+
+
 def test_deploy_workflow_matches_guarded_native_graph() -> None:
     jobs = workflow_jobs()
 
@@ -156,6 +183,8 @@ def test_deploy_workflow_normalizes_incoming_permissions_for_service_group() -> 
     workflow_text = uncommented_workflow_text()
 
     assert 'chmod 700 ${remote_incoming_dir_q}' not in workflow_text
+    assert '"set -euo pipefail' not in workflow_text
+    assert '"set -eu' in workflow_text
     assert 'resolved_app_user="${APP_USER:-${APP_NAME}}"' in workflow_text
     assert 'resolved_app_group="${APP_GROUP:-${resolved_app_user}}"' in workflow_text
     assert 'remote_incoming_root="${APP_ROOT}/incoming"' in workflow_text
@@ -176,6 +205,11 @@ def test_deploy_workflow_normalizes_incoming_permissions_for_service_group() -> 
         re.MULTILINE,
     )
     assert re.search(r"^\s*sudo chmod u\+rwx .*remote_incoming_dir.*$", workflow_text, re.MULTILINE)
+    assert re.search(
+        r"^\s*sudo chmod o-rwx .*remote_incoming_root.*remote_incoming_dir.*$",
+        workflow_text,
+        re.MULTILINE,
+    )
     assert re.search(
         r"^\s*sudo chmod g\+s .*remote_incoming_root.*remote_incoming_dir.*$",
         workflow_text,
@@ -370,11 +404,14 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
     assert 'if [[ -n "${PYTHON_BIN:-}" || -n "${KT_NATIVE_PYTHON_BIN:-}" ]]; then' in deploy_text
     assert re.search(r"^\s*python_candidate_paths\(\) \{$", deploy_text, re.MULTILINE)
     assert re.search(r"^\s*python_path_probe\(\) \{$", deploy_text, re.MULTILINE)
+    assert re.search(r"^\s*path_is_under_home\(\) \{$", deploy_text, re.MULTILINE)
     assert re.search(r"^\s*python_path_satisfies_contract\(\) \{$", deploy_text, re.MULTILINE)
     assert re.search(r"^\s*resolve_python_candidate_path\(\) \{$", deploy_text, re.MULTILINE)
     assert re.search(r"^\s*log_python_candidate_details\(\) \{$", deploy_text, re.MULTILINE)
     assert re.search(r"^\s*prepare_managed_python_install_dir\(\) \{$", deploy_text, re.MULTILINE)
     assert re.search(r"^\s*normalize_managed_python_install_permissions\(\) \{$", deploy_text, re.MULTILINE)
+    assert 'path_is_under_home "${candidate_executable}" && return 1' in deploy_text
+    assert '! path_is_under_home "${MANAGED_PYTHON_INSTALL_DIR}"' in deploy_text
     assert 'location = "user-home"' in deploy_text
     assert 'candidates+=("python3.12")' in deploy_text
     assert 'Using compatible system Python candidate ${candidate} instead of default ${PYTHON_BIN}' in deploy_text
@@ -443,11 +480,35 @@ def test_deploy_release_script_normalizes_release_permissions_for_service_group(
     assert 'run_privileged find -P "${RELEASE_DIR}" -type f -exec chmod g+r {} +' in deploy_text
     assert 'run_privileged find -P "${RELEASE_DIR}" -type f -perm /111 -exec chmod g+rx {} +' in deploy_text
     assert 'run_privileged install -d -o "${MANAGED_PYTHON_INSTALL_OWNER}" -g "${APP_GROUP}" -m 2775 "${MANAGED_PYTHON_INSTALL_DIR}"' in deploy_text
+    assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -exec chmod g-w {} +' in deploy_text
     assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chgrp "${APP_GROUP}" {} +' in deploy_text
     assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chmod g+rx,g+s {} +' in deploy_text
     assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +' in deploy_text
     assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -exec chmod g+r {} +' in deploy_text
     assert 'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type f -perm /111 -exec chmod g+rx {} +' in deploy_text
+    assert 'run_privileged find -P "${RELEASE_DIR}" -exec chmod g-w {} +' in deploy_text
+
+    managed_match = re.search(
+        r"normalize_managed_python_install_permissions\(\) \{\n(?P<body>.*?)\n\}",
+        deploy_text,
+        re.DOTALL,
+    )
+    assert managed_match is not None
+    managed_body = managed_match.group("body")
+    assert managed_body.index('run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -exec chmod g-w {} +') < managed_body.index(
+        'run_privileged find -P "${MANAGED_PYTHON_INSTALL_DIR}" -type d -exec chmod g+rx,g+s {} +'
+    )
+
+    release_tree_match = re.search(
+        r"normalize_release_tree_permissions\(\) \{\n(?P<body>.*?)\n\}",
+        deploy_text,
+        re.DOTALL,
+    )
+    assert release_tree_match is not None
+    release_tree_body = release_tree_match.group("body")
+    assert release_tree_body.index('run_privileged find -P "${RELEASE_DIR}" -exec chmod g-w {} +') < release_tree_body.index(
+        'run_privileged find -P "${RELEASE_DIR}" -type d -exec chmod g+rx,g+s {} +'
+    )
 
     prepare_match = re.search(r"prepare_release_dirs\(\) \{\n(?P<body>.*?)\n\}", deploy_text, re.DOTALL)
     assert prepare_match is not None
@@ -602,9 +663,7 @@ def test_setup_runtime_contains_required_uv_and_playwright_paths() -> None:
 
 def test_uv_sync_uses_requested_system_python_for_project_venv(tmp_path: Path) -> None:
     uv_bin = shutil.which("uv")
-    python_bin = shutil.which("python3")
     assert uv_bin is not None
-    assert python_bin is not None
 
     project_dir = tmp_path / "uv-system-python-check"
     project_dir.mkdir()
@@ -622,8 +681,7 @@ def test_uv_sync_uses_requested_system_python_for_project_venv(tmp_path: Path) -
         encoding="utf-8",
     )
 
-    requested_python = Path(python_bin).resolve()
-    managed_python_root = Path.home() / ".local" / "share" / "uv" / "python"
+    requested_python = _compatible_python_or_skip("python3.12", "python3")
 
     _ = run_command(
         uv_bin,
@@ -665,7 +723,6 @@ def test_uv_sync_uses_requested_system_python_for_project_venv(tmp_path: Path) -
     runtime_info = json.loads(inspect.stdout)
     assert Path(runtime_info["prefix"]) == (project_dir / ".venv").resolve()
     assert Path(runtime_info["base_executable"]) == requested_python
-    assert Path(runtime_info["base_executable"]).is_relative_to(managed_python_root) is False
 
 
 def test_uv_sync_can_use_custom_managed_python_install_dir_for_project_venv(tmp_path: Path) -> None:
@@ -739,8 +796,7 @@ def test_uv_sync_can_use_custom_managed_python_install_dir_for_project_venv(tmp_
 def test_deploy_release_preflight_prefers_python312_candidate_when_default_python3_fails(
     tmp_path: Path,
 ) -> None:
-    system_python = shutil.which("python3")
-    assert system_python is not None
+    compatible_python = _compatible_python_or_skip("python3.12", "python3", require_non_home=True)
 
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -748,7 +804,7 @@ def test_deploy_release_preflight_prefers_python312_candidate_when_default_pytho
     fake_python3 = fake_bin / "python3"
     fake_python3.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
     fake_python3.chmod(0o755)
-    (fake_bin / "python3.12").symlink_to(Path(system_python).resolve())
+    (fake_bin / "python3.12").symlink_to(compatible_python)
     for helper in ("bash", "date", "dirname", "id"):
         helper_path = shutil.which(helper)
         assert helper_path is not None
@@ -758,21 +814,27 @@ def test_deploy_release_preflight_prefers_python312_candidate_when_default_pytho
     script_copy.write_text(
         DEPLOY_SCRIPT.read_text(encoding="utf-8").replace(
             'main "$@"',
-            'preflight_python\nprintf "selected=%s\\n" "${PYTHON_BIN}"',
+            'preflight_python\nprintf "selected=%s\\nrequest=%s\\n" "${PYTHON_BIN}" "${PYTHON_REQUEST}"',
         ),
         encoding="utf-8",
     )
     script_copy.chmod(0o755)
 
-    result = run_command(
-        "bash",
-        str(script_copy),
-        env={"PATH": str(fake_bin)},
+    env = {name: value for name, value in os.environ.items() if name != "HOME"}
+    env["PATH"] = str(fake_bin)
+    result = subprocess.run(
+        ("bash", str(script_copy)),
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+        env=env,
     )
 
     assert "Using compatible system Python candidate python3.12 instead of default python3" in result.stdout
     assert f"Using system Python binary {fake_bin / 'python3.12'}" in result.stdout
     assert f"selected={fake_bin / 'python3.12'}" in result.stdout
+    assert f"request={fake_bin / 'python3.12'}" in result.stdout
 
 
 def test_deploy_release_preflight_falls_back_to_shared_managed_python_when_no_system_candidate(

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -380,6 +380,7 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
     diagnostics_body = diagnostics_match.group("body")
     for required_path in (
         '"${CURRENT_LINK}"',
+        '"${CURRENT_LINK}/.venv/bin/python"',
         '"${CURRENT_LINK}/.venv/bin/uvicorn"',
         '"${RELEASE_DIR}"',
         '"${SHARED_DIR}"',
@@ -447,9 +448,10 @@ def test_rendered_systemd_unit_has_required_directives() -> None:
     assert "WorkingDirectory=/srv/kt-demo-alarm/current" in unit
     assert "EnvironmentFile=/srv/kt-demo-alarm/shared/.env" in unit
     assert (
-        "ExecStart=/srv/kt-demo-alarm/current/.venv/bin/uvicorn main:app --host ${APP_BIND_HOST} --port ${APP_PORT}"
+        "ExecStart=/srv/kt-demo-alarm/current/.venv/bin/python -m uvicorn main:app --host ${APP_BIND_HOST} --port ${APP_PORT}"
         in unit
     )
+    assert "/.venv/bin/uvicorn main:app" not in unit
     assert "uv run --no-sync --no-dev" not in unit
     assert "Restart=on-failure" in unit
     assert "ProtectSystem=strict" in unit

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -380,6 +380,7 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
     diagnostics_body = diagnostics_match.group("body")
     for required_path in (
         '"${CURRENT_LINK}"',
+        '"${CURRENT_LINK}/.venv/bin/uvicorn"',
         '"${RELEASE_DIR}"',
         '"${SHARED_DIR}"',
         '"${ENV_FILE}"',
@@ -403,6 +404,7 @@ def test_deploy_release_script_normalizes_release_permissions_for_service_group(
     assert 'run_privileged find -P "${RELEASE_DIR}" -type d -exec chmod g+rx,g+s {} +' in deploy_text
     assert 'run_privileged find -P "${RELEASE_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +' in deploy_text
     assert 'run_privileged find -P "${RELEASE_DIR}" -type f -exec chmod g+r {} +' in deploy_text
+    assert 'run_privileged find -P "${RELEASE_DIR}" -type f -perm /111 -exec chmod g+rx {} +' in deploy_text
 
     prepare_match = re.search(r"prepare_release_dirs\(\) \{\n(?P<body>.*?)\n\}", deploy_text, re.DOTALL)
     assert prepare_match is not None

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -356,12 +356,15 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
     )
     assert "PYTHON_BIN_WAS_EXPLICIT=0" in deploy_text
     assert 'if [[ -n "${PYTHON_BIN:-}" || -n "${KT_NATIVE_PYTHON_BIN:-}" ]]; then' in deploy_text
-    assert re.search(r"^\s*python_candidate_satisfies_contract\(\) \{$", deploy_text, re.MULTILINE)
+    assert re.search(r"^\s*python_candidate_paths\(\) \{$", deploy_text, re.MULTILINE)
+    assert re.search(r"^\s*python_path_probe\(\) \{$", deploy_text, re.MULTILINE)
+    assert re.search(r"^\s*python_path_satisfies_contract\(\) \{$", deploy_text, re.MULTILINE)
+    assert re.search(r"^\s*resolve_python_candidate_path\(\) \{$", deploy_text, re.MULTILINE)
     assert re.search(r"^\s*log_python_candidate_details\(\) \{$", deploy_text, re.MULTILINE)
-    assert '"${candidate}" - <<\'PY\'' in deploy_text
+    assert 'location = "user-home"' in deploy_text
     assert 'candidates+=("python3.12")' in deploy_text
     assert 'Using compatible system Python candidate ${candidate} instead of default ${PYTHON_BIN}' in deploy_text
-    assert 'Using system Python binary ${PYTHON_BIN} ($(command -v "${PYTHON_BIN}"))' in deploy_text
+    assert 'Using system Python binary ${PYTHON_BIN}' in deploy_text
     assert 'log_python_candidate_details "python3.12"' in deploy_text
     assert "Python 3.12 or newer is required" in deploy_text
     assert re.search(
@@ -647,13 +650,20 @@ def test_uv_sync_uses_requested_system_python_for_project_venv(tmp_path: Path) -
 def test_deploy_release_preflight_prefers_python312_candidate_when_default_python3_fails(
     tmp_path: Path,
 ) -> None:
+    system_python = shutil.which("python3")
+    assert system_python is not None
+
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
 
     fake_python3 = fake_bin / "python3"
     fake_python3.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
     fake_python3.chmod(0o755)
-    (fake_bin / "python3.12").symlink_to(Path(sys.executable).resolve())
+    (fake_bin / "python3.12").symlink_to(Path(system_python).resolve())
+    for helper in ("bash", "date", "dirname"):
+        helper_path = shutil.which(helper)
+        assert helper_path is not None
+        (fake_bin / helper).symlink_to(Path(helper_path).resolve())
 
     script_copy = tmp_path / "deploy-release-preflight.sh"
     script_copy.write_text(
@@ -668,12 +678,12 @@ def test_deploy_release_preflight_prefers_python312_candidate_when_default_pytho
     result = run_command(
         "bash",
         str(script_copy),
-        env={"PATH": f"{fake_bin}:{os.environ['PATH']}"},
+        env={"PATH": str(fake_bin)},
     )
 
     assert "Using compatible system Python candidate python3.12 instead of default python3" in result.stdout
-    assert "Using system Python binary python3.12" in result.stdout
-    assert "selected=python3.12" in result.stdout
+    assert f"Using system Python binary {fake_bin / 'python3.12'}" in result.stdout
+    assert f"selected={fake_bin / 'python3.12'}" in result.stdout
 
 
 def test_active_native_docs_retire_advisory_lane() -> None:

--- a/tests/test_native_runtime_assets.py
+++ b/tests/test_native_runtime_assets.py
@@ -151,6 +151,31 @@ def test_active_workflow_removes_docker_runtime_and_runner_env_rendering() -> No
             assert not re.search(r">\s*\.env\b", run)
 
 
+def test_deploy_workflow_normalizes_incoming_permissions_for_service_group() -> None:
+    workflow_text = uncommented_workflow_text()
+
+    assert 'chmod 700 ${remote_incoming_dir_q}' not in workflow_text
+    assert 'resolved_app_user="${APP_USER:-${APP_NAME}}"' in workflow_text
+    assert 'resolved_app_group="${APP_GROUP:-${resolved_app_user}}"' in workflow_text
+    assert 'remote_incoming_root="${APP_ROOT}/incoming"' in workflow_text
+    assert re.search(
+        r"^\s*sudo chgrp .*resolved_app_group.*remote_incoming_root.*remote_incoming_dir.*$",
+        workflow_text,
+        re.MULTILINE,
+    )
+    assert re.search(
+        r"^\s*sudo chmod g\+rx .*remote_incoming_root.*remote_incoming_dir.*$",
+        workflow_text,
+        re.MULTILINE,
+    )
+    assert re.search(
+        r"^\s*sudo chmod g\+s .*remote_incoming_root.*remote_incoming_dir.*$",
+        workflow_text,
+        re.MULTILINE,
+    )
+    assert "APP_NAME=%q APP_USER=%q APP_GROUP=%q APP_ROOT=%q" in workflow_text
+
+
 def test_package_and_verify_source_bundle_contract(tmp_path: Path) -> None:
     artifact_dir = tmp_path / "artifact"
     artifact_dir.mkdir()
@@ -327,6 +352,38 @@ def test_deploy_release_script_contains_required_preflight_and_rollback_guards()
         r'^\s*log "Restoring previous current symlink: \$\{PREVIOUS_CURRENT\}"$',
         deploy_text,
         re.MULTILINE,
+    )
+
+
+def test_deploy_release_script_normalizes_release_permissions_for_service_group() -> None:
+    deploy_text = uncommented_text(DEPLOY_SCRIPT)
+
+    assert re.search(r"^\s*normalize_release_root_permissions\(\) \{$", deploy_text, re.MULTILINE)
+    assert 'run_privileged chgrp "${APP_GROUP}" "${RELEASES_DIR}" "${RELEASE_DIR}"' in deploy_text
+    assert 'run_privileged chmod g+rx "${RELEASES_DIR}" "${RELEASE_DIR}"' in deploy_text
+    assert 'run_privileged chmod g+s "${RELEASES_DIR}" "${RELEASE_DIR}"' in deploy_text
+    assert re.search(r"^\s*normalize_release_tree_permissions\(\) \{$", deploy_text, re.MULTILINE)
+    assert 'run_privileged find -P "${RELEASE_DIR}" -type d -exec chgrp "${APP_GROUP}" {} +' in deploy_text
+    assert 'run_privileged find -P "${RELEASE_DIR}" -type d -exec chmod g+rx,g+s {} +' in deploy_text
+    assert 'run_privileged find -P "${RELEASE_DIR}" -type f -exec chgrp "${APP_GROUP}" {} +' in deploy_text
+    assert 'run_privileged find -P "${RELEASE_DIR}" -type f -exec chmod g+r {} +' in deploy_text
+
+    prepare_match = re.search(r"prepare_release_dirs\(\) \{\n(?P<body>.*?)\n\}", deploy_text, re.DOTALL)
+    assert prepare_match is not None
+    assert "normalize_release_root_permissions" in prepare_match.group("body")
+
+    unpack_match = re.search(r"unpack_release\(\) \{\n(?P<body>.*?)\n\}", deploy_text, re.DOTALL)
+    assert unpack_match is not None
+    unpack_body = unpack_match.group("body")
+    assert unpack_body.index('tar -xzf "${BUNDLE_PATH}" -C "${RELEASE_DIR}"') < unpack_body.index(
+        "normalize_release_tree_permissions"
+    )
+
+    sync_match = re.search(r"sync_dependencies\(\) \{\n(?P<body>.*?)\n\}", deploy_text, re.DOTALL)
+    assert sync_match is not None
+    sync_body = sync_match.group("body")
+    assert sync_body.index('"${UV_BIN}" sync --frozen --no-dev') < sync_body.index(
+        "normalize_release_tree_permissions"
     )
 
 


### PR DESCRIPTION
## 요약
- native deploy의 incoming/release 권한 정규화를 강화해 업로더와 서비스 그룹이 모두 접근 가능한 handoff contract를 고정했습니다.
- release runtime이 글로벌 `uv`나 deploy-user home-local Python shim에 의존하지 않도록 entrypoint와 Python 선택 로직을 정리했습니다.
- system Python 3.12가 없을 때는 `/opt/kt-demo-alarm/shared/uv/python` 아래 shared managed Python으로 fallback 하도록 배포 경로를 보강했습니다.
- 위 계약을 `tests/test_native_runtime_assets.py`의 회귀/통합 테스트로 고정했습니다.

## 변경 파일
- `.github/workflows/deploy.yml`
- `deploy/native/deploy-release.sh`
- `deploy/native/kt-demo-alarm.service.template`
- `scripts/native/setup-runtime.sh`
- `tests/test_native_runtime_assets.py`

## 검증
- `uv run pytest tests/test_native_runtime_assets.py -q`
- `uv run pytest -q`
- `bash -n deploy/native/deploy-release.sh`
- `uv lock --check`
- GitHub Actions `Deploy to AWS EC2` workflow_dispatch run `26895485468` 성공
  - `Blocking tests` 성공
  - `Package native release` 성공
  - `Native deploy preflight` 성공
  - `Deploy native live` 성공
  - `Public health` 성공

## 비고
- merge는 아직 수행하지 않았습니다.
- GitHub Actions에서 Node.js 20 action deprecation annotation이 보였지만 이번 run의 성공/실패와는 무관한 비차단 경고였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deployment workflow now creates an incoming root and per-release directories, normalizes ownership/permissions for group-shared access, and safely passes resolved deploy user/group to remote deploy.
  * Deploy script adds Python runtime detection/validation (requires ≥3.12), selects system or managed Python, conditionally syncs dependencies, and captures richer diagnostics on failures.
  * Runtime setup pins the Python executable for dependency sync and disables managed/downloads when requested.

* **Tests**
  * Expanded coverage for deployment permissions, Python selection/fallbacks, runtime setup, and rollback diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->