### PR TITLE
Refactor notification payload assembly boundary and harden regressions

### DIFF
--- a/app/routers/events.py
+++ b/app/routers/events.py
@@ -8,21 +8,12 @@ import asyncio
 from app.models.event import EventCreate, EventResponse, RouteEventCheck
 from app.database.connection import get_db
 from app.services.event_service import EventService
+from app.services.notification_payload_assembler import NotificationPayloadAssembler
 from app.services.notification_service import NotificationService
 from app.services.auth_service import verify_api_key
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/events", tags=["events"])
-
-
-def _to_notification_event_data(event: EventResponse) -> dict:
-    """사용자 출력 템플릿에 필요한 집회 필드만 변환"""
-    return {
-        "attendees": event.attendees,
-        "location": event.location_name,
-        "start_date": event.start_date,
-        "end_date": event.end_date,
-    }
 
 
 @router.post("", response_model=EventResponse)
@@ -108,9 +99,10 @@ async def check_user_route_events(
             }
         }
 
-    message_text = NotificationService._format_event_collection_message(
+    notification_events = NotificationPayloadAssembler.event_payloads_from_responses(result.events_found)
+    message_text = NotificationService.format_event_collection_message(
         "경로상 감지된 집회 안내입니다.",
-        [_to_notification_event_data(event) for event in result.events_found],
+        notification_events,
     )
 
     return {
@@ -234,9 +226,10 @@ async def get_upcoming_protests(
             }
         }
 
-    message_text = NotificationService._format_event_collection_message(
+    notification_events = NotificationPayloadAssembler.event_payloads_from_responses(events)
+    message_text = NotificationService.format_event_collection_message(
         "예정된 집회 안내입니다.",
-        [_to_notification_event_data(event) for event in events],
+        notification_events,
     )
 
     return {
@@ -280,9 +273,10 @@ async def get_today_protests(
             }
         }
 
-    message_text = NotificationService._format_event_collection_message(
+    notification_events = NotificationPayloadAssembler.event_payloads_from_responses(events)
+    message_text = NotificationService.format_event_collection_message(
         "오늘 예정된 집회 안내입니다.",
-        [_to_notification_event_data(event) for event in events],
+        notification_events,
     )
 
     return {

--- a/app/routers/kakao_skills.py
+++ b/app/routers/kakao_skills.py
@@ -7,22 +7,12 @@ import logging
 from app.config.settings import settings
 from app.database.connection import get_db
 from app.services.event_service import EventService
+from app.services.notification_payload_assembler import NotificationPayloadAssembler
 from app.services.notification_service import NotificationService
 from app.services.user_service import UserService
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["kakao-skills"])
-
-
-def _to_notification_event_data(event: object) -> dict:
-    """사용자 출력 템플릿에 필요한 집회 필드만 변환"""
-    return {
-        "attendees": getattr(event, "attendees", "미상"),
-        "location": getattr(event, "location_name"),
-        "description": getattr(event, "description", None),
-        "start_date": getattr(event, "start_date"),
-        "end_date": getattr(event, "end_date", None),
-    }
 
 
 # ─── 집회 정보 조회 ─────────────────────────────────────────
@@ -58,17 +48,13 @@ async def get_upcoming_protests(
             }
         }
 
-    message_text = NotificationService._format_event_collection_message(
+    notification_events = NotificationPayloadAssembler.event_payloads_from_responses(events)
+    message_text = NotificationService.format_event_collection_message(
         "예정된 집회 안내입니다.",
-        [_to_notification_event_data(event) for event in events],
+        notification_events,
     )
 
-    image_url = None
-    for event in events:
-        if getattr(event, "image_path", None):
-            base_url = settings.RENDER_EXTERNAL_URL or f"http://localhost:{settings.PORT}"
-            image_url = f"{base_url}/{event.image_path}"
-            break
+    image_url = NotificationService.first_event_image_url(notification_events)
 
     outputs = []
     if image_url:
@@ -118,17 +104,13 @@ async def get_today_protests(
             }
         }
 
-    message_text = NotificationService._format_event_collection_message(
+    notification_events = NotificationPayloadAssembler.event_payloads_from_responses(events)
+    message_text = NotificationService.format_event_collection_message(
         "오늘 예정된 집회 안내입니다.",
-        [_to_notification_event_data(event) for event in events],
+        notification_events,
     )
 
-    image_url = None
-    for event in events:
-        if getattr(event, "image_path", None):
-            base_url = settings.RENDER_EXTERNAL_URL or f"http://localhost:{settings.PORT}"
-            image_url = f"{base_url}/{event.image_path}"
-            break
+    image_url = NotificationService.first_event_image_url(notification_events)
 
     outputs = []
     if image_url:
@@ -196,17 +178,13 @@ async def check_user_route_events(
             }
         }
 
-    message_text = NotificationService._format_event_collection_message(
+    notification_events = NotificationPayloadAssembler.event_payloads_from_responses(result.events_found)
+    message_text = NotificationService.format_event_collection_message(
         "경로상 감지된 집회 안내입니다.",
-        [_to_notification_event_data(event) for event in result.events_found],
+        notification_events,
     )
 
-    image_url = None
-    for event in result.events_found:
-        if getattr(event, "image_path", None):
-            base_url = settings.RENDER_EXTERNAL_URL or f"http://localhost:{settings.PORT}"
-            image_url = f"{base_url}/{event.image_path}"
-            break
+    image_url = NotificationService.first_event_image_url(notification_events)
 
     outputs = []
     if image_url:

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Any, Optional
 from app.models.event import EventCreate, EventResponse, RouteEventCheck
 from app.utils.geo_utils import haversine_distance, get_route_coordinates, is_event_near_route_accurate, is_point_near_route
 from app.database.connection import get_db_connection
+from app.services.notification_payload_assembler import NotificationPayloadAssembler
 from app.services.notification_service import NotificationService
 
 logger = logging.getLogger(__name__)
@@ -243,23 +244,8 @@ class EventService:
             
             # 자동 알림 전송 (옵션)
             if auto_notify and route_events:
-                # auto_notify_route_events 함수 호출
-                events_data = []
-                for event in route_events:
-                    events_data.append({
-                        "id": event.id,
-                        "title": event.title,
-                        "description": event.description,
-                        "attendees": event.attendees,
-                        "location": event.location_name,
-                        "latitude": event.latitude,
-                        "longitude": event.longitude,
-                        "start_date": event.start_date.isoformat(),
-                        "end_date": event.end_date.isoformat() if event.end_date else None,
-                        "category": event.category,
-                        "severity_level": event.severity_level
-                    })
-                await NotificationService.send_route_alert(user_id, events_data)
+                notification_events = NotificationPayloadAssembler.event_payloads_from_responses(route_events)
+                await NotificationService.send_route_alert(user_id, notification_events)
                 logger.info(f"사용자 {user_id}에게 {len(route_events)}개 집회 자동 알림 전송")
             
             return RouteEventCheck(
@@ -330,26 +316,14 @@ class EventService:
                     if result.events_found:
                         # 해당 사용자에게 전달될 정확한 이벤트 집합을 키로 사용
                         event_key = tuple(sorted(event.id for event in result.events_found))
+                        notification_events = NotificationPayloadAssembler.event_payloads_from_responses(
+                            result.events_found
+                        )
 
                         if event_key not in grouped_users:
                             grouped_users[event_key] = {
                                 "user_ids": [],
-                                "events_data": [
-                                    {
-                                        "id": event.id,
-                                        "title": event.title,
-                                        "description": event.description,
-                                        "attendees": event.attendees,
-                                        "location": event.location_name,
-                                        "latitude": event.latitude,
-                                        "longitude": event.longitude,
-                                        "start_date": event.start_date.isoformat() if hasattr(event.start_date, 'isoformat') else str(event.start_date),
-                                        "end_date": event.end_date.isoformat() if event.end_date and hasattr(event.end_date, 'isoformat') else str(event.end_date) if event.end_date else None,
-                                        "category": event.category,
-                                        "severity_level": event.severity_level
-                                    }
-                                    for event in result.events_found
-                                ]
+                                "events_data": notification_events,
                             }
 
                         grouped_users[event_key]["user_ids"].append(plusfriend_key)

--- a/app/services/notification_payload_assembler.py
+++ b/app/services/notification_payload_assembler.py
@@ -1,0 +1,78 @@
+"""알림 본문 payload 조립기"""
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from app.models.event import EventResponse
+
+
+@dataclass(frozen=True)
+class NotificationEventPayload:
+    """알림 본문 계약용 이벤트 DTO."""
+
+    location: str
+    description: str
+    attendees: str
+    start_date: Any
+    end_date: Any
+    image_path: Optional[str] = None
+
+
+class NotificationPayloadAssembler:
+    """도메인 이벤트를 알림 본문 계약 DTO로 번역한다."""
+
+    @staticmethod
+    def _display_text(value: Any, fallback: str = "미상") -> str:
+        """사용자 표시용 문자열을 공백 제거 후 fallback 과 함께 정규화한다."""
+        if value is None:
+            return fallback
+
+        value_text = str(value).strip()
+        return value_text or fallback
+
+    @staticmethod
+    def _display_attendees(value: Any) -> str:
+        """신고 인원 표시 문자열을 정규화한다."""
+        attendees = NotificationPayloadAssembler._display_text(value)
+        if attendees != "미상" and attendees.isdigit() and not attendees.endswith("명"):
+            return f"{attendees}명"
+        return attendees
+
+    @staticmethod
+    def _image_path_or_none(value: Any) -> Optional[str]:
+        """이미지 경로를 Optional[str]로 정규화한다."""
+        image_path = NotificationPayloadAssembler._display_text(value, fallback="")
+        return image_path or None
+
+    @staticmethod
+    def event_payload_from_response(event: EventResponse) -> NotificationEventPayload:
+        """EventResponse를 알림 본문 계약 DTO로 변환한다."""
+        return NotificationEventPayload(
+            location=NotificationPayloadAssembler._display_text(event.location_name),
+            description=NotificationPayloadAssembler._display_text(event.description),
+            attendees=NotificationPayloadAssembler._display_attendees(event.attendees),
+            start_date=event.start_date,
+            end_date=event.end_date,
+            image_path=NotificationPayloadAssembler._image_path_or_none(event.image_path),
+        )
+
+    @staticmethod
+    def event_payloads_from_responses(events: List[EventResponse]) -> List[NotificationEventPayload]:
+        """EventResponse 목록을 알림 본문 계약 DTO 목록으로 변환한다."""
+        return [NotificationPayloadAssembler.event_payload_from_response(event) for event in events]
+
+    @staticmethod
+    def event_payload_from_row(event_row: Dict[str, Any]) -> NotificationEventPayload:
+        """DB row dict를 알림 본문 계약 DTO로 변환한다."""
+        return NotificationEventPayload(
+            location=NotificationPayloadAssembler._display_text(event_row["location_name"]),
+            description=NotificationPayloadAssembler._display_text(event_row.get("description")),
+            attendees=NotificationPayloadAssembler._display_attendees(event_row.get("attendees")),
+            start_date=event_row["start_date"],
+            end_date=event_row.get("end_date"),
+            image_path=NotificationPayloadAssembler._image_path_or_none(event_row.get("image_path")),
+        )
+
+    @staticmethod
+    def event_payloads_from_rows(events: List[Dict[str, Any]]) -> List[NotificationEventPayload]:
+        """DB row dict 목록을 알림 본문 계약 DTO 목록으로 변환한다."""
+        return [NotificationPayloadAssembler.event_payload_from_row(event) for event in events]

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Any, Optional, Iterator, Tuple
 from app.models.alarm import AlarmRequest, FilteredAlarmRequest
 from app.models.kakao import EventAPIRequest, Event, EventUser
 from app.config.settings import settings
+from app.services.notification_payload_assembler import NotificationEventPayload
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,6 @@ KAKAO_EVENT_API_SUCCESS_STATUS = "SUCCESS"
 KAKAO_TASK_RESULT_POLL_ATTEMPTS = 5
 KAKAO_TASK_RESULT_POLL_DELAY_SECONDS = 0.5
 KAKAO_TASK_PENDING_STATUSES = {"PENDING", "PROCESSING", "RUNNING", "WAITING"}
-
 
 class NotificationService:
     """알림 전송 비즈니스 로직"""
@@ -58,27 +58,28 @@ class NotificationService:
             return value_text[:5] if len(value_text) >= 5 else value_text
 
     @staticmethod
-    def _format_event_time_range(event: Dict[str, Any]) -> str:
+    def _format_event_time_range(event: NotificationEventPayload) -> str:
         """집회 시작/종료 일시 범위 포맷팅"""
-        start_time = NotificationService._format_event_time(event.get("start_date"))
-        end_time = NotificationService._format_event_time(event.get("end_date"))
+        start_time = NotificationService._format_event_time(event.start_date)
+        end_time = NotificationService._format_event_time(event.end_date)
         return f"{start_time} ~ {end_time}"
 
     @staticmethod
-    def _format_event_block(index: int, event: Dict[str, Any]) -> str:
+    def _format_event_block(index: int, event: NotificationEventPayload) -> str:
         """단일 집회 정보를 사용자 알림용 번호 블록으로 포맷팅"""
-        attendees = str(event.get("attendees") or "").strip() or "미상"
-        if attendees != "미상" and attendees.isdigit() and not attendees.endswith("명"):
-            attendees = f"{attendees}명"
         return (
             f"{index}.\n"
             f"집회 일시 : {NotificationService._format_event_time_range(event)}\n"
-            f"집회 장소 : {event['location']}\n"
-            f"신고 인원 : {attendees}"
+            f"집회 장소 : {event.location}\n"
+            f"상세 내용 : {event.description}\n"
+            f"신고 인원 : {event.attendees}"
         )
 
     @staticmethod
-    def _format_event_collection_message(header: str, events: List[Dict[str, Any]]) -> str:
+    def format_event_collection_message(
+        header: str,
+        events: List[NotificationEventPayload],
+    ) -> str:
         """여러 집회 정보를 공통 번호형 템플릿으로 포맷팅"""
         blocks = [
             NotificationService._format_event_block(index, event)
@@ -87,7 +88,7 @@ class NotificationService:
         return f"{header}\n\n" + "\n\n".join(blocks)
 
     @staticmethod
-    def _format_event_message(events: List[Dict[str, Any]]) -> str:
+    def format_event_message(events: List[NotificationEventPayload]) -> str:
         """
         집회 정보를 텍스트 메시지로 포맷팅
 
@@ -97,13 +98,48 @@ class NotificationService:
         Returns:
             str: 포맷팅된 메시지 텍스트
         """
-        return NotificationService._format_event_collection_message(
+        return NotificationService.format_event_collection_message(
             "경로상 감지된 집회 안내입니다.",
             events,
         )
 
     @staticmethod
-    def _format_zone_message(zone_name: str, events: List[Dict[str, Any]]) -> str:
+    def first_event_image_url(events: List[NotificationEventPayload]) -> Optional[str]:
+        """이벤트 목록에서 첫 번째 이미지 URL을 추출한다."""
+        for event in events:
+            image_path = (event.image_path or "").lstrip("/")
+            if image_path:
+                base_url = (settings.RENDER_EXTERNAL_URL or f"http://localhost:{settings.PORT}").rstrip("/")
+                return f"{base_url}/{image_path}"
+
+        return None
+
+    @staticmethod
+    def build_event_alarm_data(events: List[NotificationEventPayload]) -> Dict[str, Any]:
+        """경로/정기 발송 공통 집회 본문 alarm payload 를 구성한다."""
+        alarm_data = {"message": NotificationService.format_event_message(events)}
+        image_url = NotificationService.first_event_image_url(events)
+        if image_url:
+            alarm_data["image_url"] = image_url
+        return alarm_data
+
+    @staticmethod
+    def build_zone_alarm_data(
+        zone_name: str,
+        events: List[NotificationEventPayload],
+    ) -> Dict[str, Any]:
+        """구역 알림 공통 본문 alarm payload 를 구성한다."""
+        alarm_data = {"message": NotificationService.format_zone_message(zone_name, events)}
+        image_url = NotificationService.first_event_image_url(events)
+        if image_url:
+            alarm_data["image_url"] = image_url
+        return alarm_data
+
+    @staticmethod
+    def format_zone_message(
+        zone_name: str,
+        events: List[NotificationEventPayload],
+    ) -> str:
         """
         구역 기반 집회 알림 메시지 포맷팅
 
@@ -114,7 +150,7 @@ class NotificationService:
         Returns:
             str: 포맷팅된 메시지 텍스트
         """
-        return NotificationService._format_event_collection_message(
+        return NotificationService.format_event_collection_message(
             f"설정하신 {zone_name}의 집회 안내입니다.",
             events,
         )
@@ -515,25 +551,16 @@ class NotificationService:
         return value if value >= 0 else None
 
     @staticmethod
-    async def send_route_alert(user_id: str, events: List[Dict[str, Any]], id_type: str = "plusfriendUserKey") -> Dict[str, Any]:
+    async def send_route_alert(
+        user_id: str,
+        events: List[NotificationEventPayload],
+        id_type: str = "plusfriendUserKey",
+    ) -> Dict[str, Any]:
         """경로 기반 집회 알림 전송"""
         if not events:
             return {"success": False, "error": "전송할 집회 정보가 없습니다"}
 
-        message_text = NotificationService._format_event_message(events)
-
-        # 첫 번째 집회 정보에서 이미지 경로 추출 (SMPA 집회들은 동일한 PDF 이미지를 공유함)
-        image_url = None
-        for event in events:
-            if event.get("image_path"):
-                base_url = settings.RENDER_EXTERNAL_URL or f"http://localhost:{settings.PORT}"
-                image_url = f"{base_url}/{event['image_path']}"
-                break
-
-        # 알림 전송
-        alarm_data = {"message": message_text}
-        if image_url:
-            alarm_data["image_url"] = image_url
+        alarm_data = NotificationService.build_event_alarm_data(events)
 
         alarm_request = AlarmRequest(
             user_id=user_id,
@@ -546,26 +573,14 @@ class NotificationService:
     @staticmethod
     async def send_bulk_alert(
         user_ids: List[str],
-        events_data: List[Dict[str, Any]],
+        events_data: List[NotificationEventPayload],
         id_type: str = "plusfriendUserKey"
     ) -> Dict[str, Any]:
         """조건부 일괄 알림 전송"""
         if not user_ids:
             return {"success": False, "error": "수신자가 없습니다"}
 
-        message_text = NotificationService._format_event_message(events_data)
-
-        # 이미지 URL 추출
-        image_url = None
-        for event in events_data:
-            if event.get("image_path"):
-                base_url = settings.RENDER_EXTERNAL_URL or f"http://localhost:{settings.PORT}"
-                image_url = f"{base_url}/{event['image_path']}"
-                break
-
-        alarm_data = {"message": message_text}
-        if image_url:
-            alarm_data["image_url"] = image_url
+        alarm_data = NotificationService.build_event_alarm_data(events_data)
 
         # Event API로 일괄 전송
         return await NotificationService.send_bulk_alarm(

--- a/app/services/zone_alarm_service.py
+++ b/app/services/zone_alarm_service.py
@@ -4,6 +4,7 @@ from typing import Dict, Any
 
 from app.database.connection import get_db_connection
 from app.utils.geo_utils import haversine_distance, FAVORITE_ZONES
+from app.services.notification_payload_assembler import NotificationPayloadAssembler
 from app.services.notification_service import NotificationService
 from app.services.alarm_status_service import AlarmStatusService
 
@@ -46,7 +47,8 @@ class ZoneAlarmService:
                 # 2. 활성 집회 전체 조회
                 cursor.execute('''
                     SELECT id, title, description, attendees, location_name, location_address,
-                           latitude, longitude, start_date, end_date, category, severity_level
+                           latitude, longitude, start_date, end_date, category, severity_level,
+                           image_path
                     FROM events
                     WHERE status = 'active'
                       AND latitude IS NOT NULL
@@ -89,25 +91,13 @@ class ZoneAlarmService:
                     group_key = (zone_id, tuple(sorted(e["id"] for e in matched_events)))
 
                     if group_key not in grouped:
+                        notification_events = NotificationPayloadAssembler.event_payloads_from_rows(
+                            [dict(event_row) for event_row in matched_events]
+                        )
                         grouped[group_key] = {
                             "zone_name": zone["name"],
                             "user_ids": [],
-                            "events_data": [
-                                {
-                                    "id": e["id"],
-                                    "title": e["title"],
-                                    "description": e["description"],
-                                    "attendees": e["attendees"],
-                                    "location": e["location_name"],
-                                    "latitude": e["latitude"],
-                                    "longitude": e["longitude"],
-                                    "start_date": e["start_date"],
-                                    "end_date": e["end_date"],
-                                    "category": e["category"],
-                                    "severity_level": e["severity_level"],
-                                }
-                                for e in matched_events
-                            ],
+                            "events_data": notification_events,
                         }
                     grouped[group_key]["user_ids"].append(plusfriend_key)
 
@@ -122,14 +112,14 @@ class ZoneAlarmService:
                 zone_name = group_data["zone_name"]
                 user_ids = group_data["user_ids"]
                 events_data = group_data["events_data"]
-                message_text = NotificationService._format_zone_message(zone_name, events_data)
+                alarm_data = NotificationService.build_zone_alarm_data(zone_name, events_data)
 
                 logger.info(f"📢 [{zone_name}] {len(user_ids)}명에게 집회 {len(events_data)}건 알림 전송")
 
                 send_result = await NotificationService.send_bulk_alarm(
                     user_ids=user_ids,
                     event_name="morning_demo_alarm",
-                    data={"message": message_text},
+                    data=alarm_data,
                     id_type="plusfriendUserKey",
                 )
 

--- a/deploy/native/package-source-bundle.sh
+++ b/deploy/native/package-source-bundle.sh
@@ -84,9 +84,11 @@ fi
 
 (
   cd "${staging_dir}"
-  find . -mindepth 1 -type f \
-    | sed 's#^\./##' \
-    | sort > bundle-manifest.txt
+  {
+    find . -mindepth 1 -type f ! -name 'bundle-manifest.txt' \
+      | sed 's#^\./##'
+    printf '%s\n' 'bundle-manifest.txt'
+  } | sort > bundle-manifest.txt
   tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner -czf "${bundle_tmp_dir}/${BUNDLE_NAME}" .
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,31 +4,32 @@ import os
 import sqlite3
 import tempfile
 from fastapi.testclient import TestClient
+from app.config.settings import settings
 from app.database.connection import init_db
 
 
 @pytest.fixture(scope="session")
 def test_db():
     """Create a test database for the session"""
-    from unittest.mock import patch
-    
-    # Use a temporary database for testing
     fd, test_db_path = tempfile.mkstemp(suffix=".db")
     os.close(fd)
-    
-    # Patch settings
-    with patch("app.config.settings.settings.DATABASE_PATH", test_db_path), \
-         patch("app.config.settings.settings.API_KEY", "test-api-key"):
-        # Initialize test database
-        init_db()
-        
-        yield test_db_path
-        
-        # Cleanup
-        try:
-            os.remove(test_db_path)
-        except FileNotFoundError:
-            pass
+
+    original_database_path = settings.DATABASE_PATH
+    original_api_key = settings.API_KEY
+
+    settings.DATABASE_PATH = test_db_path
+    settings.API_KEY = "test-api-key"
+    init_db()
+
+    yield test_db_path
+
+    settings.DATABASE_PATH = original_database_path
+    settings.API_KEY = original_api_key
+
+    try:
+        os.remove(test_db_path)
+    except FileNotFoundError:
+        pass
 
 
 @pytest.fixture(scope="function")
@@ -85,3 +86,20 @@ def sample_user_data():
         "arrival_y": 37.5709,
         "active": True
     }
+
+
+@pytest.fixture
+def settings_overrides():
+    """테스트 중 settings 값을 직접 바꾸고 종료 시 복구한다."""
+    originals = {}
+
+    def apply(**overrides):
+        for key, value in overrides.items():
+            if key not in originals:
+                originals[key] = getattr(settings, key)
+            setattr(settings, key, value)
+
+    yield apply
+
+    for key, value in originals.items():
+        setattr(settings, key, value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,17 +19,17 @@ def test_db():
 
     settings.DATABASE_PATH = test_db_path
     settings.API_KEY = "test-api-key"
-    init_db()
-
-    yield test_db_path
-
-    settings.DATABASE_PATH = original_database_path
-    settings.API_KEY = original_api_key
-
     try:
-        os.remove(test_db_path)
-    except FileNotFoundError:
-        pass
+        init_db()
+        yield test_db_path
+    finally:
+        settings.DATABASE_PATH = original_database_path
+        settings.API_KEY = original_api_key
+
+        try:
+            os.remove(test_db_path)
+        except FileNotFoundError:
+            pass
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_notification_attendees.py
+++ b/tests/test_notification_attendees.py
@@ -1,34 +1,57 @@
+from app.services.notification_payload_assembler import NotificationEventPayload, NotificationPayloadAssembler
 from app.services.notification_service import NotificationService
 
 
-def test_notification_uses_attendees_not_description():
-    message = NotificationService._format_event_message(
+def test_notification_uses_description_and_attendees_in_distinct_lines():
+    message = NotificationService.format_event_message(
         [
-            {
-                "location": "교보빌딩 남측 -> 청진공원",
-                "start_date": "2026-05-15 11:00:00",
-                "end_date": "2026-05-15 13:00:00",
-                "description": "legacy description must not appear",
-                "attendees": "100명",
-            }
+            NotificationEventPayload(
+                location="교보빌딩 남측 -> 청진공원",
+                start_date="2026-05-15 11:00:00",
+                end_date="2026-05-15 13:00:00",
+                description="도심 행진",
+                attendees="100명",
+            )
         ]
     )
 
+    assert "상세 내용 : 도심 행진" in message
     assert "신고 인원 : 100명" in message
-    assert "legacy description" not in message
 
 
-def test_notification_attendees_default_is_unknown():
-    message = NotificationService._format_zone_message(
+def test_notification_description_and_attendees_default_to_unknown():
+    event = NotificationPayloadAssembler.event_payload_from_row(
+        {
+            "location_name": "송현공원 앞",
+            "start_date": "2026-05-15 19:00:00",
+            "end_date": "2026-05-15 20:30:00",
+            "description": "",
+            "attendees": "",
+        }
+    )
+    message = NotificationService.format_zone_message(
         "광화문광장",
-        [
-            {
-                "location": "송현공원 앞",
-                "start_date": "2026-05-15 19:00:00",
-                "end_date": "2026-05-15 20:30:00",
-                "attendees": "",
-            }
-        ],
+        [event],
     )
 
+    assert "상세 내용 : 미상" in message
     assert "신고 인원 : 미상" in message
+
+
+def test_notification_image_url_normalizes_leading_slash(settings_overrides):
+    settings_overrides(RENDER_EXTERNAL_URL="http://localhost:8000")
+
+    url = NotificationService.first_event_image_url(
+        [
+            NotificationEventPayload(
+                location="광화문광장",
+                start_date="2026-05-15 19:00:00",
+                end_date="2026-05-15 20:30:00",
+                description="도심 행진",
+                attendees="50명",
+                image_path="/attachments/protest_images/demo.png",
+            )
+        ]
+    )
+
+    assert url == "http://localhost:8000/attachments/protest_images/demo.png"

--- a/tests/test_notification_templates.py
+++ b/tests/test_notification_templates.py
@@ -1,124 +1,223 @@
 from datetime import datetime
-from types import SimpleNamespace
+import sqlite3
+from zoneinfo import ZoneInfo
 
 import pytest
 
 from app.routers import events as event_router
 from app.routers import kakao_skills
+from app.services.notification_payload_assembler import NotificationEventPayload
 from app.services.notification_service import NotificationService
+
+
+def insert_event(
+    conn: sqlite3.Connection,
+    *,
+    event_id: int,
+    description: str | None,
+    attendees: str,
+    location_name: str,
+    location_address: str,
+    start_date: str,
+    end_date: str,
+    image_path: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO events (
+            id, title, description, attendees, police_station, location_name,
+            location_address, latitude, longitude, start_date, end_date, category,
+            severity_level, image_path, status
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+        """,
+        (
+            event_id,
+            "SMPA 집회",
+            description,
+            attendees,
+            "종로",
+            location_name,
+            location_address,
+            37.5720,
+            126.9769,
+            start_date,
+            end_date,
+            "protest",
+            2,
+            image_path,
+        ),
+    )
+    conn.commit()
 
 
 def test_route_alert_template_uses_numbered_brief_fields():
     events = [
-        {
-            "location": "산업은행 측면 -> 신교교차로",
-            "start_date": datetime(2026, 5, 14, 11, 30),
-            "end_date": datetime(2026, 5, 14, 13, 0),
-            "attendees": "70명",
-        },
-        {
-            "location": "광화문 월대 -> 舊)효자치안센터",
-            "start_date": "2026-05-14 14:30:00",
-            "end_date": "2026-05-14 16:00:00",
-            "attendees": "300명",
-        },
+        NotificationEventPayload(
+            location="산업은행 측면 -> 신교교차로",
+            description="도심 행진",
+            start_date=datetime(2026, 5, 14, 11, 30),
+            end_date=datetime(2026, 5, 14, 13, 0),
+            attendees="70명",
+        ),
+        NotificationEventPayload(
+            location="광화문 월대 -> 舊)효자치안센터",
+            description="주최 측 집결",
+            start_date="2026-05-14 14:30:00",
+            end_date="2026-05-14 16:00:00",
+            attendees="300명",
+        ),
     ]
 
-    message = NotificationService._format_event_message(events)
+    message = NotificationService.format_event_message(events)
 
     assert message == (
         "경로상 감지된 집회 안내입니다.\n\n"
         "1.\n"
         "집회 일시 : 11:30 ~ 13:00\n"
         "집회 장소 : 산업은행 측면 -> 신교교차로\n"
+        "상세 내용 : 도심 행진\n"
         "신고 인원 : 70명\n\n"
         "2.\n"
         "집회 일시 : 14:30 ~ 16:00\n"
         "집회 장소 : 광화문 월대 -> 舊)효자치안센터\n"
+        "상세 내용 : 주최 측 집결\n"
         "신고 인원 : 300명"
     )
 
 
 def test_zone_alert_template_uses_zone_header_and_unknown_description_default():
     events = [
-        {
-            "location": "산업은행 측면 -> 신교교차로",
-            "start_date": "2026-05-14T11:30:00",
-            "end_date": "2026-05-14T13:00:00",
-            "attendees": "",
-        },
-        {
-            "location": "광화문 월대 -> 舊)효자치안센터",
-            "start_date": "2026-05-14T14:30:00",
-            "end_date": "2026-05-14T16:00:00",
-            "attendees": None,
-        }
+        NotificationEventPayload(
+            location="산업은행 측면 -> 신교교차로",
+            description="미상",
+            start_date="2026-05-14T11:30:00",
+            end_date="2026-05-14T13:00:00",
+            attendees="미상",
+        ),
+        NotificationEventPayload(
+            location="광화문 월대 -> 舊)효자치안센터",
+            description="미상",
+            start_date="2026-05-14T14:30:00",
+            end_date="2026-05-14T16:00:00",
+            attendees="미상",
+        ),
     ]
 
-    message = NotificationService._format_zone_message("광화문광장", events)
+    message = NotificationService.format_zone_message("광화문광장", events)
 
     assert message == (
         "설정하신 광화문광장의 집회 안내입니다.\n\n"
         "1.\n"
         "집회 일시 : 11:30 ~ 13:00\n"
         "집회 장소 : 산업은행 측면 -> 신교교차로\n"
+        "상세 내용 : 미상\n"
         "신고 인원 : 미상\n\n"
         "2.\n"
         "집회 일시 : 14:30 ~ 16:00\n"
         "집회 장소 : 광화문 월대 -> 舊)효자치안센터\n"
+        "상세 내용 : 미상\n"
         "신고 인원 : 미상"
     )
 
 
 @pytest.mark.asyncio
-async def test_events_today_protests_uses_numbered_brief_template(monkeypatch):
-    monkeypatch.setattr(
-        event_router.EventService,
-        "get_today_events",
-        lambda db: [
-            SimpleNamespace(
-                description="legacy description must not be used",
-                attendees="70명",
-                location_name="산업은행 측면 -> 신교교차로",
-                start_date="2026-05-14 11:30:00",
-                end_date="2026-05-14 13:00:00",
-            )
-        ],
-    )
-
-    response = await event_router.get_today_protests({}, None)
+async def test_events_today_protests_uses_four_line_contract_from_db(clean_test_db):
+    conn = sqlite3.connect(clean_test_db, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    today_kst = datetime.now(ZoneInfo("Asia/Seoul")).date().isoformat()
+    try:
+        insert_event(
+            conn,
+            event_id=1,
+            description="도심 행진",
+            attendees="70명",
+            location_name="산업은행 측면 -> 신교교차로",
+            location_address="서울특별시 종로구 종로1가",
+            start_date=f"{today_kst} 11:30:00",
+            end_date=f"{today_kst} 13:00:00",
+        )
+        response = await event_router.get_today_protests({}, conn)
+    finally:
+        conn.close()
 
     assert response["template"]["outputs"][0]["simpleText"]["text"] == (
         "오늘 예정된 집회 안내입니다.\n\n"
         "1.\n"
         "집회 일시 : 11:30 ~ 13:00\n"
         "집회 장소 : 산업은행 측면 -> 신교교차로\n"
+        "상세 내용 : 도심 행진\n"
         "신고 인원 : 70명"
     )
 
 
 @pytest.mark.asyncio
-async def test_kakao_skills_upcoming_protests_uses_numbered_brief_template(monkeypatch):
-    monkeypatch.setattr(
-        kakao_skills.EventService,
-        "get_upcoming_events",
-        lambda limit, db: [
-            SimpleNamespace(
-                description="legacy description must not be used",
-                attendees="300명",
-                location_name="광화문 월대 -> 舊)효자치안센터",
-                start_date="2026-05-14T14:30:00",
-                end_date="2026-05-14T16:00:00",
-            )
-        ],
-    )
-
-    response = await kakao_skills.get_upcoming_protests({"action": {"params": {"limit": 1}}}, None)
+async def test_kakao_skills_upcoming_protests_uses_four_line_contract_from_db(clean_test_db):
+    conn = sqlite3.connect(clean_test_db, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    try:
+        insert_event(
+            conn,
+            event_id=2,
+            description="주최 측 집결",
+            attendees="300명",
+            location_name="광화문 월대 -> 舊)효자치안센터",
+            location_address="서울특별시 종로구 세종대로",
+            start_date="2999-05-14 14:30:00",
+            end_date="2999-05-14 16:00:00",
+        )
+        response = await kakao_skills.get_upcoming_protests(
+            {"action": {"params": {"limit": 1}}},
+            conn,
+        )
+    finally:
+        conn.close()
 
     assert response["template"]["outputs"][0]["simpleText"]["text"] == (
         "예정된 집회 안내입니다.\n\n"
         "1.\n"
         "집회 일시 : 14:30 ~ 16:00\n"
         "집회 장소 : 광화문 월대 -> 舊)효자치안센터\n"
+        "상세 내용 : 주최 측 집결\n"
         "신고 인원 : 300명"
+    )
+
+
+@pytest.mark.asyncio
+async def test_kakao_skills_upcoming_protests_includes_image_url_from_db(
+    clean_test_db,
+    settings_overrides,
+):
+    settings_overrides(RENDER_EXTERNAL_URL="http://localhost:8000")
+
+    conn = sqlite3.connect(clean_test_db, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    try:
+        insert_event(
+            conn,
+            event_id=3,
+            description="이미지 포함 안내",
+            attendees="150명",
+            location_name="광화문광장 북측",
+            location_address="서울특별시 종로구 세종대로",
+            start_date="2999-05-15 10:00:00",
+            end_date="2999-05-15 12:00:00",
+            image_path="/attachments/protest_images/upcoming.png",
+        )
+        response = await kakao_skills.get_upcoming_protests(
+            {"action": {"params": {"limit": 1}}},
+            conn,
+        )
+    finally:
+        conn.close()
+
+    outputs = response["template"]["outputs"]
+    assert outputs[0]["simpleImage"]["imageUrl"] == "http://localhost:8000/attachments/protest_images/upcoming.png"
+    assert outputs[1]["simpleText"]["text"] == (
+        "예정된 집회 안내입니다.\n\n"
+        "1.\n"
+        "집회 일시 : 10:00 ~ 12:00\n"
+        "집회 장소 : 광화문광장 북측\n"
+        "상세 내용 : 이미지 포함 안내\n"
+        "신고 인원 : 150명"
     )

--- a/tests/test_route_zone_alarm_events.py
+++ b/tests/test_route_zone_alarm_events.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import pytest
 import sqlite3
 
@@ -50,10 +51,14 @@ def insert_event(
     conn.commit()
 
 
-def connect_db(path: str) -> sqlite3.Connection:
+@contextmanager
+def connect_db(path: str):
     conn = sqlite3.connect(path, check_same_thread=False)
     conn.row_factory = sqlite3.Row
-    return conn
+    try:
+        yield conn
+    finally:
+        conn.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_route_zone_alarm_events.py
+++ b/tests/test_route_zone_alarm_events.py
@@ -1,44 +1,64 @@
 import pytest
 import sqlite3
-from contextlib import contextmanager
 
 from app.config.settings import settings
-from app.database.connection import get_db_connection
+from app.routers import events as event_router
 from app.services.event_service import EventService
+from app.services.notification_payload_assembler import NotificationPayloadAssembler
+from app.services.notification_service import NotificationService
 from app.services.zone_alarm_service import ZoneAlarmService
 
 
-def insert_event(conn, event_id=1):
+def insert_event(
+    conn,
+    event_id=1,
+    *,
+    description="도심 행진",
+    attendees="100명",
+    location_name="교보빌딩 남측 -> 청진공원",
+    location_address="서울특별시 종로구 종로1가",
+    start_date="2999-05-15 11:00:00",
+    end_date="2999-05-15 13:00:00",
+    image_path=None,
+):
     conn.execute(
         """
         INSERT INTO events (
             id, title, description, attendees, police_station, location_name,
             location_address, latitude, longitude, start_date, end_date, category,
-            severity_level, status
+            severity_level, image_path, status
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
         """,
         (
             event_id,
             "SMPA 집회",
-            "legacy description",
-            "100명",
+            description,
+            attendees,
             "종로",
-            "교보빌딩 남측 -> 청진공원",
-            "서울특별시 종로구 종로1가",
+            location_name,
+            location_address,
             37.5720,
             126.9769,
-            "2999-05-15 11:00:00",
-            "2999-05-15 13:00:00",
+            start_date,
+            end_date,
             "protest",
             2,
+            image_path,
         ),
     )
     conn.commit()
+
+
+def connect_db(path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
 @pytest.mark.asyncio
-async def test_route_event_check_returns_single_representative_event(clean_test_db, monkeypatch):
-    monkeypatch.setattr(settings, "DATABASE_PATH", clean_test_db)
-    with get_db_connection() as conn:
+async def test_route_event_check_returns_single_representative_event(clean_test_db):
+    with connect_db(clean_test_db) as conn:
         conn.execute(
             """
             INSERT INTO users (
@@ -58,44 +78,141 @@ async def test_route_event_check_returns_single_representative_event(clean_test_
 
 
 @pytest.mark.asyncio
-async def test_zone_alarm_uses_single_representative_event_and_attendees(clean_test_db, monkeypatch):
-    monkeypatch.setattr(settings, "DATABASE_PATH", clean_test_db)
-    monkeypatch.setattr(settings, "BOT_ID", "")
-    monkeypatch.setattr(settings, "KAKAO_EVENT_API_KEY", "")
+async def test_check_route_uses_same_four_line_contract_from_db(clean_test_db):
+    with connect_db(clean_test_db) as conn:
+        conn.execute(
+            """
+            INSERT INTO users (
+                bot_user_key, plusfriend_user_key, active, is_alarm_on,
+                departure_name, departure_x, departure_y, arrival_name, arrival_x, arrival_y
+            )
+            VALUES ('bot-1', 'pf-1', 1, 1, '출발', 126.9700, 37.5700, '도착', 126.9900, 37.5740)
+            """
+        )
+        insert_event(
+            conn,
+            description="도심 행진",
+            start_date="2999-05-15 11:00:00",
+            end_date="2999-05-15 13:00:00",
+        )
 
-    @contextmanager
-    def test_db_connection():
-        conn = sqlite3.connect(clean_test_db, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        try:
-            yield conn
-        finally:
-            conn.close()
+        response = await event_router.check_user_route_events(
+            {
+                "userRequest": {
+                    "user": {
+                        "id": "bot-1",
+                        "properties": {"plusfriendUserKey": "pf-1"},
+                    }
+                }
+            },
+            conn,
+        )
 
-    monkeypatch.setattr("app.services.zone_alarm_service.get_db_connection", test_db_connection)
-    monkeypatch.setattr("app.services.alarm_status_service.get_db_connection", test_db_connection)
+    assert response["template"]["outputs"][0]["simpleText"]["text"] == (
+        "경로상 감지된 집회 안내입니다.\n\n"
+        "1.\n"
+        "집회 일시 : 11:00 ~ 13:00\n"
+        "집회 장소 : 교보빌딩 남측 -> 청진공원\n"
+        "상세 내용 : 도심 행진\n"
+        "신고 인원 : 100명"
+    )
 
-    with get_db_connection() as conn:
+
+@pytest.mark.asyncio
+async def test_route_alert_builder_uses_same_four_line_contract_from_event_responses(
+    clean_test_db,
+    settings_overrides,
+):
+    settings_overrides(RENDER_EXTERNAL_URL="http://localhost:8000")
+
+    with connect_db(clean_test_db) as conn:
+        conn.execute(
+            """
+            INSERT INTO users (
+                bot_user_key, plusfriend_user_key, active, is_alarm_on,
+                departure_name, departure_x, departure_y, arrival_name, arrival_x, arrival_y
+            )
+            VALUES ('bot-2', 'pf-2', 1, 1, '출발', 126.9700, 37.5700, '도착', 126.9900, 37.5740)
+            """
+        )
+        insert_event(
+            conn,
+            description="순차 행진",
+            attendees="120명",
+            image_path="/attachments/protest_images/route.png",
+        )
+
+        result = await EventService.check_route_events("pf-2", auto_notify=False, db=conn)
+
+    notification_events = NotificationPayloadAssembler.event_payloads_from_responses(result.events_found)
+    alarm_data = NotificationService.build_event_alarm_data(notification_events)
+
+    assert alarm_data["message"] == (
+        "경로상 감지된 집회 안내입니다.\n\n"
+        "1.\n"
+        "집회 일시 : 11:00 ~ 13:00\n"
+        "집회 장소 : 교보빌딩 남측 -> 청진공원\n"
+        "상세 내용 : 순차 행진\n"
+        "신고 인원 : 120명"
+    )
+    assert alarm_data["image_url"] == "http://localhost:8000/attachments/protest_images/route.png"
+
+
+@pytest.mark.asyncio
+async def test_zone_alarm_uses_single_representative_event_and_four_line_contract(
+    clean_test_db,
+    settings_overrides,
+):
+    settings_overrides(
+        DATABASE_PATH=clean_test_db,
+        BOT_ID="",
+        KAKAO_EVENT_API_KEY="",
+    )
+
+    with connect_db(clean_test_db) as conn:
         conn.execute(
             """
             INSERT INTO users (bot_user_key, plusfriend_user_key, active, is_alarm_on, favorite_zone)
             VALUES ('bot-zone', 'pf-zone', 1, 1, 1)
             """
         )
-        insert_event(conn)
-        matching_users = conn.execute(
-            """
-            SELECT COUNT(*) FROM users
-            WHERE active = 1
-              AND is_alarm_on = 1
-              AND favorite_zone IS NOT NULL
-              AND plusfriend_user_key IS NOT NULL
-            """
-        ).fetchone()[0]
-        assert matching_users == 1
+        insert_event(
+            conn,
+            description=None,
+            attendees="",
+            location_name="광화문광장 동편",
+            location_address="서울특별시 종로구 세종대로",
+            image_path="/attachments/protest_images/zone.png",
+        )
 
     result = await ZoneAlarmService.scheduled_zone_check()
+
+    with connect_db(clean_test_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, title, description, attendees, police_station, location_name,
+                   location_address, latitude, longitude, start_date, end_date, category,
+                   severity_level, status, image_path
+            FROM events
+            WHERE id = 1
+            """
+        ).fetchall()
+
+    notification_events = NotificationPayloadAssembler.event_payloads_from_rows([dict(row) for row in rows])
+    alarm_data = NotificationService.build_zone_alarm_data(
+        "광화문광장(1구역)",
+        notification_events,
+    )
 
     assert result["success"] is True
     assert result["total_users"] == 1
     assert result["notifications_sent"] == 0
+    assert alarm_data["message"] == (
+        "설정하신 광화문광장(1구역)의 집회 안내입니다.\n\n"
+        "1.\n"
+        "집회 일시 : 11:00 ~ 13:00\n"
+        "집회 장소 : 광화문광장 동편\n"
+        "상세 내용 : 미상\n"
+        "신고 인원 : 미상"
+    )
+    assert alarm_data["image_url"] == "http://localhost:8000/attachments/protest_images/zone.png"


### PR DESCRIPTION
## 요약
- notification payload 조립 책임을 `NotificationService`에서 분리하고 `NotificationPayloadAssembler`로 수렴했습니다.
- route / kakao skill / scheduled zone 경로가 assembler + public notification API만 사용하도록 정리했습니다.
- 4줄 본문 계약과 이미지 URL 계약을 DB 기반 회귀 테스트로 강화했습니다.

## 변경 사항
### 프로덕션 코드
- `app/services/notification_payload_assembler.py` 추가
  - `NotificationEventPayload` DTO 정의
  - `EventResponse`/DB row -> notification DTO 번역 전담
- `app/services/notification_service.py`
  - formatter / image URL / alarm payload / 전송 책임으로 정리
  - route/zone alarm payload builder 공용화
- `app/routers/events.py`, `app/routers/kakao_skills.py`
  - 로컬 shaping 제거 후 assembler 기반 호출로 통일
- `app/services/event_service.py`, `app/services/zone_alarm_service.py`
  - scheduled/route 경로도 assembler 기반으로 정리
  - zone scheduled query에 `image_path` 조회 포함

### 테스트/부수 정리
- `tests/test_notification_templates.py`
  - KST 현재 날짜 기반 today 테스트로 변경
  - Kakao `simpleImage.imageUrl` 회귀 테스트 추가
- `tests/test_route_zone_alarm_events.py`
  - route/zone alarm payload `image_url` 회귀 테스트 추가
- `tests/test_notification_attendees.py`
  - assembler/URL 정규화 경계 보강
- `tests/conftest.py`
  - settings override fixture 추가 및 restore 정리
- `deploy/native/package-source-bundle.sh`
  - `bundle-manifest.txt`가 manifest에 항상 포함되도록 보강

## 검증
- `python -m py_compile app/services/notification_payload_assembler.py app/services/notification_service.py app/routers/events.py app/routers/kakao_skills.py app/services/event_service.py app/services/zone_alarm_service.py tests/test_notification_attendees.py tests/test_notification_templates.py tests/test_route_zone_alarm_events.py`
- `source .venv/bin/activate && pytest tests/test_notification_templates.py tests/test_notification_attendees.py tests/test_route_zone_alarm_events.py tests/test_notification_service_bulk_event_api.py -q`
  - `31 passed in 0.93s`
- `uv run pytest -q`
  - `218 passed, 2 skipped, 10 warnings in 62.92s`

Closes #161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated notification payload assembly and message formatting for route checks, scheduled alerts, and zone alarms; notification text now follows a consistent four-line contract and image selection/URL normalization was improved.

* **Tests**
  * Updated tests to validate message formatting and image URL handling using real SQLite-backed data and new test fixtures/helpers.

* **Chores**
  * Fixed source bundle manifest generation to exclude the manifest itself.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->