### PR TITLE
fix: 버스 통제 수집 카테고리 확장 및 LLM JSON 추출 견고화 (#173)

### DIFF
--- a/app/services/bus_logic/restricted_bus.py
+++ b/app/services/bus_logic/restricted_bus.py
@@ -442,32 +442,57 @@ class TOPISCrawler:
         
         return None
 
+    # 버스 관련 통제/우회 공지가 걸리는 TOPIS 카테고리
+    #   0201 = 통제안내(도로·버스 임시우회 대부분이 여기 올라옴)
+    #   0202 = 버스안내(집회 무정차 등)
+    BUS_NOTICE_CATEGORY_CODES = ('0201', '0202')
+
     def _get_bus_notices(self, page=1, per_page=5, max_retries=3):
-        """버스 공지사항 목록 가져오기 (재시도 로직 포함)"""
-        data = {
-            'pageIndex': str(page),
-            'recordPerPage': str(per_page),
-            'pageSize': '5',
-            'bdwrSeq': '',
-            'blbdDivCd': '02',
-            'bdwrDivCd': '0202',
-            'tabGubun': 'B'
-        }
-        
+        """버스 공지사항 목록 가져오기 (통제안내 0201 + 버스안내 0202 병합)"""
+        merged = {}
+        fetched_any = False
+        for divcd in self.BUS_NOTICE_CATEGORY_CODES:
+            data = {
+                'pageIndex': str(page),
+                'recordPerPage': str(per_page),
+                'pageSize': '5',
+                'bdwrSeq': '',
+                'blbdDivCd': '02',
+                'bdwrDivCd': divcd,
+                'tabGubun': 'B'
+            }
+            rows = self._post_notice_list(data, max_retries=max_retries)
+            if rows is None:
+                continue
+            fetched_any = True
+            for row in rows:
+                seq = str(row.get('bdwrSeq'))
+                merged[seq] = row
+
+        if not fetched_any:
+            return None
+
+        # 두 카테고리를 seq 내림차순(최신순)으로 병합
+        ordered = sorted(
+            merged.values(),
+            key=lambda r: int(str(r.get('bdwrSeq') or 0)) if str(r.get('bdwrSeq') or 0).isdigit() else 0,
+            reverse=True
+        )
+        return {'rows': ordered}
+
+    def _post_notice_list(self, data, max_retries=3):
+        """공지 목록 POST (재시도 포함). 성공 시 rows 리스트, 실패 시 None."""
         for attempt in range(max_retries):
             try:
                 response = self.session.post(f"{self.base_url}/notice/selectNoticeList.do", data=data, verify=False)
                 response.raise_for_status()
-                return response.json()
+                return response.json().get('rows', [])
             except Exception as e:
-                print(f"목록 가져오기 오류 (시도 {attempt + 1}/{max_retries}): {e}")
+                print(f"목록 가져오기 오류 (bdwrDivCd={data.get('bdwrDivCd')}, 시도 {attempt + 1}/{max_retries}): {e}")
                 if attempt < max_retries - 1:
-                    wait_time = (attempt + 1) * 2
-                    print(f"{wait_time}초 후 재시도...")
-                    time.sleep(wait_time)
+                    time.sleep((attempt + 1) * 2)
                 else:
                     print("최대 재시도 횟수 초과")
-        
         return None
 
     def _get_notice_detail(self, blbd_div_cd, bdwr_seq, max_retries=3):
@@ -756,10 +781,11 @@ JSON 형식:
                 "route_pages": {}
             }
             
+            any_chunk_ok = False
             if total_pages > 0:
                 num_chunks = (total_pages + chunk_size - 1) // chunk_size
                 print(f"  - 총 {total_pages}개의 페이지를 {num_chunks}개의 청크로 정밀 분석합니다.")
-                
+
                 for i in range(0, total_pages, chunk_size):
                     chunk_index = i // chunk_size + 1
                     chunk_pages = page_map[i : i + chunk_size]
@@ -800,8 +826,9 @@ JSON 형식:
                     
                     print(f"    - 청크 {chunk_index}/{num_chunks} 분석 중...")
                     chunk_data = self._call_works_ai_api(content_parts, is_multimodal=True, max_retries=max_retries)
-                    
+
                     if chunk_data:
+                        any_chunk_ok = True
                         # 데이터 병합
                         if chunk_data.get("station_info"):
                             for sid, info in chunk_data["station_info"].items():
@@ -821,6 +848,15 @@ JSON 형식:
                                 norm_k = re.sub(r'[^0-9a-zA-Z]', '', str(route))
                                 # 청크 내 상대 페이지를 전체 절대 페이지 번호로 변환하여 저장
                                 final_data["route_pages"][norm_k] = i + page
+
+            # Layer 5(안전 강등): 첨부는 있으나 모든 청크 추출이 실패해 노선/정류소 정보를
+            # 전혀 못 얻은 경우를 표시. 조회 시 "통제 없음"으로 오인시키지 않기 위한 신호.
+            extraction_incomplete = (
+                total_pages > 0
+                and not any_chunk_ok
+                and not final_data["route_pages"]
+                and not final_data["station_info"]
+            )
 
             # 최종 데이터 보강 및 이미지 생성
             enriched_station_info = self._enrich_station_info(final_data["station_info"])
@@ -862,7 +898,8 @@ JSON 형식:
                 "station_info": enriched_station_info,
                 "detour_routes": final_data["detour_routes"],
                 "route_pages": final_data["route_pages"],
-                "route_images": route_images
+                "route_images": route_images,
+                "extraction_incomplete": extraction_incomplete
             }
 
         except Exception as e:
@@ -888,36 +925,81 @@ JSON 형식:
         }
         
         messages = [{"role": "user", "content": [{"type": "text", "text": str(content)}]}] if not is_multimodal else [{"role": "user", "content": content}]
-        payload = {
-            "model": self.works_ai_model,
-            "messages": messages,
-            "response_format": {"type": "json_object"},
-            "temperature": 0.0,
-            "thinking_level": "high",
-            "include_thoughts": False
-        }
 
+        last_raw = None
         for attempt in range(max_retries):
+            # Layer 3/4: 재시도는 payload 를 바꿔 결정론적 동일 실패를 피한다.
+            #  - 1차: temperature 0.0 + thinking high (정확도 우선)
+            #  - 재시도: temperature 상향 + thinking 하향(출력 예산 확보 → 잘림 완화)
+            payload = {
+                "model": self.works_ai_model,
+                "messages": messages,
+                "response_format": {"type": "json_object"},
+                "temperature": 0.0 if attempt == 0 else 0.3,
+                "thinking_level": "high" if attempt == 0 else "low",
+                "include_thoughts": False,
+                "max_tokens": 16384,
+            }
             try:
                 response = requests.post(f"{self.works_ai_base_url}/chat/completions", headers=headers, json=payload, timeout=300)
                 response.raise_for_status()
                 result = response.json()
                 content_str = result['choices'][0]['message']['content']
+                last_raw = content_str
                 data = json.loads(self._clean_json_response(content_str))
                 return data if isinstance(data, dict) else (data[0] if isinstance(data, list) and data else {})
             except Exception as e:
                 if attempt < max_retries - 1:
                     time.sleep(2)
                 else:
-                    logger.error(f"Works AI API 최종 호출 실패: {e}")
+                    # Layer 0: 실패 시 원본 출력 일부를 남겨 회귀 픽스처/원인 분석을 가능케 한다.
+                    logger.error(f"Works AI API 최종 호출 실패: {e} | raw_head={str(last_raw)[:600]!r}")
         return None
 
     def _clean_json_response(self, text):
-        """JSON 응답 마크다운 제거"""
-        if not text: return "{}"
+        """LLM 응답에서 JSON 본문만 안전 추출.
+
+        - 마크다운 펜스 제거
+        - 바깥쪽 첫 `{` 부터 균형 잡힌 `}` 까지만 잘라냄 → 앞뒤 잡문/사고흔적으로 인한
+          'Extra data' 방어
+        - 닫히지 않은 채 잘린 경우(truncation) 부족한 만큼 `}` 를 채워 복구 시도
+        """
+        if not text:
+            return "{}"
         text = re.sub(r'```json\s*', '', text)
         text = re.sub(r'```\s*', '', text).strip()
-        return text
+
+        start = text.find('{')
+        if start == -1:
+            return text
+
+        depth = 0
+        in_str = False
+        esc = False
+        for i in range(start, len(text)):
+            ch = text[i]
+            if in_str:
+                if esc:
+                    esc = False
+                elif ch == '\\':
+                    esc = True
+                elif ch == '"':
+                    in_str = False
+            else:
+                if ch == '"':
+                    in_str = True
+                elif ch == '{':
+                    depth += 1
+                elif ch == '}':
+                    depth -= 1
+                    if depth == 0:
+                        return text[start:i + 1]
+
+        # 여기까지 왔으면 닫는 괄호가 부족(잘림) → 남은 depth 만큼 닫아 복구
+        recovered = text[start:]
+        if depth > 0:
+            recovered += '}' * depth
+        return recovered
 
     def _get_default_extraction_result(self):
         """기본 추출 결과 반환"""

--- a/app/services/bus_notice_service.py
+++ b/app/services/bus_notice_service.py
@@ -312,6 +312,27 @@ class BusNoticeService:
                         break
 
             if not target_notice:
+                # Layer 5(안전 강등): 이 날짜에 통제 공지는 있으나 추출이 실패해 노선 정보를
+                # 확보하지 못한 경우, "정상 운행"으로 단정하지 않고 상세 미확보로 안내한다.
+                if any(n.get("extraction_incomplete") for n in notices):
+                    return {
+                        "version": "2.0",
+                        "template": {
+                            "outputs": [
+                                {
+                                    "simpleText": {
+                                        "text": (
+                                            f"🚌 노선 {normalized_route}번 안내\n\n"
+                                            f"문의하신 {target_date}에 교통 통제/우회 공지가 있으나, "
+                                            "해당 노선의 상세 영향 정보를 확인하지 못했습니다.\n"
+                                            "아래 링크에서 직접 확인해주세요.\n\n"
+                                            f"📍 {TOPIS_CONTROL_INFO_URL}"
+                                        )
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 return {
                     "version": "2.0",
                     "template": {

--- a/app/services/bus_notice_service.py
+++ b/app/services/bus_notice_service.py
@@ -499,6 +499,23 @@ class BusNoticeService:
                         break
             
             if not target_notice:
+                # Layer 5(안전 강등): 추출 실패 공지가 있으면 "정상 운행"으로 단정하지 않는다.
+                # (동기 경로 get_route_check_response 와 동일한 가드)
+                if any(n.get("extraction_incomplete") for n in notices):
+                    callback_message = {
+                        "version": "2.0",
+                        "template": {
+                            "outputs": [
+                                {
+                                    "simpleText": {
+                                        "text": f"🚌 노선 {normalized_route}번 안내\n\n문의하신 {target_date}에 교통 통제/우회 공지가 있으나, 해당 노선의 상세 영향 정보를 확인하지 못했습니다.\n아래 링크에서 직접 확인해주세요.\n\n📍 {TOPIS_CONTROL_INFO_URL}"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                    await cls._send_callback_request(callback_url, callback_message)
+                    return
                 # 해당 날짜에 공지는 있으나, 요청한 노선은 통제 대상이 아닌 경우
                 callback_message = {
                     "version": "2.0",

--- a/tests/test_bus_control_fix.py
+++ b/tests/test_bus_control_fix.py
@@ -1,0 +1,104 @@
+"""Issue #173: 버스 통제 조회 회귀 테스트.
+
+- Layer 1: _clean_json_response 가 LLM 출력의 'Extra data'/잘림을 방어하는지
+- Layer A: _get_bus_notices 가 통제안내(0201) + 버스안내(0202)를 병합하는지
+- Layer 5: 추출 실패(extraction_incomplete) 공지를 "정상 운행"으로 오인하지 않는지
+"""
+import os
+import sys
+import json
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from app.services.bus_logic.restricted_bus import TOPISCrawler
+from app.services.bus_notice_service import BusNoticeService
+
+
+def _clean(text):
+    # self 미사용 순수 함수라 인스턴스 없이 호출
+    return TOPISCrawler._clean_json_response(None, text)
+
+
+# ── Layer 1: JSON 파싱 견고화 ─────────────────────────────
+
+def test_clean_json_plain():
+    assert json.loads(_clean('{"a": 1}')) == {"a": 1}
+
+
+def test_clean_json_markdown_fence():
+    raw = '```json\n{"a": 1, "b": [2, 3]}\n```'
+    assert json.loads(_clean(raw)) == {"a": 1, "b": [2, 3]}
+
+
+def test_clean_json_extra_data_trailing():
+    # 유효 JSON 뒤에 잡문/사고흔적 (관측된 'Extra data: line ..' 유형)
+    raw = '{"route_pages": {"162": 1}}\n\n설명: 위 노선은 ...'
+    assert json.loads(_clean(raw)) == {"route_pages": {"162": 1}}
+
+
+def test_clean_json_truncated_recovers():
+    # 출력이 중간에 잘림 (관측된 'Expecting delimiter' 유형) → 닫아서 파싱 가능
+    raw = '{"route_pages": {"162": 1, "503": 2'
+    data = json.loads(_clean(raw))
+    assert data["route_pages"] == {"162": 1, "503": 2}
+
+
+def test_clean_json_braces_inside_string():
+    # 문자열 내부 중괄호가 depth 계산을 깨지 않아야 함
+    raw = '{"note": "구간 {A} 통제", "n": 1} trailing'
+    assert json.loads(_clean(raw)) == {"note": "구간 {A} 통제", "n": 1}
+
+
+# ── Layer A: 카테고리 병합 수집 ───────────────────────────
+
+def test_get_bus_notices_merges_control_and_bus_categories(tmp_path):
+    c = TOPISCrawler(cache_file=str(tmp_path / "cache.json"), download_folder=str(tmp_path / "dl"))
+    seen = []
+
+    def fake_post(data, max_retries=3):
+        seen.append(data["bdwrDivCd"])
+        if data["bdwrDivCd"] == "0201":   # 통제안내: 버스 우회 공지가 여기 있음
+            return [{"bdwrSeq": "6021"}, {"bdwrSeq": "6018"}]
+        return [{"bdwrSeq": "6018"}, {"bdwrSeq": "6017"}]  # 버스안내(6018 중복)
+
+    c._post_notice_list = fake_post
+    res = c._get_bus_notices()
+    seqs = [r["bdwrSeq"] for r in res["rows"]]
+
+    assert set(seen) == {"0201", "0202"}      # 두 카테고리 모두 조회
+    assert seqs == ["6021", "6018", "6017"]   # 중복 제거 + seq 내림차순
+
+
+# ── Layer 5: 추출 실패 시 안전 강등 ───────────────────────
+
+@pytest.mark.asyncio
+async def test_route_check_degrades_when_extraction_incomplete(tmp_path, monkeypatch):
+    crawler = TOPISCrawler(cache_file=str(tmp_path / "c.json"), download_folder=str(tmp_path / "dl"))
+    notice = {
+        "seq": "9999",
+        "title": "테스트 통제 공지",
+        "create_date": "2026-07-15 00:00:00",
+        "general_periods": ["2026-07-15 00:00 ~ 2026-07-20 23:59"],
+        "route_pages": {},
+        "route_images": {},
+        "extraction_incomplete": True,
+    }
+    monkeypatch.setattr(BusNoticeService, "crawler", crawler)
+    monkeypatch.setattr(BusNoticeService, "cached_notices", {"9999": notice})
+
+    resp = await BusNoticeService.get_route_check_response("162", {"date": "2026-07-16"})
+    text = resp["template"]["outputs"][0]["simpleText"]["text"]
+    assert "확인하지 못했습니다" in text
+    assert "정상 운행" not in text
+
+
+@pytest.mark.asyncio
+async def test_route_check_says_normal_when_no_notice(tmp_path, monkeypatch):
+    crawler = TOPISCrawler(cache_file=str(tmp_path / "c.json"), download_folder=str(tmp_path / "dl"))
+    monkeypatch.setattr(BusNoticeService, "crawler", crawler)
+    monkeypatch.setattr(BusNoticeService, "cached_notices", {})
+
+    resp = await BusNoticeService.get_route_check_response("162", {"date": "2026-07-16"})
+    text = resp["template"]["outputs"][0]["simpleText"]["text"]
+    assert "정상 운행" in text

--- a/tests/test_bus_control_fix.py
+++ b/tests/test_bus_control_fix.py
@@ -102,3 +102,34 @@ async def test_route_check_says_normal_when_no_notice(tmp_path, monkeypatch):
     resp = await BusNoticeService.get_route_check_response("162", {"date": "2026-07-16"})
     text = resp["template"]["outputs"][0]["simpleText"]["text"]
     assert "정상 운행" in text
+
+
+@pytest.mark.asyncio
+async def test_background_callback_degrades_when_extraction_incomplete(tmp_path, monkeypatch):
+    # 비동기 콜백 경로(process_route_check_background)도 동기 경로와 동일하게
+    # 추출 실패 공지를 "정상 운행"으로 단정하지 않아야 한다.
+    crawler = TOPISCrawler(cache_file=str(tmp_path / "c.json"), download_folder=str(tmp_path / "dl"))
+    notice = {
+        "seq": "9999",
+        "title": "테스트 통제 공지",
+        "create_date": "2026-07-15 00:00:00",
+        "general_periods": ["2026-07-15 00:00 ~ 2026-07-20 23:59"],
+        "route_pages": {},
+        "route_images": {},
+        "extraction_incomplete": True,
+    }
+    monkeypatch.setattr(BusNoticeService, "crawler", crawler)
+    monkeypatch.setattr(BusNoticeService, "cached_notices", {"9999": notice})
+
+    sent = {}
+
+    async def fake_send(cls_url, message):
+        sent["text"] = message["template"]["outputs"][0]["simpleText"]["text"]
+
+    monkeypatch.setattr(BusNoticeService, "_send_callback_request", classmethod(
+        lambda cls, url, message: fake_send(url, message)
+    ))
+
+    await BusNoticeService.process_route_check_background("162", {"date": "2026-07-16"}, "http://callback.test")
+    assert "확인하지 못했습니다" in sent["text"]
+    assert "정상 운행" not in sent["text"]


### PR DESCRIPTION
## Related Issue / 관련 이슈

Closes #173

## Summary / 요약

버스 통제 조회가 **통제가 있는 노선·날짜에도 "정상 운행 중"으로 응답**하던 문제를 해소한다. 원인 2가지(수집 카테고리 누락 + LLM JSON 추출 취약)를 함께 처리한다.

## Why / 이유

- **원인 A(수집):** 크롤러가 TOPIS 공지판에서 `bdwrDivCd=0202`(버스안내)만 조회했다. 실제 버스 임시우회 공지는 대부분 `0201`(통제안내)에 올라와 통째로 누락됐다.
- **원인 B(추출):** 통제 공지를 가져와도 LLM(Works AI) 응답 JSON 파싱 실패(`Extra data`, `Expecting ',' delimiter`)로 노선/기간이 빈 값이 되어 "통제 없음"으로 빠졌다. 백업 방어가 없었다.

## Changes / 변경 사항

- **카테고리(A)** `_get_bus_notices`: `0201`+`0202`를 병합 수집(중복 제거, seq 내림차순). `_post_notice_list` 헬퍼 분리.
- **Layer 1** `_clean_json_response`: 바깥 `{}`를 균형 중괄호로 추출해 `Extra data` 방어, 잘린 출력은 부족한 `}`를 채워 복구.
- **Layer 3/4** `_call_works_ai_api`: 재시도 시 `temperature`/`thinking_level`을 변경해 결정론적 동일 실패·출력 잘림 완화, `max_tokens` 명시.
- **Layer 0**: 파싱 실패 시 원본 출력 일부 로깅(회귀 분석용).
- **Layer 5(안전 강등)**: 추출 완전 실패(`extraction_incomplete`) 공지는 조회 시 "정상 운행"으로 단정하지 않고 "상세 미확보"로 안내(`bus_notice_service.get_route_check_response`).
- 회귀 테스트 `tests/test_bus_control_fix.py` 8건 추가.

## Validation / 검증

- `uv run pytest -q` — **246 passed, 2 skipped** (신규 8건 포함)
- 운영 서버 실검증(프로덕션 캐시 무손상, 임시 경로):
  - 이전에 JSON 파싱 실패했던 공지 **6025 → 노선 273 정상 추출**, 통제기간(7/15) 조회 시 통제 안내 출력.
  - 공지 **6021 → 노선 162 등 정상 유지**, 통제기간(7/12) 통제 있음 / 오늘(7/8) 정상 운행.
  - `_get_bus_notices()`가 0201+0202 **병합 10건** 반환(기존 0202 5건 → 통제안내 공지 5건 추가 확보).

Not run:

- Layer 5 안전 강등은 단위 테스트로 검증(실서버에서는 하드닝 후 추출이 성공해 자연 트리거되지 않음).

## Risk and Rollback / 위험 및 롤백

- 위험: 낮음~중간. 수집 카테고리 확대로 LLM 추출 호출이 다소 증가(0201 공지 추가분). `max_tokens`/`thinking_level` 파라미터는 운영 BizRouter에서 200 응답 확인.
- 롤백: 본 커밋 revert 후 재배포. 캐시(`topis_cache.json`)는 스키마 호환(추가 필드 `extraction_incomplete`만 부가)이라 롤백 시에도 안전.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
