### PR TITLE
docs: 배포 문서 통합 — 계약/절차/결정기록/legacy 규칙 단일 서술처 수렴

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,8 @@ backup_oldfiles/
 !docs/
 !docs/*.md
 !docs/**/*.md
+# Auto-generated agent docs stay untracked (repo-wide convention)
+docs/AGENTS.md
 !legacy/
 !legacy/**/README.md
 

--- a/deploy/native/README.md
+++ b/deploy/native/README.md
@@ -48,10 +48,14 @@ stages; the script is the source of truth for exact behavior.
 5. shared compatibility symlink creation
 6. `uv sync --frozen --no-dev`
 7. systemd candidate render + `systemd-analyze verify`
-8. current symlink switch
-9. service start/restart
-10. local health check
-11. old release prune
+8. capture previous current release (rollback anchor)
+9. current symlink switch
+10. service start/restart — on failure, roll back to the previous current
+11. local health check — on failure, roll back to the previous current
+12. old release prune
+
+On a first native deploy with no previous current, the post-switch rollback
+instead stops the service and unlinks the failed current.
 
 ## Live activation guard
 

--- a/deploy/native/README.md
+++ b/deploy/native/README.md
@@ -21,7 +21,10 @@ then allows a guarded native live job to upload that bundle to the target host.
 
 ## Bundle rules
 
-The package/verify scripts enforce the same source-bundle contract:
+The package/verify scripts are the source of truth for this contract: the
+exact allowlist is `source_paths` in `package-source-bundle.sh`, and the exact
+allow/deny matching lives in `path_is_allowed` / `path_is_denied` in
+`verify-source-bundle.sh`. The invariants they enforce:
 
 - allowed: `app/`, `main.py`, `pyproject.toml`, `uv.lock`, `.python-version`,
   `deploy/native/`, `docs/native-linux-deploy-guide.md`,
@@ -32,6 +35,23 @@ The package/verify scripts enforce the same source-bundle contract:
 
 `bundle-manifest.txt` must be present in the archive and must match the packaged
 file list exactly.
+
+## Release flow
+
+On the target host `deploy-release.sh` performs the release in the following
+stages; the script is the source of truth for exact behavior.
+
+1. checksum/manifest/allowlist verify
+2. port/Docker/user/group/env preflight
+3. release dir creation
+4. source bundle unpack
+5. shared compatibility symlink creation
+6. `uv sync --frozen --no-dev`
+7. systemd candidate render + `systemd-analyze verify`
+8. current symlink switch
+9. service start/restart
+10. local health check
+11. old release prune
 
 ## Live activation guard
 
@@ -54,11 +74,10 @@ native preflight.
 
 ## Legacy boundary
 
-- Historical Docker deploy files live under `legacy/docker-deploy/`.
-- `scripts/setup-ec2.sh` is a legacy Docker bootstrap helper and not part of the
-  active native workflow.
-- Re-enabling the legacy Docker path requires a new PRD and explicit operator
-  approval.
+Historical Docker deploy files live under `legacy/docker-deploy/`, and
+`scripts/setup-ec2.sh` is a legacy Docker bootstrap helper. The legacy rules
+(inactive status, reactivation gate) are documented in
+[`legacy/docker-deploy/README.md`](../../legacy/docker-deploy/README.md).
 
 ## Local verification
 
@@ -67,6 +86,3 @@ bash -n deploy/native/*.sh scripts/native/*.sh
 uv run pytest tests/test_native_runtime_assets.py -q
 uv run pytest -q
 ```
-
-Do not re-enable the legacy Docker graph from workflow comments without a new PRD
-and explicit operator approval.

--- a/docs/docker-free-fastapi-deploy-runbook.md
+++ b/docs/docker-free-fastapi-deploy-runbook.md
@@ -30,6 +30,14 @@
 | Phase 2 — activation | `deploy-native-live`는 guard가 열렸을 때만 실행 |
 | Phase 3 — post-activation | `public-health`는 live success 뒤에만 blocking 수행 |
 
+| Job | 역할 | Blocking 여부 |
+|---|---|---|
+| `blocking-tests` | lockfile freshness + full pytest | **Blocking** |
+| `package-native-release` | allowlisted source bundle + checksum 생성 | **Blocking** |
+| `deploy-native-preflight` | bundle verify, native static tests, non-mutating preflight | **Blocking** |
+| `deploy-native-live` | source bundle 업로드 + remote release deploy | Guarded |
+| `public-health` | live job 성공 후 public endpoint 검증 | Guarded |
+
 ## 3. Remote release contract
 
 live job는 아래 파일만 target host의 incoming dir로 전송한다.
@@ -39,19 +47,8 @@ live job는 아래 파일만 target host의 incoming dir로 전송한다.
 - `deploy/native/deploy-release.sh`
 - `deploy/native/verify-source-bundle.sh`
 
-그 뒤 remote host에서 `deploy-release.sh`가 아래 순서로 동작한다.
-
-1. checksum/manifest/allowlist 검증
-2. port/Docker/user/group/env preflight
-3. release dir 생성
-4. source bundle unpack
-5. shared compatibility symlink 생성
-6. `uv sync --frozen --no-dev`
-7. systemd candidate render + `systemd-analyze verify`
-8. current symlink switch
-9. service start/restart
-10. local health check
-11. old release prune
+그 뒤 remote host에서 `deploy-release.sh`가 release를 수행한다. 내부 단계 순서와 계약은
+[`deploy/native/README.md`의 Release flow](../deploy/native/README.md#release-flow)를 참조한다.
 
 ## 4. Failure handling
 
@@ -95,7 +92,106 @@ bash /opt/kt-demo-alarm/incoming/<release-id>/deploy-release.sh
 
 ## 7. Legacy Docker note
 
-Docker assets are preserved for history and rollback planning under `legacy/docker-deploy/`,
-but the active workflow must not build, load, or start Docker images. `scripts/setup-ec2.sh`
-is also a legacy bootstrap helper only. Re-enabling a Docker runtime path requires a new
-PRD and explicit operator approval.
+Legacy Docker 자산과 재활성화 규칙은
+[`legacy/docker-deploy/README.md`](../legacy/docker-deploy/README.md)를 참조한다.
+
+<a id="manual-lane"></a>
+## 8. Manual redeploy lane (수동 재배포)
+
+GitHub live gate를 쓸 수 없는 서버(예: `scp`만 허용되는 공공기관 환경)에서 **반복 수동
+재배포**를 수행하는 절차다. 아래 raw 명령을 순서대로 따라 하면 재배포가 완료된다.
+최초 이관(shared-state 이전 포함)의 완료 기록은
+[manual-public-server-cutover-guide.md](manual-public-server-cutover-guide.md)를 참조한다.
+
+> **wrapper 경계**: `scripts/manual/public-server-cutover.sh`는 **최초 이관용** tracked
+> command surface다. wrapper의 `push` subcommand는 shared-state 아카이브가 없으면
+> hard-fail하고 이를 전송 페이로드에 포함하므로, shared state가 이미 서버에 존재하는
+> 반복 재배포에는 사용하지 않는다. subcommand 목록은 아카이브된
+> [이관 가이드 §3](manual-public-server-cutover-guide.md)을 참조한다.
+
+### 8.1 변수 규약
+
+```bash
+APP_NAME="kt-demo-alarm"
+APP_ROOT="/opt/kt-demo-alarm"
+DEST_HOST="<target-host>"
+DEST_USER="<target-user>"
+RELEASE_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+ARTIFACT_DIR="$PWD/release-artifact/manual-${RELEASE_ID}"
+INCOMING_DIR="${APP_ROOT}/incoming/${RELEASE_ID}"
+```
+
+### 8.2 prepare-artifact — 로컬 검증과 artifact 준비
+
+```bash
+mkdir -p "${ARTIFACT_DIR}"
+
+bash -n deploy/native/*.sh scripts/native/*.sh
+uv run pytest tests/test_native_runtime_assets.py -q
+uv run pytest -q
+
+bash deploy/native/package-source-bundle.sh "${ARTIFACT_DIR}"
+bash deploy/native/verify-source-bundle.sh \
+  "${ARTIFACT_DIR}/source-bundle.tar.gz" \
+  "${ARTIFACT_DIR}/source-bundle.sha256"
+```
+
+### 8.3 preflight-dest — 대상 서버 사전 확인
+
+§1 Guard prerequisites의 호스트 조건을 대상 서버에서 증빙으로 확보한다.
+
+```bash
+ssh "${DEST_USER}@${DEST_HOST}" "\
+systemctl --version && \
+uv --version && \
+id ${APP_NAME} && \
+stat -c '%a %U %G %n' '${APP_ROOT}/shared/.env' && \
+docker ps --format '{{.Names}}' || true && \
+ss -ltn 'sport = :8000' || true"
+```
+
+### 8.4 push — artifact 전송
+
+반복 재배포에서는 shared state가 이미 서버에 있으므로 **`shared-state.tar.gz`를 전송하지
+않는다** (최초 이관 시의 shared-state 이전은 아카이브 문서 참조). 아래 4개 파일만 보낸다.
+
+```bash
+ssh "${DEST_USER}@${DEST_HOST}" "mkdir -p '${INCOMING_DIR}'"
+
+scp \
+  "${ARTIFACT_DIR}/source-bundle.tar.gz" \
+  "${ARTIFACT_DIR}/source-bundle.sha256" \
+  deploy/native/deploy-release.sh \
+  deploy/native/verify-source-bundle.sh \
+  "${DEST_USER}@${DEST_HOST}:${INCOMING_DIR}/"
+```
+
+### 8.5 deploy — deploy-release 실행
+
+기본값은 승인 없는 cutover를 막는 방향으로 유지한다.
+
+```bash
+ssh "${DEST_USER}@${DEST_HOST}" "\
+APP_NAME='${APP_NAME}' \
+APP_ROOT='${APP_ROOT}' \
+RELEASE_ID='${RELEASE_ID}' \
+BUNDLE_PATH='${INCOMING_DIR}/source-bundle.tar.gz' \
+CHECKSUM_PATH='${INCOMING_DIR}/source-bundle.sha256' \
+VERIFY_SOURCE_BUNDLE_BIN='${INCOMING_DIR}/verify-source-bundle.sh' \
+bash '${INCOMING_DIR}/deploy-release.sh'"
+```
+
+명시적으로 승인된 경우에만 §5의 override(`ALLOW_PORT_TAKEOVER`, `ALLOW_DOCKER_CUTOVER`)를
+추가한다.
+
+### 8.6 postcheck — 증빙 수집
+
+§6 Completion evidence와 동일한 항목을 원격에서 수집한다.
+
+```bash
+ssh "${DEST_USER}@${DEST_HOST}" "\
+readlink -f '${APP_ROOT}/current' && \
+systemctl status '${APP_NAME}' --no-pager && \
+curl -fsS 'http://127.0.0.1:8000/' && \
+journalctl -u '${APP_NAME}' -n 100 --no-pager"
+```

--- a/docs/docker-free-fastapi-deploy-runbook.md
+++ b/docs/docker-free-fastapi-deploy-runbook.md
@@ -186,7 +186,8 @@ bash '${INCOMING_DIR}/deploy-release.sh'"
 
 ### 8.6 postcheck — 증빙 수집
 
-§6 Completion evidence와 동일한 항목을 원격에서 수집한다.
+§6 Completion evidence의 로컬 항목(active symlink, service, local health, logs)을
+원격에서 수집한다.
 
 ```bash
 ssh "${DEST_USER}@${DEST_HOST}" "\
@@ -194,4 +195,13 @@ readlink -f '${APP_ROOT}/current' && \
 systemctl status '${APP_NAME}' --no-pager && \
 curl -fsS 'http://127.0.0.1:8000/' && \
 journalctl -u '${APP_NAME}' -n 100 --no-pager"
+```
+
+§6의 public health 항목은 여기서 `&&` 체인에 넣지 않는다. 이 lane의 완료선은
+`minimal-cutover`이고, public 도메인·TLS 도달성은 후속 항목이라 재배포 시점에 아직
+열려 있지 않을 수 있다([이관 가이드 §7 완료선](manual-public-server-cutover-guide.md)).
+public 종단이 준비된 경우에만 별도로 확인한다.
+
+```bash
+ssh "${DEST_USER}@${DEST_HOST}" "curl -fsS 'https://<public-domain>/'"
 ```

--- a/docs/manual-public-server-cutover-guide.md
+++ b/docs/manual-public-server-cutover-guide.md
@@ -1,5 +1,10 @@
 # 공공기관 서버 수동 이관 가이드
 
+> **📦 완료된 최초 이관 기록** — 이 문서의 이관 절차는 2026-06~07 서버 이관(#146, #165)으로
+> 완료되었다. **반복 수동 재배포는
+> [runbook의 Manual redeploy lane](docker-free-fastapi-deploy-runbook.md#manual-lane)을 사용한다.**
+> 본 문서는 최초 이관의 기록과 예외 경로 설계 근거로 보존한다.
+
 ## 0. 목적
 
 이 문서는 **GitHub guarded live gate를 서버 B용으로 재구성할 수 없고**, 대상 환경이 공공기관 정책 때문에
@@ -23,8 +28,8 @@
 
 | 구분 | 내용 | 근거 |
 |---|---|---|
-| Active deploy path | source bundle → server-side `uv sync --frozen --no-dev` → systemd-managed `uvicorn main:app` | `docs/native-linux-deploy-guide.md:5-21` |
-| Bundle safety | `.env`, `.venv`, DB, attachments, cache는 source bundle에 포함하지 않는다 | `deploy/native/README.md:24-33` |
+| Active deploy path | source bundle → server-side `uv sync --frozen --no-dev` → systemd-managed `uvicorn main:app` | [native-linux-deploy-guide.md의 결정 기록](native-linux-deploy-guide.md#decision) |
+| Bundle safety | `.env`, `.venv`, DB, attachments, cache는 source bundle에 포함하지 않는다 | [deploy/native/README.md의 Bundle rules](../deploy/native/README.md#bundle-rules) |
 | Remote activation | verify → unpack → shared symlink → `uv sync` → systemd install → current switch → local health | `deploy/native/deploy-release.sh:342-360` |
 | Non-goal | GitHub workflow, bundle allowlist/denylist, deploy-release activation flow는 바꾸지 않는다 | `.omx/plans/prd-server-migration-20260604T021812Z.md` |
 
@@ -71,6 +76,8 @@ INCOMING_DIR="${APP_ROOT}/incoming/${RELEASE_ID}"
 
 ## 5. source layout과 shared-state 범위
 
+> **[완료된 이관 기록 — 재사용 대상 아님]**
+
 ### 5.1 source layout 판별
 
 | source layout | 판별 기준 | destination restore target |
@@ -96,7 +103,11 @@ INCOMING_DIR="${APP_ROOT}/incoming/${RELEASE_ID}"
 
 ## 6. phase-by-phase 절차
 
+> 반복 사용 절차의 canonical 명령은 [runbook Manual redeploy lane](docker-free-fastapi-deploy-runbook.md#manual-lane)이 보유한다. 아래 본문은 최초 이관 당시의 기록이다.
+
 ### 6.1 `prepare-artifact`
+
+> [현행 절차: runbook Manual redeploy lane 참조](docker-free-fastapi-deploy-runbook.md#manual-lane)
 
 로컬 검증과 artifact 준비를 먼저 수행한다.
 
@@ -115,6 +126,8 @@ bash deploy/native/verify-source-bundle.sh \
 
 ### 6.2 `detect-source-layout`
 
+> **[완료된 이관 기록 — 재사용 대상 아님]**
+
 ```bash
 ssh "${SRC_USER}@${SRC_HOST}" "\
 if [ -d '${APP_ROOT}/shared' ]; then
@@ -125,6 +138,8 @@ fi"
 ```
 
 ### 6.3 `export-shared-state`
+
+> **[완료된 이관 기록 — 재사용 대상 아님]**
 
 #### A. `native-shared`
 
@@ -149,6 +164,8 @@ tar -C '${APP_ROOT}' -czf - \
 
 ### 6.4 `preflight-dest`
 
+> [현행 절차: runbook Manual redeploy lane 참조](docker-free-fastapi-deploy-runbook.md#manual-lane)
+
 최근 preflight baseline 에서는 `uv`, service account, `${APP_ROOT}/shared/.env`, Docker 중복, port 8000 takeover 위험이 blocker 였다.
 같은 계열 환경이면 아래 출력을 먼저 확보한다.
 
@@ -172,6 +189,8 @@ ss -ltn 'sport = :8000' || true"
 
 ### 6.5 `push`
 
+> [현행 절차: runbook Manual redeploy lane 참조](docker-free-fastapi-deploy-runbook.md#manual-lane) — 반복 재배포의 push 페이로드는 `shared-state.tar.gz`를 포함하지 않는다.
+
 remote upload는 `scp` 로만 수행한다.
 
 ```bash
@@ -186,6 +205,8 @@ scp \
 
 ### 6.6 `restore-shared`
 
+> **[완료된 이관 기록 — 재사용 대상 아님]**
+
 ```bash
 ssh "${DEST_USER}@${DEST_HOST}" "\
 mkdir -p \
@@ -197,6 +218,8 @@ tar -C '${APP_ROOT}/shared' -xzf '${INCOMING_DIR}/shared-state.tar.gz'"
 ```
 
 ### 6.7 `deploy`
+
+> [현행 절차: runbook Manual redeploy lane 참조](docker-free-fastapi-deploy-runbook.md#manual-lane)
 
 기본값은 승인 없는 cutover 를 막는 방향으로 유지한다.
 
@@ -227,6 +250,8 @@ bash '${INCOMING_DIR}/deploy-release.sh'"
 ```
 
 ### 6.8 `postcheck`
+
+> [현행 절차: runbook Manual redeploy lane 참조](docker-free-fastapi-deploy-runbook.md#manual-lane)
 
 ```bash
 ssh "${DEST_USER}@${DEST_HOST}" "\
@@ -284,7 +309,7 @@ systemctl restart '${APP_NAME}'"
 
 | 문서 | 역할 |
 |---|---|
-| `docs/native-linux-deploy-guide.md` | canonical native deploy 계약 |
-| `docs/docker-free-fastapi-deploy-runbook.md` | operator-owned cutover / manual dry-run / evidence |
-| `deploy/native/README.md` | bundle allowlist/denylist, env ownership, live gate |
+| `docs/native-linux-deploy-guide.md` | native-first 결정 기록 (ADR) |
+| `docs/docker-free-fastapi-deploy-runbook.md` | 배포 절차 — CI 레인, manual redeploy lane, 증빙 |
+| `deploy/native/README.md` | 배포 계약 — bundle allowlist/denylist, release flow, live gate, env ownership |
 | `.omx/logs/g076-user-host-preflight-20260602T1046Z.md` | 기존 host preflight blocker baseline |

--- a/docs/native-linux-deploy-guide.md
+++ b/docs/native-linux-deploy-guide.md
@@ -1,6 +1,18 @@
-# Native Linux Deploy Guide — first-pass canonical path
+# Native Linux Deploy Guide — native-first 결정 기록 (ADR)
 
-## 결론
+> 이 문서는 `kt-demo-alarm`이 Docker 기반 배포 대신 native Linux 배포를 canonical path로
+> 채택한 **결정 기록(ADR)** 이다. 계약과 절차의 현행 서술처는 [문서 맵](#doc-map)을 따른다.
+
+## 배경 (Context)
+
+- 운영 대상에 GitHub guarded live gate를 재구성할 수 없고 `scp` 중심 수동 전송만 허용되는
+  공공기관 서버가 포함된다 ([이관 기록](manual-public-server-cutover-guide.md) 참조).
+- 배포 경로가 보장해야 하는 조건: 시크릿이 CI를 경유하지 않을 것(server-owned config),
+  기존 Docker runtime·port와의 충돌을 사전에 차단할 것(preflight fail-fast), 이미지 반입
+  없이 소스 번들만으로 재현 가능할 것.
+
+<a id="decision"></a>
+## 결정 (Decision)
 
 `kt-demo-alarm`의 active deploy path는 Docker image/Compose가 아니라 아래 흐름이다.
 
@@ -20,109 +32,32 @@ blocking-tests
 | Runtime config ownership | server-owned `${APP_ROOT}/shared/.env` only |
 | Legacy Docker | `legacy/docker-deploy/` 아래에 보존하되 active workflow path에서는 사용하지 않음 |
 
-## Workflow jobs
+## 대안 (Alternatives considered)
 
-| Job | 역할 | Blocking 여부 |
-|---|---|---|
-| `blocking-tests` | lockfile freshness + full pytest | **Blocking** |
-| `package-native-release` | allowlisted source bundle + checksum 생성 | **Blocking** |
-| `deploy-native-preflight` | bundle verify, native static tests, non-mutating preflight | **Blocking** |
-| `deploy-native-live` | source bundle 업로드 + remote release deploy | Guarded |
-| `public-health` | live job 성공 후 public endpoint 검증 | Guarded |
-
-## Source bundle contract
-
-### Must include
-
-- `app/`
-- `main.py`
-- `pyproject.toml`
-- `uv.lock`
-- `.python-version`
-- `deploy/native/`
-- `docs/native-linux-deploy-guide.md`
-- `docs/docker-free-fastapi-deploy-runbook.md`
-- `nginx/` when present
-
-### Must exclude
-
-- `.env`, `.env.*`
-- `.venv/`
-- `.pytest_cache/`, `.ruff_cache/`, `__pycache__/`
-- `*.db`, `*.sqlite`, `*.sqlite3`
-- `attachments/`, `topis_attachments/`, `topis_cache/`
-- `*.key`, `*.pem`, `id_rsa`, `credentials.json`
-- Docker image tar/gzip artifacts
-
-`deploy/native/package-source-bundle.sh`가 `bundle-manifest.txt`를 생성하고,
-`deploy/native/verify-source-bundle.sh`가 checksum/allowlist/denylist/manifest 일치를
-검증한다.
-
-## Native release layout
-
-| Variable | Default | Purpose |
-|---|---|---|
-| `APP_ROOT` | `/opt/kt-demo-alarm` | app home |
-| `RELEASES_DIR` | `${APP_ROOT}/releases` | immutable release directories |
-| `CURRENT_LINK` | `${APP_ROOT}/current` | active release symlink |
-| `SHARED_DIR` | `${APP_ROOT}/shared` | mutable shared state |
-| `ENV_FILE` | `${SHARED_DIR}/.env` | server-owned app secrets/config |
-| `DATA_DIR` | `${SHARED_DIR}/data` | SQLite and related data |
-| `LOG_DIR` | `${SHARED_DIR}/logs` | application logs |
-| `CACHE_DIR` | `${SHARED_DIR}/topis_cache` | TOPIS cache |
-| `ATTACHMENT_DIR` | `${SHARED_DIR}/topis_attachments` | attachment storage |
-
-The deploy script recreates compatibility symlinks inside each release:
-
-| Release path | Target |
+| 대안 | 기각 사유 |
 |---|---|
-| `${RELEASE_DIR}/topis_attachments` | `${SHARED_DIR}/topis_attachments` |
-| `${RELEASE_DIR}/topis_cache` | `${SHARED_DIR}/topis_cache` |
-| `${RELEASE_DIR}/data` | `${SHARED_DIR}/data` |
-| `${RELEASE_DIR}/logs` | `${SHARED_DIR}/logs` |
-| `${RELEASE_DIR}/attachments` | `${SHARED_DIR}/data/attachments` |
+| Docker image/Compose 경로 유지 | 이미지 반입이 불가능한 대상 서버에서 재현 불가, 기존 runtime과의 중복 실행 위험. 자산은 legacy로 보존하고 재활성화 게이트를 둠 |
+| CI runner 측 `.env` 렌더링/업로드 | 시크릿이 워크플로를 경유하게 됨 — server-owned `${APP_ROOT}/shared/.env` 단일 소유로 대체 |
+| live 배포 상시 활성화 | 운영자 승인 없는 cutover 위험 — repository variable + protected environment 이중 가드로 대체 |
 
-## Guarded live activation
+## 결과 (Consequences)
 
-`deploy-native-live`는 아래 두 조건이 동시에 만족될 때만 실행한다.
+- 배포 계약(번들 allowlist/denylist, release layout, activation guard, release flow)은
+  [`deploy/native/README.md`](../deploy/native/README.md)가 단일 서술처이며, 실질 소스는
+  packaging/verify 스크립트다.
+- CI 레인과 수동 재배포 절차는 [runbook](docker-free-fastapi-deploy-runbook.md)이 단일
+  서술처다.
+- live 배포는 이중 가드(repository variable + protected environment) 뒤에 있으며, 가드
+  조건과 동작의 서술처는 [`deploy/native/README.md`](../deploy/native/README.md)다.
+- 최초 서버 이관은 완료되었고(#165), 그 기록은
+  [이관 가이드](manual-public-server-cutover-guide.md)에 아카이브로 보존된다.
 
-1. repository variable `KT_NATIVE_DEPLOY_ENABLED=1`
-2. protected `native-live` environment approval
+<a id="doc-map"></a>
+## 문서 맵
 
-둘 중 하나라도 없으면 workflow는 preflight evidence까지만 남기고 종료한다.
-
-## Server preflight expectations
-
-| Gate | Default behavior |
+| 주제 | 서술처 |
 |---|---|
-| Port already listens on `${APP_PORT}` | active native service가 아니면 fail-fast (`ALLOW_PORT_TAKEOVER=true`가 있어야 예외) |
-| Existing Docker runtime for same app | fail-fast (`ALLOW_DOCKER_CUTOVER=true`가 있어야 예외) |
-| Missing `APP_USER`/`APP_GROUP` | release switch 전에 fail |
-| Missing or too-open env file | dependency sync 전에 fail |
-| Missing `uv`, `systemd`, `sha256sum`, `tar` | release switch 전에 fail |
-
-## Secret safety
-
-| Rule | Implementation |
-|---|---|
-| No runner-side app `.env` rendering | active workflow has no `.env` generation/upload step |
-| No app `.env` upload | live job uploads only source bundle, checksum, and deploy helper scripts |
-| No secret content logs | `stat`/mode/path evidence only |
-| Server-owned config | operators provision `${SHARED_DIR}/.env` before cutover |
-
-## Legacy inventory
-
-| Surface | Current status |
-|---|---|
-| `legacy/docker-deploy/` | historical Docker deploy files (`Dockerfile`, `docker-compose.yml`, `.dockerignore`) |
-| `legacy/docker-deploy/README.md` | inactive legacy asset notice + reactivation gate |
-| `scripts/setup-ec2.sh` | legacy Docker bootstrap helper; current canonical path 아님 |
-| `legacy/bootstrap/README.md` | bootstrap classification and native-path redirect |
-
-## Local verification
-
-```bash
-bash -n deploy/native/*.sh scripts/native/*.sh
-uv run pytest tests/test_native_runtime_assets.py -q
-uv run pytest -q
-```
+| 배포 계약 — 번들 allowlist/denylist, release layout, activation guard, release flow | [`deploy/native/README.md`](../deploy/native/README.md) |
+| 배포 절차 — CI 레인, 수동 재배포(manual lane), preflight, postcheck 증빙 | [`docker-free-fastapi-deploy-runbook.md`](docker-free-fastapi-deploy-runbook.md) |
+| 최초 이관 기록 (완료, 아카이브) | [`manual-public-server-cutover-guide.md`](manual-public-server-cutover-guide.md) |
+| Legacy 규칙 — Docker 자산 `legacy/docker-deploy/`, bootstrap helper `scripts/setup-ec2.sh` | [`legacy/docker-deploy/README.md`](../legacy/docker-deploy/README.md) |

--- a/legacy/bootstrap/README.md
+++ b/legacy/bootstrap/README.md
@@ -13,6 +13,8 @@
 ## Operator note
 
 Before using `scripts/setup-ec2.sh`, confirm that you intentionally need the legacy Docker bootstrap path.
+The legacy Docker rules (inactive status, reactivation gate) are documented in
+[`../docker-deploy/README.md`](../docker-deploy/README.md).
 
 For the current canonical flow, use:
 

--- a/legacy/docker-deploy/README.md
+++ b/legacy/docker-deploy/README.md
@@ -1,5 +1,9 @@
 # Legacy Docker deploy inventory
 
+This README is the single narrative home for the legacy Docker rules
+(inactive status, reactivation gate). Active deploy docs link here instead of
+restating them.
+
 ## Status
 
 `legacy/docker-deploy/` is an inactive historical inventory for the pre-native deploy path.


### PR DESCRIPTION
## Related Issue / 관련 이슈

Closes #167
Refs #165

## Summary / 요약

배포 지식의 서술처를 4계층으로 일원화했다: **계약**은 `deploy/native/README.md`(스크립트가 실질 소스임을 명시, 신규 Release flow 섹션), **절차**는 runbook(CI 레인 + 신규 §8 manual redeploy lane), **결정 기록**은 guide(순수 ADR로 축소), **legacy 규칙**은 `legacy/docker-deploy/README.md`. cutover guide는 완료된 최초 이관 기록으로 제자리 아카이브 표시하고, `docs/AGENTS.md`는 gitignore로 정리했다. 이제 계약이 바뀌면 수정할 문서는 정확히 한 곳이다.

## Why / 이유

동일 내용(번들 allowlist, deploy-release 순서, activation guard, preflight, postcheck, legacy 규칙)이 3~6곳에 중복 서술되어 계약 변경 시마다 문서 동기화 커밋이 반복 발생했다(#167 배경). 접근 방식은 deep-interview 스펙 + Planner/Architect/Critic 합의 계획으로 확정: 파일 이동 없이 제자리 재구성(번들 must-include가 guide/runbook 경로를 하드코딩), 열거형 목록은 README에만 두고 운영자 명령은 runbook에 인라인(스크립트↔문서 sync 재발 방지), 이력은 삭제 대신 아카이브 마킹.

## Changes / 변경 사항

- `deploy/native/README.md`: Bundle rules에 스크립트 소스 지목, 신규 **Release flow**(deploy-release 11단계), Legacy boundary 링크 축소
- `docs/native-linux-deploy-guide.md`: 배경/결정/대안/결과/문서 맵의 **순수 ADR**로 재작성 (경로·결정 테이블 보존)
- `docs/docker-free-fastapi-deploy-runbook.md`: CI job 표 흡수, §3 단계 목록→README 링크, 신규 **§8 Manual redeploy lane** (raw 명령; `public-server-cutover.sh`는 최초 이관용으로 경계 명시 — wrapper `push`는 shared-state 아카이브와 결합되어 반복 재배포에 부적합)
- `docs/manual-public-server-cutover-guide.md`: 상단 아카이브 배너 + 일회성/반복 섹션 마커 9곳, stale 라인 참조 앵커화 (헤딩·본문 보존)
- `legacy/*/README.md`: legacy Docker 규칙의 단일 서술처 지정 및 위임 링크
- `.gitignore`: `docs/AGENTS.md` 제외 (자동 생성물 26개 전부 미추적으로 통일)

## Validation / 검증

- `uv run pytest -q` - 238 passed, 2 skipped (문서 문자열을 고정하는 `test_native_runtime_assets.py`, `test_manual_public_server_cutover_assets.py` 포함 그린)
- 링크+앵커 검사 (6개 문서 상대 링크, 명시적 `<a id>` 앵커 정확 일치) - 전부 유효
- `package-source-bundle.sh` + `verify-source-bundle.sh` 스크래치 실행 - 성공 (must-include 경로 생존 실증)
- 중복 토픽 6종 grep 대조 - 각각 단일 서술처 밖에서는 링크로만 등장
- `git check-ignore` - `docs/AGENTS.md`만 ignore, 필수 문서 4종은 비-ignore 유지

Not run:
- 실제/스테이징 재배포 — 스펙 결정에 따라 이 PR의 머지 게이트가 아님. 다음 실제 재배포 시 runbook §8 단독 재현성을 검증하고 #167 후속 체크로 기록 예정

## Risk and Rollback / 위험 및 롤백

- Risk: 문서-only 변경. 잔존 위험은 runbook §8 raw 명령이 실배포로는 미검증이라는 점 (cutover guide 원문·스크립트 소스·#165 기록과의 대조로만 검증됨)
- Rollback: 커밋 3개 revert (스크립트·워크플로 무변경이므로 안전)

## Review Focus / 리뷰 중점

- runbook **§8 manual lane**이 실제 운영 절차와 일치하는지 (특히 push의 4파일 페이로드와 원격 `mkdir -p`, wrapper 경계 서술)
- `deploy/native/README.md`의 Release flow 11단계가 `deploy-release.sh` 실동작과 일치하는지
- cutover guide의 아카이브 마커가 기록 가독성을 해치지 않는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)