### PR TITLE
feat: split DB bootstrap contract and add SQLite compatibility probe

### DIFF
--- a/app/database/bootstrap.py
+++ b/app/database/bootstrap.py
@@ -51,7 +51,7 @@ def ensure_table_columns(
             column_name,
             column_definition,
         )
-        existing_columns = _existing_columns(cursor, table_name)
+        existing_columns.add(column_name)
 
 
 def ensure_table_indexes(

--- a/app/database/bootstrap.py
+++ b/app/database/bootstrap.py
@@ -1,0 +1,93 @@
+"""데이터베이스 bootstrap 선언과 additive migration 적용."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+from app.database.models import (
+    BOOTSTRAP_TABLE_SCHEMAS,
+    TABLE_INDEX_STATEMENTS,
+    TABLE_MIGRATION_COLUMNS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _existing_columns(cursor: sqlite3.Cursor, table_name: str) -> set[str]:
+    return {
+        row[1]
+        for row in cursor.execute(f"PRAGMA table_info({table_name})").fetchall()
+    }
+
+
+def _add_column_with_duplicate_tolerance(
+    cursor: sqlite3.Cursor,
+    table_name: str,
+    column_name: str,
+    column_definition: str,
+) -> None:
+    try:
+        cursor.execute(
+            f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_definition}"
+        )
+    except sqlite3.OperationalError as exc:
+        if "duplicate column name" not in str(exc).lower():
+            raise
+
+
+def ensure_table_columns(
+    cursor: sqlite3.Cursor,
+    table_name: str,
+    columns: list[tuple[str, str]],
+) -> None:
+    existing_columns = _existing_columns(cursor, table_name)
+    for column_name, column_definition in columns:
+        if column_name in existing_columns:
+            continue
+        _add_column_with_duplicate_tolerance(
+            cursor,
+            table_name,
+            column_name,
+            column_definition,
+        )
+        existing_columns = _existing_columns(cursor, table_name)
+
+
+def ensure_table_indexes(
+    cursor: sqlite3.Cursor,
+    statements: tuple[str, ...],
+) -> None:
+    for statement in statements:
+        cursor.execute(statement)
+
+
+def ensure_events_contract(cursor: sqlite3.Cursor) -> None:
+    ensure_table_columns(cursor, "events", TABLE_MIGRATION_COLUMNS["events"])
+    ensure_table_indexes(cursor, TABLE_INDEX_STATEMENTS["events"])
+
+
+def apply_bootstrap_contract(cursor: sqlite3.Cursor) -> None:
+    for statement in BOOTSTRAP_TABLE_SCHEMAS.values():
+        cursor.execute(statement)
+
+    for table_name, columns in TABLE_MIGRATION_COLUMNS.items():
+        ensure_table_columns(cursor, table_name, columns)
+
+    for statements in TABLE_INDEX_STATEMENTS.values():
+        ensure_table_indexes(cursor, statements)
+
+
+def bootstrap_database(database_path: str, *, path_source: str = "settings") -> None:
+    conn = sqlite3.connect(database_path, check_same_thread=False)
+    try:
+        cursor = conn.cursor()
+        apply_bootstrap_contract(cursor)
+        conn.commit()
+        logger.info(
+            "database lifecycle mode=bootstrap db_path=%s path_source=%s",
+            database_path,
+            path_source,
+        )
+    finally:
+        conn.close()

--- a/app/database/compatibility_probe.py
+++ b/app/database/compatibility_probe.py
@@ -383,7 +383,7 @@ def _empty_schema_snapshot() -> dict[str, Any]:
 
 def _build_unreadable_database_reason(
     database_path: Path,
-    exc: sqlite3.DatabaseError,
+    exc: Exception,
 ) -> str:
     return f"unreadable database file: {database_path.resolve()} ({exc})"
 
@@ -401,7 +401,7 @@ def _load_actual_snapshot(target_database: Path) -> tuple[dict[str, Any], list[s
             return _collect_schema_snapshot(conn), []
         finally:
             conn.close()
-    except sqlite3.DatabaseError as exc:
+    except (sqlite3.DatabaseError, RuntimeError) as exc:
         return (
             _empty_schema_snapshot(),
             [_build_unreadable_database_reason(target_database, exc)],

--- a/app/database/compatibility_probe.py
+++ b/app/database/compatibility_probe.py
@@ -1,0 +1,599 @@
+"""현재 앱의 SQLite 호환성 계약을 보고하는 read-only probe."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sqlite3
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from app.database.bootstrap import apply_bootstrap_contract
+from app.database.connection import get_database_path
+from app.database.models import BOOTSTRAP_TABLE_SCHEMAS
+
+logger = logging.getLogger(__name__)
+
+PROBE_TABLE_ORDER = tuple(BOOTSTRAP_TABLE_SCHEMAS)
+REPORT_VERSION = 2
+REQUIRED_REPORT_FIELDS = (
+    "report_version",
+    "database_path",
+    "required_tables",
+    "required_columns",
+    "required_indexes",
+    "sqlite_dialect_assumptions",
+    "engine_specific_delta",
+    "detected_assumptions_count",
+    "failure_reasons",
+    "row_access_contract",
+    "startup_contract",
+)
+
+SQLITE_DIALECT_ASSUMPTIONS = (
+    {
+        "id": "sqlite_row_factory",
+        "detail": "런타임 조회 결과는 sqlite3.Row 기반 매핑 접근을 전제로 한다.",
+        "evidence": [
+            "app/database/connection.py:16-17",
+            "app/database/connection.py:27-28",
+        ],
+    },
+    {
+        "id": "pragma_table_info",
+        "detail": "admin legacy schema 호환은 PRAGMA table_info(...) 응답 형식에 의존한다.",
+        "evidence": [
+            "app/routers/admin.py:395-405",
+        ],
+    },
+    {
+        "id": "rowid_fallback",
+        "detail": "recent alarm/event 조회는 rowid fallback 정렬을 사용한다.",
+        "evidence": [
+            "app/routers/admin.py:319-325",
+            "app/routers/admin.py:364-369",
+            "app/services/alarm_status_service.py:216-245",
+        ],
+    },
+    {
+        "id": "partial_unique_index",
+        "detail": "events.source_record_hash partial unique index 가 현재 bootstrap 계약에 포함된다.",
+        "evidence": [
+            "app/database/bootstrap.py:65-67",
+            "app/database/models.py:133-136",
+        ],
+    },
+    {
+        "id": "datetime_now_kst_offset",
+        "detail": "경로 집회 조회는 datetime('now', '+9 hours') 를 사용한다.",
+        "evidence": [
+            "app/services/event_service.py:214-219",
+        ],
+    },
+    {
+        "id": "date_start_date",
+        "detail": "오늘 집회 조회는 date(start_date) 비교를 사용한다.",
+        "evidence": [
+            "app/services/event_service.py:453-464",
+        ],
+    },
+)
+
+ROW_ACCESS_CONTRACT = {
+    "row_factory": "sqlite3.Row",
+    "access_pattern": "row['column_name']",
+    "evidence": [
+        "app/database/connection.py:16-17",
+        "app/database/connection.py:27-28",
+    ],
+}
+
+STARTUP_CONTRACT = {
+    "bootstrap_entrypoint": "app.database.connection.init_db",
+    "probe_runs_on_startup": False,
+    "evidence": [
+        "main.py:36-54",
+    ],
+}
+
+
+def _build_contract_snapshot() -> dict[str, Any]:
+    """현재 bootstrap 선언이 요구하는 테이블/컬럼/인덱스 계약을 계산한다."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        apply_bootstrap_contract(conn.cursor())
+        return _collect_schema_snapshot(conn)
+    finally:
+        conn.close()
+
+
+def _build_engine_specific_delta() -> dict[str, Any]:
+    """현재 SQLite 런타임 전용 delta 를 action-oriented 형태로 정리한다."""
+    category_by_assumption_id = {
+        "sqlite_row_factory": "row_access",
+        "pragma_table_info": "schema_introspection",
+        "rowid_fallback": "legacy_fallback",
+        "partial_unique_index": "index_dialect",
+        "datetime_now_kst_offset": "datetime_expression",
+        "date_start_date": "date_expression",
+    }
+    portability_hotspots = [
+        {
+            "assumption_id": assumption["id"],
+            "category": category_by_assumption_id[assumption["id"]],
+            "detail": assumption["detail"],
+            "evidence": assumption["evidence"],
+        }
+        for assumption in SQLITE_DIALECT_ASSUMPTIONS
+    ]
+    return {
+        "current_engine": "sqlite",
+        "current_driver": "sqlite3",
+        "active_assumption_ids": [
+            assumption["id"]
+            for assumption in SQLITE_DIALECT_ASSUMPTIONS
+        ],
+        "portability_hotspots": portability_hotspots,
+    }
+
+
+def _collect_schema_snapshot(conn: sqlite3.Connection) -> dict[str, Any]:
+    table_names = _get_existing_tables(conn)
+    column_definitions_by_table = {}
+    columns_by_table = {}
+    for table_name in PROBE_TABLE_ORDER:
+        if table_name not in table_names:
+            continue
+        column_definitions = _get_table_column_definitions(conn, table_name)
+        column_definitions_by_table[table_name] = column_definitions
+        columns_by_table[table_name] = [
+            column["name"]
+            for column in column_definitions
+        ]
+    indexes = []
+    for table_name in PROBE_TABLE_ORDER:
+        if table_name in table_names:
+            indexes.extend(_get_table_indexes(conn, table_name))
+
+    return normalize_schema_snapshot(
+        {
+            "table_names": table_names,
+            "columns_by_table": columns_by_table,
+            "column_definitions_by_table": column_definitions_by_table,
+            "indexes": indexes,
+        }
+    )
+
+
+def normalize_schema_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """schema snapshot 을 deterministic ordering 으로 정규화한다."""
+    normalized_columns = {
+        table_name: sorted(columns)
+        for table_name, columns in sorted(snapshot["columns_by_table"].items())
+    }
+    normalized_column_definitions = {
+        table_name: sorted(
+            [
+                _normalize_column_definition(column)
+                for column in columns
+            ],
+            key=lambda item: item["name"],
+        )
+        for table_name, columns in sorted(
+            snapshot.get("column_definitions_by_table", {}).items()
+        )
+    }
+    normalized_indexes = sorted(
+        snapshot["indexes"],
+        key=lambda item: (item["table"], item["name"]),
+    )
+    return {
+        "table_names": sorted(snapshot["table_names"]),
+        "columns_by_table": normalized_columns,
+        "column_definitions_by_table": normalized_column_definitions,
+        "indexes": normalized_indexes,
+    }
+
+
+def _get_existing_tables(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute(
+        """
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+        """
+    ).fetchall()
+    return {row["name"] for row in rows}
+
+
+def _normalize_column_definition(column: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": column["name"],
+        "type": column["type"],
+        "notnull": bool(column["notnull"]),
+        "default": column["default"],
+        "pk": int(column["pk"]),
+    }
+
+
+def _quote_identifier(identifier: str) -> str:
+    return f'"{identifier.replace("\"", "\"\"")}"'
+
+
+def _get_table_column_definitions(
+    conn: sqlite3.Connection,
+    table_name: str,
+) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        f"PRAGMA table_info({_quote_identifier(table_name)})"
+    ).fetchall()
+    return [
+        _normalize_column_definition(
+            {
+                "name": row["name"],
+                "type": row["type"],
+                "notnull": row["notnull"],
+                "default": row["dflt_value"],
+                "pk": row["pk"],
+            }
+        )
+        for row in rows
+    ]
+
+
+def _get_table_indexes(conn: sqlite3.Connection, table_name: str) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        f"PRAGMA index_list({_quote_identifier(table_name)})"
+    ).fetchall()
+    indexes = []
+    for row in rows:
+        index_name = row["name"]
+        sql_row = conn.execute(
+            """
+            SELECT sql
+            FROM sqlite_master
+            WHERE type = 'index' AND name = ?
+            """,
+            (index_name,),
+        ).fetchone()
+        indexes.append(
+            {
+                "table": table_name,
+                "name": index_name,
+                "columns": _get_index_columns(conn, index_name),
+                "unique": bool(row["unique"]),
+                "partial": bool(row["partial"]),
+                "where": _extract_where_clause(sql_row["sql"] if sql_row else None),
+            }
+        )
+    return indexes
+
+
+def _get_index_columns(conn: sqlite3.Connection, index_name: str) -> list[str]:
+    rows = conn.execute(
+        f"PRAGMA index_info({_quote_identifier(index_name)})"
+    ).fetchall()
+    return [row["name"] for row in rows]
+
+
+def _extract_where_clause(index_sql: str | None) -> str | None:
+    if not index_sql:
+        return None
+
+    match = re.search(r"\bWHERE\b\s+(.*)$", index_sql, flags=re.IGNORECASE)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def _normalize_sql_fragment(sql_fragment: str | None) -> str | None:
+    if sql_fragment is None:
+        return None
+    return " ".join(sql_fragment.split()).lower()
+
+
+def _normalize_column_type(column_type: str | None) -> str:
+    if column_type is None:
+        return ""
+    return " ".join(column_type.split()).upper()
+
+
+def _column_definition_matches(
+    expected_column: dict[str, Any],
+    actual_column: dict[str, Any],
+) -> bool:
+    return (
+        _normalize_column_type(expected_column["type"])
+        == _normalize_column_type(actual_column["type"])
+        and bool(expected_column["notnull"]) == bool(actual_column["notnull"])
+        and _normalize_sql_fragment(expected_column["default"])
+        == _normalize_sql_fragment(actual_column["default"])
+        and int(expected_column["pk"]) == int(actual_column["pk"])
+    )
+
+
+def _index_definition_matches(
+    expected_index: dict[str, Any],
+    actual_index: dict[str, Any],
+) -> bool:
+    return (
+        expected_index["columns"] == actual_index["columns"]
+        and expected_index["unique"] == actual_index["unique"]
+        and expected_index["partial"] == actual_index["partial"]
+        and _normalize_sql_fragment(expected_index["where"])
+        == _normalize_sql_fragment(actual_index["where"])
+    )
+
+
+def open_readonly_probe_connection(database_path: str) -> sqlite3.Connection:
+    connection_uri = f"{Path(database_path).resolve().as_uri()}?mode=ro"
+    conn = sqlite3.connect(connection_uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only = ON")
+    query_only_row = conn.execute("PRAGMA query_only").fetchone()
+    if query_only_row[0] != 1:
+        conn.close()
+        raise RuntimeError("Probe connection did not enable query_only mode.")
+    return conn
+
+
+def _build_failure_reasons(
+    required_tables: list[dict[str, Any]],
+    required_columns: list[dict[str, Any]],
+    required_indexes: list[dict[str, Any]],
+) -> list[str]:
+    failure_reasons = [
+        f"missing table: {table['name']}"
+        for table in required_tables
+        if not table["exists"]
+    ]
+    for table in required_columns:
+        if table["missing_columns"]:
+            missing = ", ".join(table["missing_columns"])
+            failure_reasons.append(f"missing columns in {table['table']}: {missing}")
+        if table["mismatched_columns"]:
+            mismatched = ", ".join(table["mismatched_columns"])
+            failure_reasons.append(
+                f"mismatched column definition in {table['table']}: {mismatched}"
+            )
+    for index in required_indexes:
+        if not index["exists"]:
+            failure_reasons.append(f"missing index: {index['name']}")
+            continue
+        if not index["definition_matches"]:
+            failure_reasons.append(f"mismatched index definition: {index['name']}")
+    return failure_reasons
+
+
+def _empty_schema_snapshot() -> dict[str, Any]:
+    return normalize_schema_snapshot(
+        {
+            "table_names": [],
+            "columns_by_table": {},
+            "column_definitions_by_table": {},
+            "indexes": [],
+        }
+    )
+
+
+def _build_unreadable_database_reason(
+    database_path: Path,
+    exc: sqlite3.DatabaseError,
+) -> str:
+    return f"unreadable database file: {database_path.resolve()} ({exc})"
+
+
+def _load_actual_snapshot(target_database: Path) -> tuple[dict[str, Any], list[str]]:
+    if not target_database.is_file():
+        return (
+            _empty_schema_snapshot(),
+            [f"missing database file: {target_database.resolve()}"],
+        )
+
+    try:
+        conn = open_readonly_probe_connection(str(target_database))
+        try:
+            return _collect_schema_snapshot(conn), []
+        finally:
+            conn.close()
+    except sqlite3.DatabaseError as exc:
+        return (
+            _empty_schema_snapshot(),
+            [_build_unreadable_database_reason(target_database, exc)],
+        )
+
+
+def validate_report(report: dict[str, Any]) -> dict[str, Any]:
+    missing_fields = [
+        field_name
+        for field_name in REQUIRED_REPORT_FIELDS
+        if field_name not in report
+    ]
+    if missing_fields:
+        missing = ", ".join(missing_fields)
+        raise ValueError(f"Compatibility probe report is missing required fields: {missing}")
+
+    assumption_count = len(report["sqlite_dialect_assumptions"])
+    if report["detected_assumptions_count"] != assumption_count:
+        raise ValueError(
+            "Compatibility probe report has mismatched detected_assumptions_count."
+        )
+
+    engine_specific_delta = report["engine_specific_delta"]
+    if not isinstance(engine_specific_delta, dict):
+        raise ValueError("Compatibility probe report engine_specific_delta must be a dict.")
+
+    active_assumption_ids = engine_specific_delta.get("active_assumption_ids")
+    expected_assumption_ids = [
+        assumption["id"]
+        for assumption in report["sqlite_dialect_assumptions"]
+    ]
+    if active_assumption_ids != expected_assumption_ids:
+        raise ValueError(
+            "Compatibility probe report engine_specific_delta has mismatched active_assumption_ids."
+        )
+
+    portability_hotspots = engine_specific_delta.get("portability_hotspots")
+    if not isinstance(portability_hotspots, list) or len(portability_hotspots) != assumption_count:
+        raise ValueError(
+            "Compatibility probe report engine_specific_delta must list portability_hotspots for every assumption."
+        )
+
+    if not isinstance(report["failure_reasons"], list):
+        raise ValueError("Compatibility probe report failure_reasons must be a list.")
+
+    return report
+
+
+def serialize_report(report: dict[str, Any], *, output_format: str = "json") -> str:
+    validated_report = validate_report(report)
+    if output_format != "json":
+        raise ValueError(f"Unsupported probe output format: {output_format}")
+    return json.dumps(validated_report, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def generate_compatibility_report(database_path: str | None = None) -> dict[str, Any]:
+    """현재 앱 계약과 대상 DB 상태를 함께 요약한 probe 보고서를 만든다."""
+    target_database_path = database_path or get_database_path()
+    path_source = "argument" if database_path else "settings"
+    target_database = Path(target_database_path)
+    resolved_database_path = str(target_database.resolve())
+    contract_snapshot = _build_contract_snapshot()
+    actual_snapshot, database_failure_reasons = _load_actual_snapshot(target_database)
+
+    actual_indexes_by_name = {
+        index["name"]: index
+        for index in actual_snapshot["indexes"]
+    }
+
+    required_tables = [
+        {
+            "name": table_name,
+            "exists": table_name in actual_snapshot["table_names"],
+        }
+        for table_name in PROBE_TABLE_ORDER
+    ]
+
+    required_columns = []
+    for table_name in PROBE_TABLE_ORDER:
+        expected_columns = contract_snapshot["columns_by_table"].get(table_name, [])
+        actual_columns = actual_snapshot["columns_by_table"].get(table_name, [])
+        expected_column_definitions = {
+            column["name"]: column
+            for column in contract_snapshot["column_definitions_by_table"].get(
+                table_name,
+                [],
+            )
+        }
+        actual_column_definitions = {
+            column["name"]: column
+            for column in actual_snapshot["column_definitions_by_table"].get(
+                table_name,
+                [],
+            )
+        }
+        column_definitions = []
+        for column_name in expected_columns:
+            actual_column = actual_column_definitions.get(column_name)
+            expected_column = expected_column_definitions[column_name]
+            column_definitions.append(
+                {
+                    "name": column_name,
+                    "exists": actual_column is not None,
+                    "definition_matches": actual_column is not None
+                    and _column_definition_matches(expected_column, actual_column),
+                    "expected": expected_column,
+                    "actual": actual_column,
+                }
+            )
+        required_columns.append(
+            {
+                "table": table_name,
+                "columns": expected_columns,
+                "missing_columns": [
+                    column_name
+                    for column_name in expected_columns
+                    if column_name not in actual_columns
+                ],
+                "mismatched_columns": [
+                    column["name"]
+                    for column in column_definitions
+                    if column["exists"] and not column["definition_matches"]
+                ],
+                "column_definitions": column_definitions,
+            }
+        )
+
+    required_indexes = []
+    for expected_index in contract_snapshot["indexes"]:
+        actual_index = actual_indexes_by_name.get(expected_index["name"])
+        required_indexes.append(
+            {
+                **expected_index,
+                "exists": actual_index is not None,
+                "definition_matches": actual_index is not None
+                and _index_definition_matches(expected_index, actual_index),
+                "actual": actual_index,
+            }
+        )
+
+    failure_reasons = [
+        *database_failure_reasons,
+        *_build_failure_reasons(
+            required_tables,
+            required_columns,
+            required_indexes,
+        ),
+    ]
+
+    report = {
+        "report_version": REPORT_VERSION,
+        "database_path": resolved_database_path,
+        "required_tables": required_tables,
+        "required_columns": required_columns,
+        "required_indexes": required_indexes,
+        "sqlite_dialect_assumptions": list(SQLITE_DIALECT_ASSUMPTIONS),
+        "engine_specific_delta": _build_engine_specific_delta(),
+        "detected_assumptions_count": len(SQLITE_DIALECT_ASSUMPTIONS),
+        "failure_reasons": failure_reasons,
+        "row_access_contract": dict(ROW_ACCESS_CONTRACT),
+        "startup_contract": dict(STARTUP_CONTRACT),
+    }
+    logger.info(
+        "database lifecycle mode=probe db_path=%s path_source=%s",
+        resolved_database_path,
+        path_source,
+    )
+    return validate_report(report)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="현재 앱의 SQLite 호환성 계약을 JSON 으로 출력한다."
+    )
+    parser.add_argument(
+        "--database-path",
+        dest="database_path",
+        default=None,
+        help="probe 대상 SQLite 파일 경로 (생략 시 settings.DATABASE_PATH 사용)",
+    )
+    parser.add_argument(
+        "--format",
+        dest="output_format",
+        choices=("json",),
+        default="json",
+        help="출력 형식",
+    )
+    args = parser.parse_args(argv)
+    report = generate_compatibility_report(database_path=args.database_path)
+    print(serialize_report(report, output_format=args.output_format))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/database/connection.py
+++ b/app/database/connection.py
@@ -1,16 +1,9 @@
 """데이터베이스 연결 관리"""
 import sqlite3
-import logging
 from contextlib import contextmanager
-from app.config.settings import settings
-from app.database.models import (
-    USERS_TABLE_SCHEMA,
-    EVENTS_TABLE_SCHEMA,
-    ALARM_TASKS_TABLE_SCHEMA,
-    EVENTS_MIGRATION_COLUMNS,
-)
 
-logger = logging.getLogger(__name__)
+from app.config.settings import settings
+from app.database.bootstrap import bootstrap_database, ensure_events_contract
 
 
 def get_database_path() -> str:
@@ -41,72 +34,10 @@ def get_db_connection():
 
 def _ensure_events_contract(cursor: sqlite3.Cursor) -> None:
     """기존 events 테이블을 현재 SMPA 이벤트 계약으로 보강한다."""
-    existing_columns = {
-        row[1]
-        for row in cursor.execute("PRAGMA table_info(events)").fetchall()
-    }
-
-    for column_name, column_definition in EVENTS_MIGRATION_COLUMNS:
-        if column_name not in existing_columns:
-            cursor.execute(
-                f"ALTER TABLE events ADD COLUMN {column_name} {column_definition}"
-            )
-
-    cursor.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_events_source_record_hash "
-        "ON events(source_record_hash) "
-        "WHERE source_record_hash IS NOT NULL"
-    )
+    ensure_events_contract(cursor)
 
 
 def init_db():
     """데이터베이스 초기화 - 중앙집중식 스키마 사용"""
-    conn = sqlite3.connect(get_database_path(), check_same_thread=False)
-    cursor = conn.cursor()
-
-    # Users 테이블 생성 (통합 스키마 사용)
-    cursor.execute(USERS_TABLE_SCHEMA)
-
-    # Events 테이블 생성 (통합 스키마 사용)
-    cursor.execute(EVENTS_TABLE_SCHEMA)
-    _ensure_events_contract(cursor)
-
-    # Alarm Tasks 테이블 생성 (알림 상태 추적용)
-    cursor.execute(ALARM_TASKS_TABLE_SCHEMA)
-
-    # 컬럼 추가 로직 (이미 있으면 Exception 발생하므로 try-except로 무시)
-    try:
-        cursor.execute("ALTER TABLE users ADD COLUMN open_id TEXT")
-        cursor.execute("ALTER TABLE users ADD COLUMN plusfriend_user_key TEXT")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_users_open_id ON users(open_id)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_users_plusfriend_key ON users(plusfriend_user_key)")
-        logger.info("✅ open_id, plusfriend_user_key 컬럼 추가 완료")
-    except sqlite3.OperationalError as e:
-        if "duplicate column name" not in str(e).lower():
-            logger.warning(f"컬럼 갱신 실패 (무시됨): {str(e)}")
-
-    try:
-        cursor.execute("ALTER TABLE users ADD COLUMN is_alarm_on BOOLEAN DEFAULT TRUE")
-        logger.info("✅ is_alarm_on 컬럼 추가 완료")
-    except sqlite3.OperationalError as e:
-        if "duplicate column name" not in str(e).lower():
-            logger.warning(f"is_alarm_on 컬럼 갱신 실패 (무시됨): {str(e)}")
-
-    try:
-        cursor.execute("ALTER TABLE users ADD COLUMN favorite_zone INTEGER")
-        logger.info("✅ favorite_zone 컬럼 추가 완료")
-    except sqlite3.OperationalError as e:
-        if "duplicate column name" not in str(e).lower():
-            logger.warning(f"favorite_zone 컬럼 갱신 실패 (무시됨): {str(e)}")
-
-    try:
-        cursor.execute("ALTER TABLE events ADD COLUMN image_path TEXT")
-        logger.info("✅ events 테이블 image_path 컬럼 추가 완료")
-    except sqlite3.OperationalError as e:
-        if "duplicate column name" not in str(e).lower():
-            logger.warning(f"events 테이블 image_path 컬럼 갱신 실패 (무시됨): {str(e)}")
-
-
-    conn.commit()
-    conn.close()
+    bootstrap_database(get_database_path(), path_source="settings")
     print("✅ 데이터베이스 초기화 완료")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -62,6 +62,7 @@ EVENTS_TABLE_SCHEMA = '''
 EVENTS_MIGRATION_COLUMNS = [
     ("attendees", "TEXT NOT NULL DEFAULT '미상'"),
     ("police_station", "TEXT"),
+    ("image_path", "TEXT"),
     ("source", "TEXT NOT NULL DEFAULT 'SMPA'"),
     ("source_id", "TEXT"),
     ("source_url", "TEXT"),
@@ -104,3 +105,39 @@ ROUTE_COLUMNS = [
     ('language', 'TEXT'),
     ('favorite_zone', 'INTEGER')  # 관심장소 구역 (1, 2, 3 또는 NULL)
 ]
+
+USERS_MIGRATION_COLUMNS = [
+    ("open_id", "TEXT"),
+    ("plusfriend_user_key", "TEXT"),
+    ("is_alarm_on", "BOOLEAN DEFAULT TRUE"),
+    ("favorite_zone", "INTEGER"),
+]
+
+BOOTSTRAP_TABLE_SCHEMAS = {
+    "users": USERS_TABLE_SCHEMA,
+    "events": EVENTS_TABLE_SCHEMA,
+    "alarm_tasks": ALARM_TASKS_TABLE_SCHEMA,
+}
+
+TABLE_MIGRATION_COLUMNS = {
+    "users": USERS_MIGRATION_COLUMNS,
+    "events": EVENTS_MIGRATION_COLUMNS,
+    "alarm_tasks": [],
+}
+
+USERS_INDEX_STATEMENTS = (
+    "CREATE INDEX IF NOT EXISTS idx_users_open_id ON users(open_id)",
+    "CREATE INDEX IF NOT EXISTS idx_users_plusfriend_key ON users(plusfriend_user_key)",
+)
+
+EVENTS_INDEX_STATEMENTS = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_events_source_record_hash "
+    "ON events(source_record_hash) "
+    "WHERE source_record_hash IS NOT NULL",
+)
+
+TABLE_INDEX_STATEMENTS = {
+    "users": USERS_INDEX_STATEMENTS,
+    "events": EVENTS_INDEX_STATEMENTS,
+    "alarm_tasks": (),
+}

--- a/tests/test_database_bootstrap_boundaries.py
+++ b/tests/test_database_bootstrap_boundaries.py
@@ -1,0 +1,53 @@
+"""startup/lifespan bootstrap-only 경계 테스트."""
+
+import logging
+import sqlite3
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+def _table_names(db_path: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table'
+            """
+        ).fetchall()
+        return {row[0] for row in rows}
+    finally:
+        conn.close()
+
+
+def test_startup_runs_bootstrap_but_not_probe(tmp_path, settings_overrides, caplog):
+    db_path = tmp_path / "lifespan-bootstrap.db"
+    settings_overrides(DATABASE_PATH=str(db_path))
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+
+    with TestClient(app) as client:
+        response = client.get("/")
+
+    assert response.status_code == 200
+    assert {"users", "events", "alarm_tasks"}.issubset(_table_names(str(db_path)))
+
+    bootstrap_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "app.database.bootstrap"
+    ]
+    probe_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "app.database.compatibility_probe"
+    ]
+
+    assert any(
+        "mode=bootstrap" in message and "path_source=settings" in message
+        for message in bootstrap_logs
+    )
+    assert probe_logs == []

--- a/tests/test_database_bootstrap_contract.py
+++ b/tests/test_database_bootstrap_contract.py
@@ -1,0 +1,135 @@
+"""DB bootstrap source-of-truth 회귀 테스트."""
+
+import sqlite3
+
+from app.database.bootstrap import _add_column_with_duplicate_tolerance
+from app.database.connection import init_db
+
+
+def _column_names(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    return {row["name"] for row in rows}
+
+
+def _index_names(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA index_list({table_name})").fetchall()
+    return {row["name"] for row in rows}
+
+
+def test_init_db_uses_central_bootstrap_contract_for_fresh_db(
+    tmp_path,
+    settings_overrides,
+):
+    db_path = tmp_path / "bootstrap-contract.db"
+    settings_overrides(DATABASE_PATH=str(db_path))
+
+    init_db()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        assert "image_path" in _column_names(conn, "events")
+        assert {
+            "open_id",
+            "plusfriend_user_key",
+            "is_alarm_on",
+            "favorite_zone",
+        }.issubset(_column_names(conn, "users"))
+        assert {
+            "idx_users_open_id",
+            "idx_users_plusfriend_key",
+        }.issubset(_index_names(conn, "users"))
+        assert "idx_events_source_record_hash" in _index_names(conn, "events")
+    finally:
+        conn.close()
+
+
+def test_init_db_applies_central_user_migration_columns_to_legacy_db(
+    tmp_path,
+    settings_overrides,
+):
+    db_path = tmp_path / "legacy-users.db"
+    legacy = sqlite3.connect(db_path)
+    legacy.execute(
+        """
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            bot_user_key TEXT UNIQUE NOT NULL,
+            active BOOLEAN DEFAULT TRUE
+        )
+        """
+    )
+    legacy.execute(
+        """
+        CREATE TABLE events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            location_name TEXT NOT NULL,
+            latitude REAL NOT NULL,
+            longitude REAL NOT NULL,
+            start_date DATETIME NOT NULL
+        )
+        """
+    )
+    legacy.execute(
+        """
+        CREATE TABLE alarm_tasks (
+            task_id TEXT PRIMARY KEY,
+            alarm_type TEXT NOT NULL
+        )
+        """
+    )
+    legacy.execute(
+        """
+        INSERT INTO users (bot_user_key, active)
+        VALUES ('legacy-user', 1)
+        """
+    )
+    legacy.commit()
+    legacy.close()
+
+    settings_overrides(DATABASE_PATH=str(db_path))
+    init_db()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            """
+            SELECT bot_user_key, open_id, plusfriend_user_key, is_alarm_on, favorite_zone
+            FROM users
+            WHERE bot_user_key = 'legacy-user'
+            """
+        ).fetchone()
+        assert row["bot_user_key"] == "legacy-user"
+        assert row["open_id"] is None
+        assert row["plusfriend_user_key"] is None
+        assert row["is_alarm_on"] == 1
+        assert row["favorite_zone"] is None
+        assert "image_path" in _column_names(conn, "events")
+    finally:
+        conn.close()
+
+
+def test_add_column_with_duplicate_tolerance_absorbs_duplicate_column_error(tmp_path):
+    db_path = tmp_path / "duplicate-column.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                bot_user_key TEXT UNIQUE NOT NULL,
+                active BOOLEAN DEFAULT TRUE
+            )
+            """
+        )
+        cursor = conn.cursor()
+        _add_column_with_duplicate_tolerance(cursor, "users", "open_id", "TEXT")
+        _add_column_with_duplicate_tolerance(cursor, "users", "open_id", "TEXT")
+        conn.commit()
+
+        conn.row_factory = sqlite3.Row
+        assert "open_id" in _column_names(conn, "users")
+    finally:
+        conn.close()

--- a/tests/test_database_compatibility_probe.py
+++ b/tests/test_database_compatibility_probe.py
@@ -1,0 +1,557 @@
+"""SQLite compatibility probe 계약 테스트."""
+
+import json
+import logging
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+from app.database.compatibility_probe import ROW_ACCESS_CONTRACT
+from app.database.compatibility_probe import SQLITE_DIALECT_ASSUMPTIONS
+from app.database.compatibility_probe import STARTUP_CONTRACT
+from app.database.compatibility_probe import _build_contract_snapshot
+from app.database.compatibility_probe import generate_compatibility_report
+from app.database.compatibility_probe import normalize_schema_snapshot
+from app.database.compatibility_probe import open_readonly_probe_connection
+from app.database.compatibility_probe import validate_report
+from app.database.connection import init_db
+
+
+def _find_required_columns(report: dict, table_name: str) -> dict:
+    return next(
+        item
+        for item in report["required_columns"]
+        if item["table"] == table_name
+    )
+
+
+def _find_required_column_definition(table_report: dict, column_name: str) -> dict:
+    return next(
+        item
+        for item in table_report["column_definitions"]
+        if item["name"] == column_name
+    )
+
+
+def _find_required_index(report: dict, index_name: str) -> dict:
+    return next(
+        item
+        for item in report["required_indexes"]
+        if item["name"] == index_name
+    )
+
+
+def _assert_evidence_reference_exists(reference: str) -> None:
+    path_text, line_range = reference.split(":", 1)
+    path = Path(__file__).resolve().parents[1] / path_text
+    assert path.exists(), f"Missing evidence path: {path_text}"
+    lines = path.read_text().splitlines()
+    if "-" in line_range:
+        start_text, end_text = line_range.split("-", 1)
+        start_line = int(start_text)
+        end_line = int(end_text)
+    else:
+        start_line = end_line = int(line_range)
+    assert 1 <= start_line <= len(lines), f"Invalid start line for {reference}"
+    assert start_line <= end_line <= len(lines), f"Invalid end line for {reference}"
+
+
+def _database_snapshot(db_path) -> dict:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        schema_rows = conn.execute(
+            """
+            SELECT type, name, sql
+            FROM sqlite_master
+            WHERE name NOT LIKE 'sqlite_%'
+            ORDER BY type, name
+            """
+        ).fetchall()
+        table_rows = {}
+        for table_name in ("users", "events", "alarm_tasks"):
+            rows = conn.execute(
+                f"SELECT * FROM {table_name} ORDER BY rowid"
+            ).fetchall()
+            table_rows[table_name] = [dict(row) for row in rows]
+        return {
+            "schema": [dict(row) for row in schema_rows],
+            "rows": table_rows,
+        }
+    finally:
+        conn.close()
+
+
+def test_probe_reports_current_sqlite_dialect_assumptions(tmp_path, settings_overrides):
+    db_path = tmp_path / "compatibility-probe.db"
+    settings_overrides(DATABASE_PATH=str(db_path))
+    init_db()
+
+    report = generate_compatibility_report(database_path=str(db_path))
+
+    assert {table["name"] for table in report["required_tables"]} == {
+        "users",
+        "events",
+        "alarm_tasks",
+    }
+    assert all(table["exists"] for table in report["required_tables"])
+
+    assumption_ids = {
+        assumption["id"]
+        for assumption in report["sqlite_dialect_assumptions"]
+    }
+    assert {
+        "sqlite_row_factory",
+        "pragma_table_info",
+        "rowid_fallback",
+        "partial_unique_index",
+        "datetime_now_kst_offset",
+        "date_start_date",
+    }.issubset(assumption_ids)
+    assert report["report_version"] == 2
+    assert report["engine_specific_delta"]["current_engine"] == "sqlite"
+    assert report["engine_specific_delta"]["current_driver"] == "sqlite3"
+    assert report["engine_specific_delta"]["active_assumption_ids"] == [
+        assumption["id"]
+        for assumption in report["sqlite_dialect_assumptions"]
+    ]
+    portability_hotspots = {
+        hotspot["assumption_id"]: hotspot
+        for hotspot in report["engine_specific_delta"]["portability_hotspots"]
+    }
+    assert portability_hotspots["sqlite_row_factory"]["category"] == "row_access"
+    assert portability_hotspots["pragma_table_info"]["category"] == "schema_introspection"
+    assert portability_hotspots["rowid_fallback"]["category"] == "legacy_fallback"
+    assert report["detected_assumptions_count"] == len(report["sqlite_dialect_assumptions"])
+    assert report["failure_reasons"] == []
+
+    events_columns = _find_required_columns(report, "events")
+    assert "source_record_hash" in events_columns["columns"]
+    assert "source_payload_hash" in events_columns["columns"]
+    assert events_columns["missing_columns"] == []
+    assert events_columns["mismatched_columns"] == []
+
+    source_column = _find_required_column_definition(events_columns, "source")
+    assert source_column["definition_matches"] is True
+    assert source_column["expected"] == source_column["actual"]
+    assert source_column["expected"]["notnull"] is True
+
+    probe_index = _find_required_index(report, "idx_events_source_record_hash")
+    assert probe_index["table"] == "events"
+    assert probe_index["columns"] == ["source_record_hash"]
+    assert probe_index["unique"] is True
+    assert probe_index["partial"] is True
+    assert probe_index["where"] == "source_record_hash IS NOT NULL"
+    assert probe_index["exists"] is True
+
+    assert report["row_access_contract"]["row_factory"] == "sqlite3.Row"
+    assert report["row_access_contract"]["access_pattern"] == "row['column_name']"
+    assert report["startup_contract"]["bootstrap_entrypoint"] == "app.database.connection.init_db"
+    assert report["startup_contract"]["probe_runs_on_startup"] is False
+
+
+def test_probe_readonly_connection_rejects_writes_and_preserves_database_state(
+    tmp_path,
+    settings_overrides,
+):
+    db_path = tmp_path / "compatibility-probe-readonly.db"
+    settings_overrides(DATABASE_PATH=str(db_path))
+    init_db()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO users (bot_user_key, active)
+            VALUES ('readonly-user', 1)
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    before_snapshot = _database_snapshot(db_path)
+    report = generate_compatibility_report(database_path=str(db_path))
+    assert report["database_path"] == str(db_path.resolve())
+
+    with open_readonly_probe_connection(str(db_path)) as probe_conn:
+        query_only = probe_conn.execute("PRAGMA query_only").fetchone()[0]
+        assert query_only == 1
+
+        try:
+            probe_conn.execute(
+                """
+                INSERT INTO users (bot_user_key, active)
+                VALUES ('should-fail', 1)
+                """
+            )
+        except sqlite3.OperationalError as exc:
+            assert "readonly" in str(exc).lower()
+        else:
+            raise AssertionError("read-only probe connection unexpectedly allowed a write")
+
+        assert probe_conn.total_changes == 0
+
+    after_snapshot = _database_snapshot(db_path)
+    assert after_snapshot == before_snapshot
+
+
+def test_probe_report_returns_structured_failure_for_missing_database_path(tmp_path):
+    db_path = tmp_path / "compatibility-probe-missing.db"
+    assert not db_path.exists()
+
+    report = generate_compatibility_report(database_path=str(db_path))
+
+    assert report["database_path"] == str(db_path.resolve())
+    assert all(not table["exists"] for table in report["required_tables"])
+    assert f"missing database file: {db_path.resolve()}" in report["failure_reasons"]
+    assert "missing table: users" in report["failure_reasons"]
+    assert "missing table: events" in report["failure_reasons"]
+    assert "missing index: sqlite_autoindex_alarm_tasks_1" in report["failure_reasons"]
+    assert "missing index: sqlite_autoindex_users_1" in report["failure_reasons"]
+    assert "missing index: idx_events_source_record_hash" in report["failure_reasons"]
+    assert not db_path.exists()
+
+
+def test_probe_report_returns_structured_failure_for_invalid_database_file(tmp_path):
+    db_path = tmp_path / "compatibility-probe-invalid.db"
+    db_path.write_text("not sqlite", encoding="utf-8")
+
+    report = generate_compatibility_report(database_path=str(db_path))
+
+    assert report["database_path"] == str(db_path.resolve())
+    assert all(not table["exists"] for table in report["required_tables"])
+    assert (
+        f"unreadable database file: {db_path.resolve()} (file is not a database)"
+        in report["failure_reasons"]
+    )
+    assert "missing table: users" in report["failure_reasons"]
+    assert "missing index: idx_events_source_record_hash" in report["failure_reasons"]
+
+
+def test_probe_contract_snapshot_matches_bootstrap_contract():
+    snapshot = _build_contract_snapshot()
+
+    assert snapshot["table_names"] == ["alarm_tasks", "events", "users"]
+    assert "image_path" in snapshot["columns_by_table"]["events"]
+    event_source_column = next(
+        column
+        for column in snapshot["column_definitions_by_table"]["events"]
+        if column["name"] == "source"
+    )
+    assert event_source_column["type"] == "TEXT"
+    assert event_source_column["notnull"] is True
+    assert event_source_column["default"] == "'SMPA'"
+
+    index_names = {index["name"] for index in snapshot["indexes"]}
+    assert {
+        "idx_events_source_record_hash",
+        "sqlite_autoindex_alarm_tasks_1",
+        "sqlite_autoindex_users_1",
+    }.issubset(index_names)
+
+    parsed_index = next(
+        index
+        for index in snapshot["indexes"]
+        if index["name"] == "idx_events_source_record_hash"
+    )
+    assert parsed_index["columns"] == ["source_record_hash"]
+    assert parsed_index["unique"] is True
+    assert parsed_index["partial"] is True
+    assert parsed_index["where"] == "source_record_hash IS NOT NULL"
+
+
+def test_schema_snapshot_normalizer_sorts_tables_columns_and_indexes():
+    normalized = normalize_schema_snapshot(
+        {
+            "table_names": {"users", "events"},
+            "columns_by_table": {
+                "users": ["plusfriend_user_key", "bot_user_key"],
+                "events": ["source", "title"],
+            },
+            "column_definitions_by_table": {
+                "users": [
+                    {
+                        "name": "plusfriend_user_key",
+                        "type": "TEXT",
+                        "notnull": False,
+                        "default": None,
+                        "pk": 0,
+                    },
+                    {
+                        "name": "bot_user_key",
+                        "type": "TEXT",
+                        "notnull": True,
+                        "default": None,
+                        "pk": 0,
+                    },
+                ],
+            },
+            "indexes": [
+                {"table": "users", "name": "idx_users_z", "columns": [], "unique": False, "partial": False, "where": None},
+                {"table": "users", "name": "idx_users_a", "columns": [], "unique": False, "partial": False, "where": None},
+            ],
+        }
+    )
+
+    assert normalized["table_names"] == ["events", "users"]
+    assert normalized["columns_by_table"]["users"] == [
+        "bot_user_key",
+        "plusfriend_user_key",
+    ]
+    assert [
+        column["name"]
+        for column in normalized["column_definitions_by_table"]["users"]
+    ] == [
+        "bot_user_key",
+        "plusfriend_user_key",
+    ]
+    assert [index["name"] for index in normalized["indexes"]] == [
+        "idx_users_a",
+        "idx_users_z",
+    ]
+
+
+def test_probe_report_validator_rejects_missing_required_fields(tmp_path, settings_overrides):
+    db_path = tmp_path / "compatibility-probe-validate.db"
+    settings_overrides(DATABASE_PATH=str(db_path))
+    init_db()
+
+    report = generate_compatibility_report(database_path=str(db_path))
+    report.pop("report_version")
+
+    with pytest.raises(ValueError, match="report_version"):
+        validate_report(report)
+
+
+def test_probe_report_validator_rejects_engine_specific_delta_drift(
+    tmp_path,
+    settings_overrides,
+):
+    db_path = tmp_path / "compatibility-probe-delta-validate.db"
+    settings_overrides(DATABASE_PATH=str(db_path))
+    init_db()
+
+    report = generate_compatibility_report(database_path=str(db_path))
+    report["engine_specific_delta"]["active_assumption_ids"] = ["sqlite_row_factory"]
+
+    with pytest.raises(ValueError, match="active_assumption_ids"):
+        validate_report(report)
+
+
+def test_probe_report_flags_index_definition_drift(tmp_path, settings_overrides):
+    db_path = tmp_path / "compatibility-probe-index-drift.db"
+    settings_overrides(DATABASE_PATH=str(db_path))
+    init_db()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("DROP INDEX idx_events_source_record_hash")
+        conn.execute(
+            """
+            CREATE UNIQUE INDEX idx_events_source_record_hash
+            ON events(source_payload_hash)
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = generate_compatibility_report(database_path=str(db_path))
+
+    probe_index = _find_required_index(report, "idx_events_source_record_hash")
+    assert probe_index["exists"] is True
+    assert probe_index["definition_matches"] is False
+    assert probe_index["actual"]["columns"] == ["source_payload_hash"]
+    assert "mismatched index definition: idx_events_source_record_hash" in report["failure_reasons"]
+
+
+def test_probe_report_flags_column_definition_drift(tmp_path, settings_overrides):
+    db_path = tmp_path / "compatibility-probe-column-drift.db"
+    settings_overrides(DATABASE_PATH=str(db_path))
+    init_db()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        users_create_sql = conn.execute(
+            """
+            SELECT sql
+            FROM sqlite_master
+            WHERE type = 'table' AND name = 'users'
+            """
+        ).fetchone()[0]
+        assert "is_alarm_on BOOLEAN DEFAULT TRUE" in users_create_sql
+        conn.execute("DROP INDEX IF EXISTS idx_users_open_id")
+        conn.execute("DROP INDEX IF EXISTS idx_users_plusfriend_key")
+        conn.execute("DROP TABLE users")
+        conn.execute(
+            users_create_sql.replace(
+                "is_alarm_on BOOLEAN DEFAULT TRUE",
+                "is_alarm_on BOOLEAN DEFAULT FALSE",
+            )
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_users_open_id ON users(open_id)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_users_plusfriend_key ON users(plusfriend_user_key)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = generate_compatibility_report(database_path=str(db_path))
+
+    users_columns = _find_required_columns(report, "users")
+    assert users_columns["missing_columns"] == []
+    assert users_columns["mismatched_columns"] == ["is_alarm_on"]
+
+    is_alarm_on_column = _find_required_column_definition(users_columns, "is_alarm_on")
+    assert is_alarm_on_column["definition_matches"] is False
+    assert is_alarm_on_column["expected"]["default"] != is_alarm_on_column["actual"]["default"]
+    assert "mismatched column definition in users: is_alarm_on" in report["failure_reasons"]
+
+
+def test_probe_report_tolerates_quoted_extra_index_names(tmp_path, settings_overrides):
+    db_path = tmp_path / "compatibility-probe-quoted-index.db"
+    settings_overrides(DATABASE_PATH=str(db_path))
+    init_db()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            'CREATE INDEX "idx users weird space" ON users(favorite_zone)'
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = generate_compatibility_report(database_path=str(db_path))
+
+    assert report["failure_reasons"] == []
+
+
+def test_probe_evidence_references_resolve_to_existing_source_lines():
+    references = []
+    for assumption in SQLITE_DIALECT_ASSUMPTIONS:
+        references.extend(assumption["evidence"])
+    references.extend(ROW_ACCESS_CONTRACT["evidence"])
+    references.extend(STARTUP_CONTRACT["evidence"])
+
+    for reference in references:
+        _assert_evidence_reference_exists(reference)
+
+
+def test_probe_cli_returns_structured_json_for_missing_database_path(tmp_path):
+    db_path = tmp_path / "compatibility-probe-cli-missing.db"
+    assert not db_path.exists()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "app.database.compatibility_probe",
+            "--database-path",
+            str(db_path),
+            "--format",
+            "json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+
+    report = json.loads(result.stdout)
+    assert report["database_path"] == str(db_path.resolve())
+    assert all(not table["exists"] for table in report["required_tables"])
+    assert f"missing database file: {db_path.resolve()}" in report["failure_reasons"]
+    assert not db_path.exists()
+
+
+def test_probe_cli_returns_structured_json_for_invalid_database_file(tmp_path):
+    db_path = tmp_path / "compatibility-probe-cli-invalid.db"
+    db_path.write_text("not sqlite", encoding="utf-8")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "app.database.compatibility_probe",
+            "--database-path",
+            str(db_path),
+            "--format",
+            "json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+
+    report = json.loads(result.stdout)
+    assert report["database_path"] == str(db_path.resolve())
+    assert all(not table["exists"] for table in report["required_tables"])
+    assert (
+        f"unreadable database file: {db_path.resolve()} (file is not a database)"
+        in report["failure_reasons"]
+    )
+
+
+def test_probe_cli_smoke_outputs_json_report(tmp_path, settings_overrides):
+    db_path = tmp_path / "compatibility-probe-cli.db"
+    settings_overrides(DATABASE_PATH=str(db_path))
+    init_db()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "app.database.compatibility_probe",
+            "--database-path",
+            str(db_path),
+            "--format",
+            "json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+
+    report = json.loads(result.stdout)
+    assert report["database_path"] == str(db_path.resolve())
+    assert report["report_version"] == 2
+    assert report["engine_specific_delta"]["current_engine"] == "sqlite"
+    assert report["detected_assumptions_count"] == len(report["sqlite_dialect_assumptions"])
+    assert report["failure_reasons"] == []
+
+
+def test_probe_logs_mode_and_database_path_source(tmp_path, settings_overrides, caplog):
+    db_path = tmp_path / "compatibility-probe-log.db"
+    settings_overrides(DATABASE_PATH=str(db_path))
+    init_db()
+
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+
+    report = generate_compatibility_report(database_path=str(db_path))
+    assert report["database_path"] == str(db_path.resolve())
+
+    probe_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "app.database.compatibility_probe"
+    ]
+    assert any(
+        "mode=probe" in message
+        and "path_source=argument" in message
+        and str(db_path.resolve()) in message
+        for message in probe_messages
+    )


### PR DESCRIPTION
## Summary
- split startup-time bootstrap / additive migration work out of `app/database/connection.py` into `app/database/bootstrap.py`
- centralize bootstrap table, migration-column, and index declarations in `app/database/models.py`
- keep the public runtime entrypoints (`get_database_path()`, `get_db()`, `get_db_connection()`, `init_db()`) while reducing `connection.py` to connection/runtime boundary responsibilities
- add a read-only `app.database.compatibility_probe` CLI/report that exposes the app's real SQLite assumptions, structured failures, and engine-specific delta
- add fresh/legacy bootstrap, startup boundary, and probe regression coverage

## Tests
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`

## Issue
Closes #163
Refs #159
Refs #99
Refs #155
Refs #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated database schema initialization with intelligent migration support to ensure consistent data structure across application updates.
  * New database compatibility checking to validate schema integrity at startup before operations begin.

* **Refactor**
  * Streamlined database initialization by consolidating schema setup logic into a centralized process.

* **Tests**
  * Added comprehensive test coverage for database bootstrap and schema validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->