### PR TITLE
fix: align default schedule times with operator-set production values (#165)

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -52,11 +52,12 @@ class Settings(BaseSettings):
     ATTACHMENT_FOLDER: str = "topis_attachments"
 
     # --- Scheduling ---
-    CRAWLING_HOUR: int = 8
-    CRAWLING_MINUTE: int = 0
-    ROUTE_CHECK_HOUR: int = 13
+    # 운영 서버 담당자가 확정한 발송 시각 (2026-06-26 서버 반영값과 동일하게 유지할 것)
+    CRAWLING_HOUR: int = 7
+    CRAWLING_MINUTE: int = 50
+    ROUTE_CHECK_HOUR: int = 8
     ROUTE_CHECK_MINUTE: int = 0
-    ZONE_CHECK_HOUR: int = 13
+    ZONE_CHECK_HOUR: int = 8
     ZONE_CHECK_MINUTE: int = 0
 
     # --- SMPA Crawling ---


### PR DESCRIPTION
## Related Issue / 관련 이슈

Closes #165

## Summary / 요약

repo의 알림 스케줄 기본값을 운영 서버에 실제 반영된 값(크롤링 07:50, 경로/구역 알림 08:00)으로 정렬한다.

## Why / 이유

운영 담당자가 2026-06-26 서버에서 `settings.py`를 직접 수정해 발송 시각을 확정했으나(크롤링 07:50, 경로/구역 08:00), repo 기본값은 크롤링 08:00 / 경로·구역 13:00으로 남아 있었다. 이 상태로 재배포하면 담당자가 확정한 발송 시각이 소리 없이 13:00으로 되돌아간다. 2026-07-05 재배포(release `20260705T064853Z`, '상세 내용' 회귀 해소)는 이 커밋을 포함한 번들로 수행되어 운영 설정이 유지됐고, 본 PR은 그 변경을 main에 반영한다.

## Changes / 변경 사항

- `app/config/settings.py`: `CRAWLING_HOUR` 8→7, `CRAWLING_MINUTE` 0→50, `ROUTE_CHECK_HOUR` 13→8, `ZONE_CHECK_HOUR` 13→8, 운영 확정값임을 알리는 주석 추가

## Validation / 검증

- `uv run pytest -q` - 238 passed, 2 skipped (HEAD 기준 재실행)
- 운영 서버 활성 릴리즈(`20260705T064853Z`)에서 스케줄러 등록 로그 `07:50 크롤링, 08:00 경로 확인, 08:00 구역 확인` 확인
- 운영 서버 `/today-protests` 응답 및 단일 사용자 테스트 발송으로 '상세 내용' 포함 실수신 확인 (2026-07-05)

Not run:

- None

## Risk and Rollback / 위험 및 롤백

위험: 낮음 — 기본값 상수 변경만 포함하며, 이미 운영 서버에 동일 값이 반영되어 검증됨. 롤백: 본 커밋 revert 후 재배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
